### PR TITLE
feat: backoffice — Plan expandible + Ear Live + fix estado ear

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -160,12 +160,24 @@ def root():
     return RedirectResponse("/dashboard")
 
 
+_EAR_STALE_SECS = 180  # heartbeat cada 60s → 3x es margin seguro
+
+
+def _ear_state() -> dict | None:
+    """Devuelve state.json solo si el heartbeat en devices.json es reciente."""
+    devices = _read_json("devices.json") or {}
+    cutoff = time.time() - _EAR_STALE_SECS
+    if not any(d.get("ts", 0) > cutoff for d in devices.values()):
+        return None
+    return _read_json("state.json") or None
+
+
 @app.get("/dashboard", response_class=HTMLResponse)
 def dashboard(request: Request):
     health  = _core("/health") or {}
     history = _read_json("history.json") or []
     alerts  = _core("/alerts") or []
-    state   = _read_json("state.json") or {}
+    state   = _ear_state()
 
     # Latencias promedio de la sesión
     lats = {"stt": [], "llm": [], "total": []}
@@ -318,6 +330,108 @@ def delete_user_htmx(uid: str):
     return HTMLResponse("")
 
 
+@app.get("/ear", response_class=HTMLResponse)
+def ear_page(request: Request):
+    return _render(request, "ear.html", "ear")
+
+
+@app.get("/ear/stream")
+def ear_stream():
+    """SSE: score + estado del ear a ~5Hz."""
+    def _gen():
+        while True:
+            score_data = _read_json("score.json") or {}
+            score = round(score_data.get("score", 0.0), 4)
+            state_obj = _ear_state()
+            state = state_obj.get("state", "stopped") if state_obj else "stopped"
+            yield f"data: {json.dumps({'score': score, 'state': state})}\n\n"
+            time.sleep(0.2)
+    return StreamingResponse(
+        _gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@app.get("/api/ear/history", response_class=HTMLResponse)
+def ear_history_fragment():
+    history = _read_json("history.json") or []
+    recent  = list(reversed(history[-15:]))
+    if not recent:
+        return HTMLResponse(
+            '<tr><td colspan="5" class="px-3 py-4 text-center text-gray-600">Sin comandos aún</td></tr>'
+        )
+
+    def lat_color(v: float) -> str:
+        if v <= 0:  return "text-gray-600"
+        if v < 10:  return "text-green-400"
+        if v < 20:  return "text-yellow-400"
+        return "text-red-400"
+
+    rows: list[str] = []
+    prev_conv = None
+    for e in recent:
+        conv_id = e.get("conversation_id") or ""
+        if prev_conv is not None and conv_id != prev_conv:
+            rows.append('<tr><td colspan="5" class="text-center text-gray-700 py-0.5 text-xs">· · ·</td></tr>')
+        accion = e.get("accion") or "—"
+        if accion and "→" in accion:
+            accion = accion.split("→")[-1].strip()
+        lat = e.get("lat_total", 0)
+        rows.append(
+            f'<tr class="border-b border-gray-800/50 hover:bg-gray-800/30">'
+            f'<td class="px-3 py-1.5 text-gray-500 text-xs whitespace-nowrap">{e.get("ts","")}</td>'
+            f'<td class="px-3 py-1.5 text-blue-500 text-xs font-mono">{conv_id[:6] or "——"}</td>'
+            f'<td class="px-3 py-1.5 text-gray-200 text-xs">{e.get("texto","")}</td>'
+            f'<td class="px-3 py-1.5 text-cyan-400 text-xs">{accion[:45]}</td>'
+            f'<td class="px-3 py-1.5 {lat_color(lat)} text-xs text-right font-mono">{lat:.1f}s</td>'
+            f'</tr>'
+        )
+        prev_conv = conv_id
+    return HTMLResponse("\n".join(rows))
+
+
+@app.get("/api/ear/latency", response_class=HTMLResponse)
+def ear_latency_fragment():
+    history = _read_json("history.json") or []
+    if not history:
+        return HTMLResponse('<p class="text-gray-600 text-sm text-center py-3">Sin datos aún</p>')
+
+    last   = history[-1]
+    valids = [e for e in history if e.get("lat_total", 0) > 0]
+
+    def avg(k: str) -> float:
+        return sum(e.get(k, 0) for e in valids) / len(valids) if valids else 0
+
+    def lat_color(v: float) -> str:
+        if v <= 0:  return "text-gray-600"
+        if v < 5:   return "text-green-400"
+        if v < 10:  return "text-yellow-400"
+        return "text-red-400"
+
+    def fmt(v: float) -> str:
+        return f"{v:.1f}s" if v > 0 else "—"
+
+    rows: list[str] = []
+    for label, key in [("STT (Whisper)", "lat_stt"), ("LLM + HA", "lat_llm"), ("Total", "lat_total")]:
+        lv, av = last.get(key, 0), avg(key)
+        rows.append(
+            f'<div class="flex justify-between items-center py-1.5 border-b border-gray-800/50">'
+            f'<span class="text-gray-400 text-sm">{label}</span>'
+            f'<div class="flex gap-6">'
+            f'<span class="{lat_color(lv)} font-mono text-sm w-12 text-right">{fmt(lv)}</span>'
+            f'<span class="text-gray-600 font-mono text-sm w-12 text-right">{fmt(av)}</span>'
+            f'</div></div>'
+        )
+    rows.append(
+        f'<div class="flex justify-between items-center pt-2">'
+        f'<span class="text-gray-600 text-xs">Comandos (sesión)</span>'
+        f'<span class="text-white font-bold">{len(history)}</span>'
+        f'</div>'
+    )
+    return HTMLResponse("\n".join(rows))
+
+
 @app.get("/logs", response_class=HTMLResponse)
 def logs_page(request: Request):
     return _render(request, "logs.html", "logs")
@@ -365,3 +479,146 @@ def integrations_page(request: Request):
 
     return _render(request, "integrations.html", "integrations",
                    health=health, agents=agents, ollama_models=ollama_models)
+
+
+# ── Plan ───────────────────────────────────────────────────────────────────────
+
+import re as _re
+import yaml as _yaml
+
+_GH_DEFAULT_REPO = "mblasi/home-agents"
+_TASK_ID_RE = _re.compile(r"^\d+(\.\d+)*$")
+
+
+def _load_issue_urls() -> dict[str, tuple[str, int]]:
+    """Return {task_id: (gh_url, issue_number)} from masterplan/issues.yaml."""
+    issues_path = Path.home() / "workspace/home-agents/masterplan/issues.yaml"
+    try:
+        raw = _yaml.safe_load(issues_path.read_text()) or {}
+    except Exception:
+        return {}
+    urls: dict[str, tuple[str, int]] = {}
+    for task_id, v in raw.items():
+        task_id = str(task_id)
+        if isinstance(v, int):
+            urls[task_id] = (f"https://github.com/{_GH_DEFAULT_REPO}/issues/{v}", v)
+        elif isinstance(v, dict):
+            repo = v.get("repo", _GH_DEFAULT_REPO)
+            num  = v.get("number")
+            if num:
+                urls[task_id] = (f"https://github.com/{repo}/issues/{num}", num)
+    return urls
+
+
+def _parse_plan() -> list[dict]:
+    """Parse masterplan/estado.md → phases with per-task detail and GH issue links."""
+    plan_path = Path.home() / "workspace/home-agents/masterplan/estado.md"
+    try:
+        content = plan_path.read_text()
+    except Exception:
+        return []
+
+    issue_urls = _load_issue_urls()
+
+    phases: list[dict] = []
+    current: dict | None = None
+    in_code_block = False
+    in_masterplan = False
+
+    for line in content.splitlines():
+        if line.strip() == "## MASTERPLAN":
+            in_masterplan = True
+            continue
+        if not in_masterplan:
+            continue
+
+        if line.startswith("### FASE"):
+            if current:
+                phases.append(current)
+            rest = line[4:].strip()[5:]  # drop "### " then "FASE "
+            phase_id, _, title = rest.partition(" - ")
+            current = {
+                "id": phase_id.strip(),
+                "title": title.strip() or phase_id.strip(),
+                "objetivo": "",
+                "estado_raw": "Pendiente",
+                "tasks_done": 0,
+                "tasks_total": 0,
+                "tasks": [],
+            }
+            in_code_block = False
+            continue
+
+        if current is None:
+            continue
+
+        if line.strip().startswith("```"):
+            in_code_block = not in_code_block
+            continue
+
+        if in_code_block:
+            stripped = line.strip()
+            if stripped.startswith("Objetivo:"):
+                current["objetivo"] = stripped[9:].strip()
+            elif stripped.startswith("Estado:"):
+                current["estado_raw"] = stripped[7:].strip()
+            continue
+
+        done = None
+        if line.startswith("- [x]"):
+            done = True
+        elif line.startswith("- [ ]"):
+            done = False
+
+        if done is not None:
+            current["tasks_total"] += 1
+            if done:
+                current["tasks_done"] += 1
+            # Extract task id and text: "- [x] 1.9  Elegir voz..."
+            rest = line[6:].strip()
+            parts = rest.split(None, 1)
+            task_id = parts[0] if parts else ""
+            text    = parts[1].strip() if len(parts) > 1 else task_id
+            # Strip markdown bold markers
+            text = text.replace("**", "")
+            # Only treat as linkable id if it looks like N.M[.K...]
+            if not _TASK_ID_RE.match(task_id):
+                task_id = ""
+            gh_url, gh_num = issue_urls.get(task_id, (None, None))
+            current["tasks"].append({
+                "id":      task_id,
+                "text":    text,
+                "done":    done,
+                "gh_url":  gh_url,
+                "gh_num":  gh_num,
+            })
+
+    if current:
+        phases.append(current)
+
+    for p in phases:
+        raw = p["estado_raw"].upper()
+        if "COMPLETA" in raw:
+            p["estado"] = "COMPLETA"
+        elif "EN CURSO" in raw or "PROGRESO" in raw:
+            p["estado"] = "EN CURSO"
+        else:
+            p["estado"] = "Pendiente"
+        if p["tasks_total"] > 0:
+            p["pct"] = round(100 * p["tasks_done"] / p["tasks_total"])
+        else:
+            p["pct"] = 100 if p["estado"] == "COMPLETA" else 0
+
+    return phases
+
+
+@app.get("/plan", response_class=HTMLResponse)
+def plan_page(request: Request):
+    phases = _parse_plan()
+    total_done  = sum(p["tasks_done"]  for p in phases)
+    total_tasks = sum(p["tasks_total"] for p in phases)
+    total_pct   = round(100 * total_done / total_tasks) if total_tasks else 0
+    phases_complete = sum(1 for p in phases if p["estado"] == "COMPLETA")
+    return _render(request, "plan.html", "plan",
+                   phases=phases, total_done=total_done, total_tasks=total_tasks,
+                   total_pct=total_pct, phases_complete=phases_complete)

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -32,6 +32,7 @@
       <div class="flex flex-col gap-1">
         <p class="px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-600">Monitoreo</p>
         <a href="/dashboard"    class="{{ link_active if section == 'dashboard'    else link_base }}">📊 Dashboard</a>
+        <a href="/ear"          class="{{ link_active if section == 'ear'          else link_base }}">👂 Ear — Live</a>
         <a href="/stats"        class="{{ link_active if section == 'stats'        else link_base }}">📈 Estadísticas</a>
         <a href="/alerts"       class="{{ link_active if section == 'alerts'       else link_base }}">🔔 Alertas</a>
         <a href="/logs"         class="{{ link_active if section == 'logs'         else link_base }}">📋 Logs</a>
@@ -43,6 +44,7 @@
         <a href="/agents"       class="{{ link_active if section == 'agents'       else link_base }}">🤖 Agentes</a>
         <a href="/conversations"class="{{ link_active if section == 'conversations'else link_base }}">💬 Conversaciones</a>
         <a href="/shared-state" class="{{ link_active if section == 'shared-state' else link_base }}">🔗 Shared State</a>
+        <a href="/plan"         class="{{ link_active if section == 'plan'         else link_base }}">🗺️ Plan</a>
       </div>
 
       <!-- Configuración -->

--- a/backoffice/templates/ear.html
+++ b/backoffice/templates/ear.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+{% block title %}Ear — Live{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Ear — Live</h1>
+  <div class="flex items-center gap-2 text-xs text-gray-500">
+    <span id="conn-dot" class="w-2 h-2 rounded-full bg-gray-600 transition-colors"></span>
+    <span id="conn-label">conectando…</span>
+  </div>
+</div>
+
+<div class="grid grid-cols-5 gap-4">
+
+  <!-- Panel izquierdo: estado + score bar -->
+  <div id="state-panel"
+       class="col-span-2 bg-gray-900 border border-gray-800 rounded-xl
+              flex flex-col items-center justify-center gap-6 p-8 transition-colors min-h-72">
+
+    <!-- Icono + texto de estado -->
+    <div class="text-center space-y-2">
+      <div id="state-icon" class="text-6xl leading-none select-none">⏸️</div>
+      <div id="state-label" class="text-xl font-bold text-gray-500 transition-colors">Detenido</div>
+    </div>
+
+    <!-- Score bar -->
+    <div class="w-full max-w-xs space-y-1.5">
+      <div class="flex justify-between text-xs text-gray-500">
+        <span>Wake word score</span>
+        <span id="score-value" class="font-mono text-gray-400">0.000</span>
+      </div>
+      <div class="relative w-full bg-gray-800 rounded-full h-3 overflow-visible">
+        <div id="score-fill"
+             class="h-3 rounded-full bg-gray-600 transition-all duration-100"
+             style="width:0%"></div>
+        <!-- Threshold marker -->
+        <div class="absolute inset-y-0 w-px bg-orange-400/50 pointer-events-none"
+             style="left:80%"></div>
+      </div>
+      <div class="text-right text-xs text-orange-400/50">umbral 0.800</div>
+    </div>
+
+  </div>
+
+  <!-- Panel derecho: historial + latencias -->
+  <div class="col-span-3 flex flex-col gap-4">
+
+    <!-- Historial (análogo a panel_history.py) -->
+    <div class="flex-1 bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      <div class="px-4 py-2.5 border-b border-gray-800 flex items-center justify-between">
+        <span class="text-sm font-semibold text-gray-300">Historial</span>
+        <span class="text-xs text-gray-600">últimos 15 comandos · actualiza cada 2s</span>
+      </div>
+      <div class="overflow-auto" style="max-height:260px">
+        <table class="w-full">
+          <thead class="sticky top-0 bg-gray-900 z-10">
+            <tr class="text-left border-b border-gray-800">
+              <th class="px-3 py-1.5 text-xs text-gray-500 font-medium">Hora</th>
+              <th class="px-3 py-1.5 text-xs text-gray-500 font-medium">Conv</th>
+              <th class="px-3 py-1.5 text-xs text-gray-500 font-medium">Comando</th>
+              <th class="px-3 py-1.5 text-xs text-gray-500 font-medium">Acción</th>
+              <th class="px-3 py-1.5 text-xs text-gray-500 font-medium text-right">Lat.</th>
+            </tr>
+          </thead>
+          <tbody id="history-body"
+                 hx-get="/api/ear/history"
+                 hx-trigger="load, every 2s"
+                 hx-target="#history-body"
+                 hx-swap="innerHTML">
+            <tr><td colspan="5" class="px-3 py-4 text-center text-gray-600 text-xs">cargando…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Latencias (análogo a panel_latency.py) -->
+    <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      <div class="px-4 py-2.5 border-b border-gray-800 flex items-center justify-between">
+        <span class="text-sm font-semibold text-gray-300">Latencias</span>
+        <span class="text-xs text-gray-600">último &nbsp;/&nbsp; promedio sesión</span>
+      </div>
+      <div id="latency-body" class="px-4 py-2"
+           hx-get="/api/ear/latency"
+           hx-trigger="load, every 2s"
+           hx-target="#latency-body"
+           hx-swap="innerHTML">
+        <p class="text-gray-600 text-sm text-center py-3">cargando…</p>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+(function () {
+  const STATES = {
+    init:       ['⏳', 'Inicializando…', 'text-yellow-400', 'border-yellow-700'],
+    listening:  ['👂', 'Escuchando',     'text-green-400',  'border-green-700'],
+    triggered:  ['🎯', '¡Wake word!',    'text-cyan-400',   'border-cyan-700'],
+    recording:  ['⏺',  'Grabando…',      'text-red-400',    'border-red-700'],
+    processing: ['⚙',  'Procesando…',   'text-yellow-400', 'border-yellow-700'],
+    speaking:   ['🔊', 'Respondiendo…', 'text-blue-400',   'border-blue-700'],
+    stopped:    ['⛔', 'Detenido',       'text-gray-500',   'border-gray-800'],
+  };
+  const ALL_BORDERS = Object.values(STATES).map(s => s[3]);
+
+  const panel      = document.getElementById('state-panel');
+  const icon       = document.getElementById('state-icon');
+  const label      = document.getElementById('state-label');
+  const fill       = document.getElementById('score-fill');
+  const scoreVal   = document.getElementById('score-value');
+  const connDot    = document.getElementById('conn-dot');
+  const connLabel  = document.getElementById('conn-label');
+
+  let currentState = null;
+
+  function scoreBarColor(s) {
+    if (s > 0.80) return 'bg-red-500';
+    if (s > 0.40) return 'bg-yellow-500';
+    if (s > 0.05) return 'bg-green-500';
+    return 'bg-gray-600';
+  }
+
+  function applyState(state) {
+    if (state === currentState) return;
+    currentState = state;
+    const [ic, lb, textCls, borderCls] = STATES[state] || STATES.stopped;
+    icon.textContent  = ic;
+    label.textContent = lb;
+    label.className   = 'text-xl font-bold transition-colors ' + textCls;
+    ALL_BORDERS.forEach(c => panel.classList.remove(c));
+    panel.classList.add(borderCls);
+  }
+
+  const es = new EventSource('/ear/stream');
+
+  es.onopen = () => {
+    connDot.className  = 'w-2 h-2 rounded-full bg-green-500 transition-colors';
+    connLabel.textContent = 'conectado';
+  };
+  es.onerror = () => {
+    connDot.className  = 'w-2 h-2 rounded-full bg-red-500 transition-colors';
+    connLabel.textContent = 'desconectado';
+    applyState('stopped');
+  };
+  es.onmessage = (e) => {
+    const d = JSON.parse(e.data);
+    const pct = (d.score * 100).toFixed(1);
+    fill.style.width = pct + '%';
+    fill.className   = 'h-3 rounded-full transition-all duration-100 ' + scoreBarColor(d.score);
+    scoreVal.textContent = d.score.toFixed(3);
+    applyState(d.state);
+  };
+})();
+</script>
+{% endblock %}

--- a/backoffice/templates/plan.html
+++ b/backoffice/templates/plan.html
@@ -1,0 +1,129 @@
+{% extends "base.html" %}
+{% block title %}Plan{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-2">Plan de desarrollo</h1>
+<p class="text-gray-500 text-sm mb-6">masterplan/estado.md</p>
+
+<!-- Resumen global -->
+<div class="grid grid-cols-4 gap-4 mb-8">
+  <div class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-4">
+    <div class="text-xs text-gray-500 uppercase tracking-wider mb-1">Fases completadas</div>
+    <div class="text-2xl font-bold">{{ phases_complete }}<span class="text-gray-600 text-lg font-normal">/{{ phases|length }}</span></div>
+  </div>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-4">
+    <div class="text-xs text-gray-500 uppercase tracking-wider mb-1">Tareas completadas</div>
+    <div class="text-2xl font-bold">{{ total_done }}<span class="text-gray-600 text-lg font-normal">/{{ total_tasks }}</span></div>
+  </div>
+  <div class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-4 col-span-2">
+    <div class="text-xs text-gray-500 uppercase tracking-wider mb-2">Progreso total</div>
+    <div class="flex items-center gap-3">
+      <div class="flex-1 bg-gray-800 rounded-full h-2.5">
+        <div class="bg-emerald-500 h-2.5 rounded-full" style="width: {{ total_pct }}%"></div>
+      </div>
+      <span class="text-sm font-semibold text-emerald-400 w-10 text-right">{{ total_pct }}%</span>
+    </div>
+  </div>
+</div>
+
+<!-- Fases -->
+<div class="space-y-2">
+  {% for p in phases %}
+  {% set is_complete = p.estado == "COMPLETA" %}
+  {% set is_active   = p.estado == "EN CURSO" %}
+
+  <details class="group bg-gray-900 border rounded-xl overflow-hidden
+    {% if is_complete %}border-gray-800{% elif is_active %}border-blue-800/60{% else %}border-gray-800/60{% endif %}">
+
+    <!-- Header / summary -->
+    <summary class="flex items-center gap-4 px-5 py-4 cursor-pointer select-none
+                    hover:bg-gray-800/40 transition-colors [&::-webkit-details-marker]:hidden list-none">
+
+      <!-- Chevron -->
+      <svg class="w-4 h-4 text-gray-600 shrink-0 transition-transform group-open:rotate-90"
+           fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+      </svg>
+
+      <!-- Phase id + badge -->
+      <div class="flex items-center gap-2 shrink-0 w-40">
+        <span class="text-xs font-mono text-gray-500">FASE {{ p.id }}</span>
+        {% if is_complete %}
+        <span class="px-1.5 py-0.5 bg-emerald-900/40 text-emerald-400 rounded text-xs font-medium">COMPLETA</span>
+        {% elif is_active %}
+        <span class="px-1.5 py-0.5 bg-blue-900/40 text-blue-400 rounded text-xs font-medium">EN CURSO</span>
+        {% else %}
+        <span class="px-1.5 py-0.5 bg-gray-800 text-gray-500 rounded text-xs font-medium">Pendiente</span>
+        {% endif %}
+      </div>
+
+      <!-- Title + objetivo -->
+      <div class="flex-1 min-w-0">
+        <div class="font-medium truncate {% if not is_complete and not is_active %}text-gray-400{% endif %}">{{ p.title }}</div>
+        {% if p.objetivo %}
+        <div class="text-xs text-gray-600 truncate mt-0.5">{{ p.objetivo }}</div>
+        {% endif %}
+      </div>
+
+      <!-- Progress bar -->
+      {% if p.tasks_total > 0 %}
+      <div class="shrink-0 flex items-center gap-2 w-44">
+        <div class="flex-1 bg-gray-800 rounded-full h-1.5">
+          <div class="h-1.5 rounded-full
+            {% if is_complete %}bg-emerald-500{% elif is_active %}bg-blue-500{% else %}bg-gray-600{% endif %}"
+            style="width: {{ p.pct }}%"></div>
+        </div>
+        <span class="text-xs text-gray-500 tabular-nums w-12 text-right">{{ p.tasks_done }}/{{ p.tasks_total }}</span>
+      </div>
+      {% else %}
+      <div class="w-44 text-right text-xs text-gray-700">sin tareas</div>
+      {% endif %}
+
+    </summary>
+
+    <!-- Task list (visible when open) -->
+    {% if p.tasks %}
+    <div class="border-t border-gray-800 divide-y divide-gray-800/60">
+      {% for t in p.tasks %}
+      <div class="flex items-start gap-3 px-5 py-2.5
+                  {% if t.done %}bg-transparent{% else %}bg-gray-900{% endif %}
+                  hover:bg-gray-800/30 transition-colors">
+
+        <!-- Status icon -->
+        {% if t.done %}
+        <span class="shrink-0 mt-0.5 text-emerald-500 text-sm">✓</span>
+        {% else %}
+        <span class="shrink-0 mt-0.5 text-gray-600 text-sm">○</span>
+        {% endif %}
+
+        <!-- Task id -->
+        {% if t.id %}
+        <span class="shrink-0 font-mono text-xs text-gray-600 mt-0.5 w-10">{{ t.id }}</span>
+        {% else %}
+        <span class="shrink-0 w-10"></span>
+        {% endif %}
+
+        <!-- Description -->
+        <span class="flex-1 text-sm {% if t.done %}text-gray-500 line-through decoration-gray-700{% else %}text-gray-300{% endif %}">
+          {{ t.text }}
+        </span>
+
+        <!-- GH issue link -->
+        {% if t.gh_url %}
+        <a href="{{ t.gh_url }}" target="_blank" rel="noopener"
+           class="shrink-0 text-xs px-1.5 py-0.5 rounded
+                  {% if t.done %}text-gray-600 hover:text-gray-400{% else %}text-blue-500 hover:text-blue-400{% endif %}
+                  transition-colors">
+          #{{ t.gh_num }}
+        </a>
+        {% endif %}
+
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+
+  </details>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Vista /plan con detalle expandible**: cada fase es un `<details>` con chevron; al abrir muestra tareas con ✓/○, ID y link al issue de GH
- **Vista /ear Live**: réplica web del dashboard zellij — score animado con SSE (5Hz), historial y latencias con HTMX polling (2s)  
- **Fix dashboard**: el estado del ear ahora usa el heartbeat de `devices.json` (cada 60s) en lugar de `state.json` — detecta correctamente cuando el ear está apagado

## Test plan

- [ ] /plan → expandir fases con y sin tareas, verificar links de GH
- [ ] /ear → iniciar el ear, verificar score animado y cambios de estado
- [ ] /dashboard → apagar ear, verificar que muestra "Ear detenido" (no "listening")

🤖 Generated with [Claude Code](https://claude.com/claude-code)