### PR TITLE
feat: add Interagent platform concept and specs

### DIFF
--- a/interagent/CONCEPT.md
+++ b/interagent/CONCEPT.md
@@ -1,0 +1,98 @@
+# Interagent — Red de redes de agentes
+
+## La idea
+
+Internet es una red de redes. Interagent es una red de redes de agentes.
+
+Cada hogar o empresa corre su propio **nodo**: un conjunto de agentes de IA locales
+(domótica, clima, agenda, inversiones) que procesan todo sin salir de la red local.
+La plataforma Interagent permite que esos nodos aislados **publiquen servicios** para
+la comunidad y **consuman servicios de otros**, formando un ecosistema distribuido.
+
+## Analogía con internet
+
+| Internet | Interagent |
+|---|---|
+| Autonomous System (AS) | Nodo (hogar / empresa) |
+| BGP / DNS | Registry central |
+| Endpoint HTTP | Servicio de agente |
+| CDN / gateway | Interagent Gateway |
+| App Store | Marketplace de servicios |
+
+## Componentes
+
+### Nodo (local)
+- Orquestador FastAPI + agentes especializados
+- Agent SDK: publica y consume servicios de la registry
+- Keypair único: firma todas las llamadas salientes
+- Metering agent: contabiliza uso para billing
+
+### Registry (cloud)
+- Catálogo de servicios con búsqueda, tags, versiones y schemas
+- Auth via firma de keypair por nodo
+- Metering y billing mensual (cobra al consumidor, paga al proveedor)
+- Gateway para llamadas pagas (metering confiable)
+- Llamadas free: directo nodo-a-nodo con rate limiting en el SDK
+
+### Community layer
+- Stars (1-5) por nodo consumidor post-uso
+- Joins: nodos que integraron el servicio
+- Maturity score: `stars × log(joins) × log(calls_total)`
+- Sistema de reportes + auto-ban preventivo + moderación manual
+
+## Flujo de una llamada
+
+```
+Nodo B quiere el servicio "weather.forecast.v1" del Nodo A
+
+Nodo B → [firma request] → Gateway → [valida + mide] → Nodo A → respuesta
+                                                               ↓
+                                                      Gateway → Nodo B
+```
+
+Free tier: Nodo B → [firma request] → Nodo A directamente (sin gateway)
+
+## Modelo de negocio
+
+| Tier | Precio/mes | Llamadas/mes |
+|------|-----------|-------------|
+| Free | $0 | 1.000 por servicio |
+| Starter | $9 | 50.000 totales |
+| Pro | $49 | 500.000 totales |
+| Enterprise | custom | ilimitadas |
+
+Split por llamada paga: **70% proveedor / 25% plataforma / 5% comunidad**
+
+Cash out mensual a proveedores vía Stripe Connect.
+
+## Relación con home-agents
+
+El proyecto home-agents (`~/ai-lab`) es el nodo de referencia:
+- La FASE 3 (orquestador FastAPI) se convierte en la base del SDK
+- El agente de clima publica `weather.forecast.v1` como primer servicio real
+- Sirve como caso de estudio para la documentación de onboarding
+
+## Preguntas abiertas clave
+
+1. **NAT traversal**: ¿cómo exponer un nodo doméstico a internet?
+   Candidatos: Cloudflare Tunnel (gratis, confiable), relay server en registry.
+
+2. **Registry centralizada vs federada**: MVP centralizado, protocolo diseñado
+   para ser federable en el futuro.
+
+3. **Subdominios por nodo**: `node-abc123.interagent.io` requiere wildcard SSL
+   pero da mejor UX que IPs directas.
+
+## Estructura del repositorio
+
+```
+interagent/
+├── CONCEPT.md              ← este archivo
+├── protocol/
+│   ├── service.schema.yaml     definición formal de un servicio
+│   └── registry.openapi.yaml  API de la registry
+├── sdk/
+│   └── README.md           diseño del SDK
+└── monetization/
+    └── model.md            modelo de negocio detallado
+```

--- a/interagent/monetization/model.md
+++ b/interagent/monetization/model.md
@@ -1,0 +1,139 @@
+# Modelo de monetización — Interagent Platform
+
+## Premisa
+
+Interagent es un marketplace bilateral:
+- **Proveedores**: nodos que publican servicios y cobran por su uso
+- **Consumidores**: nodos que integran servicios de otros y pagan por el uso
+- **Un mismo nodo puede ser los dos al mismo tiempo**
+
+La plataforma toma un porcentaje de cada transacción como intermediario,
+igual que App Store (30%) o Stripe (2.9% + fijo).
+
+---
+
+## Tiers de plan para consumidores
+
+| Tier | Precio/mes | Llamadas/mes | SLA | Soporte |
+|------|-----------|-------------|-----|---------|
+| **Free** | $0 | 1.000 por servicio free | Sin SLA | Community |
+| **Starter** | $9 | 50.000 totales | 99% uptime | Email |
+| **Pro** | $49 | 500.000 totales | 99.9% uptime | Priority |
+| **Enterprise** | custom | Ilimitadas | custom SLA | Dedicado |
+
+- Overage (por encima del límite): $0.002 por llamada adicional (Starter/Pro)
+- El plan free solo da acceso a servicios free tier
+
+---
+
+## Tiers de publicación para proveedores
+
+| Tier del servicio | ¿Quién puede publicarlo? | Monetización |
+|---|---|---|
+| **free** | Cualquier nodo | Sin ingresos para el proveedor |
+| **starter** | Nodos con plan Starter o superior | El consumidor paga, proveedor recibe 70% |
+| **pro** | Nodos con plan Pro o superior | Ídem |
+| **enterprise** | Nodos Enterprise | Precio y split custom |
+
+Un nodo free puede publicar servicios, pero solo en tier free (sin cobro).
+Para cobrar por sus servicios, el nodo proveedor debe tener al menos plan Starter.
+
+---
+
+## Split de revenue por llamada paga
+
+```
+Precio por 1.000 llamadas: $X (definido por el proveedor)
+
+  70%  →  Proveedor del servicio
+  25%  →  Plataforma Interagent
+   5%  →  Fondo de moderación y comunidad
+```
+
+El fondo de comunidad se usa para:
+- Financiar moderación manual de reportes
+- Grants para servicios open source destacados
+- Infraestructura del relay server (NAT traversal)
+
+---
+
+## Cash in y cash out
+
+### Cash in (plataforma recibe)
+- Suscripciones mensuales de nodos (Starter, Pro, Enterprise)
+- 25% de cada llamada paga entre nodos
+- Overages de llamadas
+
+### Cash out (plataforma paga)
+- 70% de cada llamada paga → al nodo proveedor (mensual)
+- Método: Stripe Connect (ACH / SEPA / transferencia local según país)
+- Umbral mínimo de pago: $10 acumulados (para reducir costos de transferencia)
+- Frecuencia: primer día hábil de cada mes, por el mes anterior
+
+---
+
+## Ejemplo numérico
+
+Nodo A publica `weather.forecast.v1` a $1 por 1.000 llamadas.
+
+En el mes de mayo recibe 200.000 llamadas pagas de 15 nodos distintos:
+
+```
+Revenue bruto:          200.000 / 1.000 × $1    = $200
+  → Proveedor (70%):                               $140
+  → Plataforma (25%):                               $50
+  → Fondo comunidad (5%):                           $10
+```
+
+El Nodo A recibe $140 el 1 de junio vía Stripe Connect.
+Si el Nodo A tiene plan Starter ($9/mes) para consumir servicios de otros,
+su factura neta de junio es $9 - $140 = recibe $131.
+
+---
+
+## Estrategia de crecimiento
+
+### Por qué el free tier es crítico
+- Reduce el costo de entrada a cero (adopción masiva)
+- Los proveedores publican en free para ganar joins y stars → suben maturity score
+- Un servicio con maturity_score alto atrae consumidores pagos → el proveedor sube a tier pago
+- Efecto red: más nodos → más servicios → más valor para cada nodo
+
+### Incentivos para publicar servicios de calidad
+- **Maturity score** determina el ranking en búsquedas (mejor score = más visibilidad)
+- **Badge "Verified Provider"**: nodos con >1.000 llamadas y 0 reportes
+- **Descuento en plan propio**: top 10 proveedores del mes reciben 20% off en su siguiente mes
+- **Featured services**: la plataforma puede destacar servicios en la home (no pago, por calidad)
+
+### Prevención de fraude
+- Rate limiting estricto en free tier (implementado en el SDK del proveedor)
+- Metering cross-referenciado: el gateway valida contra los reportes del proveedor
+- Anomaly detection: picos de llamadas fuera de patrón → revisión automática
+- Chargebacks: si un proveedor reporta datos falsos, se suspende y se retiene el pago
+
+---
+
+## Comparación con modelos similares
+
+| Plataforma | Split proveedor | Modelo |
+|---|---|---|
+| Apple App Store | 70% | Subscriptions / one-time purchase |
+| Google Play | 85% (después de $1M) | Ídem |
+| Stripe Connect | ~97% (cobran el 3%) | Pagos directos |
+| AWS Marketplace | 75-80% | SaaS / API |
+| **Interagent** | **70%** | API calls / subscriptions |
+
+El 70/25/5 es competitivo con App Store y más generoso que AWS Marketplace,
+justificado porque Interagent provee la infraestructura (gateway, auth, metering,
+NAT traversal) además del marketplace.
+
+---
+
+## Roadmap de monetización
+
+- [ ] Etapa 3 (Free tier): free tier sin cobro ni pago — solo registro y metering
+- [ ] Etapa 5a: Stripe Subscriptions — cobrar planes Starter/Pro
+- [ ] Etapa 5b: Stripe Connect — pagar a proveedores
+- [ ] Etapa 5c: Gateway de llamadas pagas — metering confiable para split
+- [ ] Etapa 5d: Dashboard de earnings para proveedores (en tiempo real)
+- [ ] Etapa 6: Enterprise — pricing custom, contratos, SLA garantizado

--- a/interagent/protocol/registry.openapi.yaml
+++ b/interagent/protocol/registry.openapi.yaml
@@ -1,0 +1,392 @@
+openapi: "3.1.0"
+info:
+  title: Interagent Registry API
+  version: "0.1.0"
+  description: |
+    API central de la plataforma Interagent.
+    Cada request de nodo autenticado debe incluir el header `X-Node-Signature`
+    (Ed25519 sobre el body + timestamp), más `X-Node-Id` y `X-Timestamp`.
+
+servers:
+  - url: https://registry.interagent.io/v1
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+# Todas las rutas marcadas con `nodeSig` requieren firma del nodo.
+# Rutas públicas (búsqueda, detalle) no requieren auth.
+
+components:
+  securitySchemes:
+    nodeSig:
+      type: apiKey
+      in: header
+      name: X-Node-Signature
+      description: "Ed25519 signature over SHA256(body + X-Timestamp)"
+
+  schemas:
+    ServiceSummary:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        description: { type: string }
+        category: { type: string }
+        tier: { type: string, enum: [free, starter, pro, enterprise] }
+        price_per_1k_calls: { type: number }
+        stars: { type: number }
+        joins: { type: integer }
+        maturity_score: { type: number }
+        provider_node_id: { type: string }
+        status: { type: string, enum: [active, suspended, banned] }
+
+    ServiceDetail:
+      allOf:
+        - $ref: "#/components/schemas/ServiceSummary"
+        - type: object
+          properties:
+            version: { type: string }
+            tags: { type: array, items: { type: string } }
+            endpoint: { type: string }
+            schema: { type: object }
+            stats:
+              type: object
+              properties:
+                calls_total: { type: integer }
+                calls_last_30d: { type: integer }
+                uptime_30d_pct: { type: number }
+                ratings_count: { type: integer }
+
+    Node:
+      type: object
+      properties:
+        node_id: { type: string }
+        plan: { type: string, enum: [free, starter, pro, enterprise] }
+        public_key: { type: string }
+        verified_provider: { type: boolean }
+        created_at: { type: string, format: date-time }
+
+    Error:
+      type: object
+      properties:
+        code: { type: string }
+        message: { type: string }
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+paths:
+
+  # --- Nodos ---
+
+  /nodes/register:
+    post:
+      summary: Registrar un nuevo nodo en la plataforma
+      description: Devuelve node_id y keypair generado. La clave privada NO se almacena.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [public_key, contact_email]
+              properties:
+                public_key: { type: string, description: "Ed25519 public key (base64)" }
+                contact_email: { type: string }
+                display_name: { type: string }
+      responses:
+        "201":
+          description: Nodo registrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
+        "409":
+          description: Public key ya registrada
+
+  /nodes/me:
+    get:
+      summary: Info del nodo autenticado
+      security: [{ nodeSig: [] }]
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
+
+  # --- Servicios: descubrimiento (público) ---
+
+  /services:
+    get:
+      summary: Listar y buscar servicios
+      parameters:
+        - name: q
+          in: query
+          description: Búsqueda por nombre o descripción
+          schema: { type: string }
+        - name: category
+          in: query
+          schema: { type: string }
+        - name: tier
+          in: query
+          schema: { type: string, enum: [free, starter, pro, enterprise] }
+        - name: sort
+          in: query
+          schema: { type: string, enum: [maturity_score, stars, joins, calls_total] }
+          default: maturity_score
+        - name: page
+          in: query
+          schema: { type: integer, default: 1 }
+        - name: per_page
+          in: query
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  page: { type: integer }
+                  items:
+                    type: array
+                    items: { $ref: "#/components/schemas/ServiceSummary" }
+
+  /services/{service_id}:
+    get:
+      summary: Detalle de un servicio
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ServiceDetail" }
+        "404":
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  # --- Servicios: gestión (requiere auth de nodo) ---
+
+  /services:
+    post:
+      summary: Publicar un nuevo servicio
+      security: [{ nodeSig: [] }]
+      requestBody:
+        required: true
+        content:
+          application/yaml:
+            schema:
+              description: "Contenido del service.schema.yaml"
+              type: object
+      responses:
+        "201":
+          description: Servicio publicado
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ServiceDetail" }
+        "400":
+          description: Schema inválido
+
+  /services/{service_id}:
+    put:
+      summary: Actualizar un servicio propio
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ServiceDetail" }
+        "403":
+          description: El servicio no pertenece a este nodo
+
+    delete:
+      summary: Despublicar un servicio
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "204":
+          description: Servicio eliminado
+
+  # --- Joins ---
+
+  /services/{service_id}/join:
+    post:
+      summary: Registrar que el nodo usa este servicio (join)
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Join registrado o ya existente
+
+  /services/{service_id}/unjoin:
+    post:
+      summary: Dejar de usar el servicio
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Unjoin registrado
+
+  # --- Valoraciones ---
+
+  /services/{service_id}/ratings:
+    post:
+      summary: Calificar un servicio (solo nodos que hayan hecho join)
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [stars]
+              properties:
+                stars:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                comment: { type: string, maxLength: 500 }
+      responses:
+        "201":
+          description: Valoración registrada
+        "403":
+          description: Nodo no ha hecho join a este servicio
+        "409":
+          description: Ya calificaste este servicio (actualizar con PUT)
+
+    put:
+      summary: Actualizar valoración propia
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [stars]
+              properties:
+                stars: { type: integer, minimum: 1, maximum: 5 }
+                comment: { type: string, maxLength: 500 }
+      responses:
+        "200":
+          description: Valoración actualizada
+
+  # --- Reportes ---
+
+  /services/{service_id}/reports:
+    post:
+      summary: Reportar un servicio
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: service_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason:
+                  type: string
+                  enum: [spam, malicious, false_description, abusive, other]
+                detail: { type: string, maxLength: 1000 }
+      responses:
+        "201":
+          description: Reporte registrado
+        "409":
+          description: Ya reportaste este servicio
+
+  # --- Metering (llamadas entre nodos) ---
+
+  /metering/record:
+    post:
+      summary: Registrar una llamada entre nodos (usado por el SDK)
+      description: |
+        Para llamadas free tier, el nodo proveedor reporta cada llamada recibida.
+        Para llamadas pagas, el gateway lo registra automáticamente.
+      security: [{ nodeSig: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [service_id, consumer_node_id, timestamp_ms, latency_ms, success]
+              properties:
+                service_id: { type: string }
+                consumer_node_id: { type: string }
+                timestamp_ms: { type: integer }
+                latency_ms: { type: integer }
+                success: { type: boolean }
+                error_code: { type: string }
+      responses:
+        "204":
+          description: Registrado
+
+  /metering/usage:
+    get:
+      summary: Ver uso del nodo autenticado (como consumidor y proveedor)
+      security: [{ nodeSig: [] }]
+      parameters:
+        - name: period
+          in: query
+          schema: { type: string, enum: [current_month, last_month] }
+          default: current_month
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  as_consumer:
+                    type: object
+                    properties:
+                      calls_total: { type: integer }
+                      calls_by_service: { type: object }
+                      amount_due_usd: { type: number }
+                  as_provider:
+                    type: object
+                    properties:
+                      calls_received: { type: integer }
+                      calls_by_service: { type: object }
+                      earnings_usd: { type: number }

--- a/interagent/protocol/service.schema.yaml
+++ b/interagent/protocol/service.schema.yaml
@@ -1,0 +1,91 @@
+# Interagent Service Schema v0.1
+# Formato de definición de un servicio publicado en la registry.
+
+$schema: "https://interagent.io/schemas/service/v0.1"
+
+# --- Identidad ---
+service:
+  id: "weather.forecast.v1"          # <category>.<name>.<version> — único en la registry
+  name: "Weather Forecast"
+  description: "Real-time weather and 7-day forecast for any coordinate."
+  version: "1.0.0"                   # semver
+  category: "environment"            # environment | home | finance | productivity | utility | other
+  tags: [weather, forecast, climate, open-meteo]
+
+# --- Proveedor ---
+  provider:
+    node_id: "node-abc123"           # asignado por la registry al registrar el nodo
+    contact: "matias@blasi.ar"       # opcional, para soporte
+    public_key: "ed25519:..."        # clave pública del nodo para verificar firmas
+
+# --- Acceso y precio ---
+  access:
+    tier: free                       # free | starter | pro | enterprise
+    price_per_1k_calls: 0.00         # USD; 0 = free
+    rate_limit_free:
+      calls_per_day: 100
+      calls_per_month: 1000
+    endpoint: "https://node-abc123.interagent.io/svc/weather/forecast"
+    # Para free tier, llamadas van directo a este endpoint.
+    # Para tiers pagos, el gateway redirige internamente.
+
+# --- Schema de entrada y salida ---
+  schema:
+    input:
+      type: object
+      required: [location]
+      properties:
+        location:
+          type: string
+          description: "Lat,Lon — e.g. '-34.6,-58.4'"
+          example: "-34.6,-58.4"
+        days:
+          type: integer
+          minimum: 1
+          maximum: 7
+          default: 1
+    output:
+      type: object
+      properties:
+        location:
+          type: string
+        current:
+          type: object
+          properties:
+            temperature_c: { type: number }
+            humidity_pct: { type: number }
+            wind_kmh: { type: number }
+            condition: { type: string }
+        forecast:
+          type: array
+          items:
+            type: object
+            properties:
+              date: { type: string, format: date }
+              temp_max_c: { type: number }
+              temp_min_c: { type: number }
+              precipitation_mm: { type: number }
+              condition: { type: string }
+    errors:
+      - code: "LOCATION_INVALID"
+        description: "Coordinates out of range or malformed."
+      - code: "PROVIDER_OFFLINE"
+        description: "The provider node is not reachable."
+      - code: "RATE_LIMIT_EXCEEDED"
+        description: "Free tier monthly limit reached."
+
+# --- Estadísticas (calculadas por la registry, no editables por el proveedor) ---
+  stats:
+    stars: 4.7                       # promedio 1-5
+    ratings_count: 89
+    joins: 342                       # nodos que lo tienen integrado
+    calls_total: 45000
+    calls_last_30d: 3200
+    uptime_30d_pct: 99.1
+    maturity_score: 87.3             # stars × log(joins) × log(calls_total), normalizado 0-100
+
+# --- Moderación ---
+  moderation:
+    status: active                   # active | suspended | banned
+    reports_count: 0
+    verified_provider: true          # badge: >1000 llamadas sin reportes

--- a/interagent/sdk/README.md
+++ b/interagent/sdk/README.md
@@ -1,0 +1,148 @@
+# Interagent SDK
+
+Biblioteca Python para que un nodo publique y consuma servicios de la registry Interagent.
+
+## Instalación (futura)
+
+```bash
+pip install interagent-sdk
+```
+
+## CLI
+
+```bash
+# Registrar este nodo en la registry (genera keypair local)
+interagent init
+
+# Publicar un servicio (lee interagent/protocol/service.schema.yaml)
+interagent publish ./my-service.schema.yaml
+
+# Listar servicios disponibles
+interagent list [--category environment] [--tier free] [--sort maturity_score]
+
+# Llamar un servicio remoto
+interagent call weather.forecast.v1 --input '{"location": "-34.6,-58.4", "days": 3}'
+
+# Ver uso y earnings del mes actual
+interagent usage
+```
+
+## Python API
+
+### Publicar un servicio
+
+```python
+from interagent import Node, Service
+
+node = Node.from_config("~/.interagent/node.yaml")  # keypair + node_id
+
+service = Service.from_schema("./weather.schema.yaml")
+node.publish(service)
+```
+
+### Exponer un agente como servicio
+
+```python
+from interagent import Node, expose
+from fastapi import FastAPI
+
+app = FastAPI()
+node = Node.from_config("~/.interagent/node.yaml")
+
+@expose(node, service_id="weather.forecast.v1")
+async def weather_handler(location: str, days: int = 1):
+    # lógica del agente local
+    return {"temperature_c": 22.5, "forecast": [...]}
+
+# El decorador registra el endpoint y lo firma automáticamente.
+# Rate limiting del free tier se aplica aquí.
+```
+
+### Consumir un servicio remoto
+
+```python
+from interagent import Node
+
+node = Node.from_config("~/.interagent/node.yaml")
+client = node.client()
+
+result = await client.call(
+    "weather.forecast.v1",
+    input={"location": "-34.6,-58.4", "days": 3}
+)
+print(result["current"]["temperature_c"])
+```
+
+### Integrar con el orquestador existente (home-agents)
+
+```python
+# En ha-bridge/orchestrator.py — cuando no hay agente local para resolver
+# la intención, delegar a la registry:
+
+from interagent import Node
+
+node = Node.from_config("~/.interagent/node.yaml")
+client = node.client()
+
+async def resolve_intent(intent: str, params: dict):
+    # 1. Intentar con agente local
+    if intent in local_agents:
+        return await local_agents[intent].handle(params)
+    
+    # 2. Buscar en registry
+    services = await client.search(query=intent, tier="free")
+    if services:
+        return await client.call(services[0].id, input=params)
+    
+    return None
+```
+
+## Firma de requests
+
+Cada llamada saliente incluye:
+
+```
+X-Node-Id: node-abc123
+X-Timestamp: 1745800000000
+X-Node-Signature: base64(Ed25519.sign(SHA256(body_bytes + timestamp_bytes)))
+```
+
+El SDK firma automáticamente. La clave privada nunca sale del nodo.
+
+## Configuración local
+
+```yaml
+# ~/.interagent/node.yaml
+node_id: "node-abc123"
+private_key: "ed25519:..."         # generada en `interagent init`, nunca sube a la registry
+public_key: "ed25519:..."
+registry_url: "https://registry.interagent.io/v1"
+plan: free
+```
+
+## Problema de NAT traversal
+
+Un nodo doméstico típicamente está detrás de NAT y no tiene IP pública.
+Para recibir llamadas entrantes, el SDK soportará (en orden de preferencia):
+
+1. **Cloudflare Tunnel** (recomendado): `cloudflared tunnel` expone el puerto local
+   sin abrir el router. Gratis, confiable, sin IP pública.
+2. **Relay server**: la registry actúa de relay, el nodo mantiene una conexión
+   WebSocket persistente y el gateway inyecta las llamadas por esa conexión.
+3. **IP pública / VPN**: para nodos con IP fija o conectados a una VPN.
+
+El SDK detecta el método disponible y lo configura automáticamente en `interagent init`.
+
+## Roadmap del SDK
+
+- [ ] `interagent init` — registro de nodo + generación de keypair
+- [ ] `interagent publish` — publicar/actualizar servicio en registry
+- [ ] `interagent list` / `interagent search` — descubrimiento
+- [ ] `interagent call` — llamada CLI a servicio remoto
+- [ ] `Node` + `Service` + client Python API
+- [ ] Decorador `@expose` para FastAPI
+- [ ] Rate limiting automático (free tier)
+- [ ] Metering reporting (reportar llamadas recibidas)
+- [ ] NAT traversal: Cloudflare Tunnel automático
+- [ ] NAT traversal: relay WebSocket como fallback
+- [ ] `interagent usage` — dashboard de consumo y earnings en terminal


### PR DESCRIPTION
Vision document, service schema, registry OpenAPI spec, SDK design, and monetization model for the multi-agent network-of-networks platform. Registry uses Ed25519-signed requests, 70/25/5 revenue split, and Cloudflare Tunnel for NAT traversal on home nodes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only new documentation and specification files (concept, OpenAPI, schema, and SDK/monetization design) with no runtime code changes, so functional risk is low.
> 
> **Overview**
> Introduces an initial **Interagent** concept and specification set under `interagent/`, defining a “network-of-networks” of local agent nodes that can publish/consume services.
> 
> Adds a formal `service.schema.yaml`, a `registry.openapi.yaml` describing the registry API (node registration, service discovery/management, joins/ratings/reports, and metering) with Ed25519-signed node requests, plus an SDK design doc (`sdk/README.md`) and a monetization model (`monetization/model.md`) including tiers and a 70/25/5 revenue split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d9fa84852249c217ed6320467a9dbb69673b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->