### PR TITLE
feat: gestión de permisos por usuario en backoffice

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -274,31 +274,69 @@ def devices_page(request: Request):
     return _render(request, "devices.html", "devices", devices=devices)
 
 
+def _load_rbac_context() -> tuple[dict, dict]:
+    """Devuelve (agents, role_perms) del core. Ambos son dicts."""
+    agents = _core("/agents") or {}
+    role_perms = _core("/rbac/roles") or {}
+    return agents, role_perms
+
+
+def _compute_agent_overrides(
+    form, role: str, role_perms: dict, all_agent_ids: list[str]
+) -> tuple[list[str], list[str]]:
+    """Calcula grants y revocaciones a partir de los checkboxes del form.
+
+    Devuelve (agent_ids, revoked_agents):
+      agent_ids      — agentes marcados que el rol NO otorga (grants explícitos)
+      revoked_agents — agentes NO marcados que el rol SÍ otorga (revocaciones explícitas)
+    """
+    role_grants = set(role_perms.get(role, []))
+    if "*" in role_grants:
+        role_grants = set(all_agent_ids)
+
+    checked = {aid for aid in all_agent_ids if form.get(f"agent_{aid}")}
+
+    agent_ids      = sorted(checked - role_grants)
+    revoked_agents = sorted(role_grants - checked)
+    return agent_ids, revoked_agents
+
+
 @app.get("/users", response_class=HTMLResponse)
 def users_page(request: Request):
     data = _core("/users") or {}
-    return _render(request, "users.html", "users", users=data)
+    agents, role_perms = _load_rbac_context()
+    return _render(request, "users.html", "users", users=data, agents=agents, role_perms=role_perms)
 
 
 @app.get("/users/new", response_class=HTMLResponse)
 def new_user_page(request: Request):
-    return _render(request, "user_form.html", "users", user=None, uid=None, error="")
+    agents, role_perms = _load_rbac_context()
+    return _render(request, "user_form.html", "users",
+                   user=None, uid=None, error="", agents=agents, role_perms=role_perms)
 
 
 @app.post("/users/create")
 async def create_user_submit(request: Request):
     form = await request.form()
+    agents, role_perms = _load_rbac_context()
+    role = str(form.get("role", "invitado"))
+    agent_ids, revoked_agents = _compute_agent_overrides(
+        form, role, role_perms, list(agents.keys())
+    )
     payload = {
-        "id":           str(form.get("id", "")).strip(),
-        "name":         str(form.get("name", "")).strip(),
-        "role":         str(form.get("role", "invitado")),
-        "relationship": str(form.get("relationship", "invitado")),
-        "wa_phone":     str(form.get("wa_phone", "")).strip() or None,
+        "id":             str(form.get("id", "")).strip(),
+        "name":           str(form.get("name", "")).strip(),
+        "role":           role,
+        "relationship":   str(form.get("relationship", "invitado")),
+        "wa_phone":       str(form.get("wa_phone", "")).strip() or None,
+        "agent_ids":      agent_ids,
+        "revoked_agents": revoked_agents,
     }
     result = _core("/users", method="POST", json=payload)
     if result is None:
         return _render(request, "user_form.html", "users",
-                       user=payload, uid=None, error="No se pudo crear el usuario (¿ID ya existe?)")
+                       user=payload, uid=None, error="No se pudo crear el usuario (¿ID ya existe?)",
+                       agents=agents, role_perms=role_perms)
     return RedirectResponse("/users", status_code=303)
 
 
@@ -307,22 +345,33 @@ def edit_user_page(request: Request, uid: str):
     user = _core(f"/users/{uid}")
     if not user:
         return RedirectResponse("/users", status_code=303)
-    return _render(request, "user_form.html", "users", user=user, uid=uid, error="")
+    agents, role_perms = _load_rbac_context()
+    return _render(request, "user_form.html", "users",
+                   user=user, uid=uid, error="", agents=agents, role_perms=role_perms)
 
 
 @app.post("/users/{uid}/update")
 async def update_user_submit(request: Request, uid: str):
     form = await request.form()
+    agents, role_perms = _load_rbac_context()
+    role = str(form.get("role", "invitado"))
+    agent_ids, revoked_agents = _compute_agent_overrides(
+        form, role, role_perms, list(agents.keys())
+    )
     payload = {
-        "name":         str(form.get("name", "")).strip(),
-        "role":         str(form.get("role", "invitado")),
-        "relationship": str(form.get("relationship", "invitado")),
-        "wa_phone":     str(form.get("wa_phone", "")).strip() or None,
+        "name":           str(form.get("name", "")).strip(),
+        "role":           role,
+        "relationship":   str(form.get("relationship", "invitado")),
+        "wa_phone":       str(form.get("wa_phone", "")).strip() or None,
+        "agent_ids":      agent_ids,
+        "revoked_agents": revoked_agents,
     }
     result = _core(f"/users/{uid}", method="PATCH", json=payload)
     if result is None:
         return _render(request, "user_form.html", "users",
-                       user={**payload, "id": uid}, uid=uid, error="No se pudo actualizar el usuario")
+                       user={**payload, "id": uid}, uid=uid,
+                       error="No se pudo actualizar el usuario",
+                       agents=agents, role_perms=role_perms)
     return RedirectResponse("/users", status_code=303)
 
 

--- a/backoffice/templates/user_form.html
+++ b/backoffice/templates/user_form.html
@@ -44,10 +44,10 @@
     <div class="grid grid-cols-2 gap-3">
       <div>
         <label class="block text-xs text-gray-400 mb-1 uppercase tracking-wider">Rol</label>
-        <select name="role"
+        <select name="role" id="role-select"
                 class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm
                        focus:border-blue-500 focus:outline-none">
-          {% for r in ["admin", "familiar", "niño", "invitado"] %}
+          {% for r in ["admin", "familiar", "adolescente", "niño", "invitado"] %}
           <option value="{{ r }}" {{ "selected" if user and user.role == r }}>{{ r }}</option>
           {% endfor %}
         </select>
@@ -63,6 +63,58 @@
         </select>
       </div>
     </div>
+
+    {# ── Permisos sobre agentes ───────────────────────────────────────────────── #}
+    {% if agents %}
+    <div>
+      <label class="block text-xs text-gray-400 mb-2 uppercase tracking-wider">Acceso a agentes</label>
+
+      {# Calcular estado actual del usuario #}
+      {% set current_role = user.role if user else "invitado" %}
+      {% set role_grants = role_perms.get(current_role, []) %}
+      {% set has_all = "*" in role_grants %}
+      {% set user_grants = user.agent_ids if user and user.agent_ids else [] %}
+      {% set user_revokes = user.revoked_agents if user and user.revoked_agents else [] %}
+
+      <div class="bg-gray-800/50 border border-gray-700 rounded-lg divide-y divide-gray-700/50" id="agents-list">
+        {% for aid, info in agents.items() %}
+          {% set from_role = has_all or aid in role_grants %}
+          {% set explicitly_granted = aid in user_grants %}
+          {% set explicitly_revoked = aid in user_revokes %}
+          {% set checked = (from_role and not explicitly_revoked) or explicitly_granted %}
+          <label class="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-800/70 agent-row"
+                 data-agent="{{ aid }}">
+            <input type="checkbox"
+                   name="agent_{{ aid }}"
+                   id="agent_{{ aid }}"
+                   {% if checked %}checked{% endif %}
+                   class="w-4 h-4 rounded border-gray-600 bg-gray-700 text-blue-500
+                          focus:ring-blue-500 focus:ring-offset-gray-900 agent-checkbox"
+                   data-from-role="{{ 'true' if from_role else 'false' }}">
+            <span class="text-base">{{ info.icon }}</span>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium text-gray-200">{{ info.name }}</div>
+              <div class="text-xs text-gray-500 truncate">{{ info.desc }}</div>
+            </div>
+            <span class="text-xs shrink-0 override-label
+                         {% if explicitly_granted %}text-emerald-400
+                         {% elif explicitly_revoked %}text-red-400
+                         {% elif from_role %}text-gray-600
+                         {% else %}text-gray-700{% endif %}"
+                  id="label_{{ aid }}">
+              {% if explicitly_granted %}+ otorgado
+              {% elif explicitly_revoked %}&mdash; revocado
+              {% elif from_role %}por rol
+              {% else %}sin acceso{% endif %}
+            </span>
+          </label>
+        {% endfor %}
+      </div>
+      <p class="text-xs text-gray-600 mt-1.5">
+        Los checkboxes con "por rol" siguen el rol seleccionado. Cualquier cambio manual es un override individual.
+      </p>
+    </div>
+    {% endif %}
 
     <div>
       <label class="block text-xs text-gray-400 mb-1 uppercase tracking-wider">
@@ -92,4 +144,62 @@
     </div>
   </form>
 </div>
+
+<script>
+// Permisos por rol (inyectados desde el servidor)
+const ROLE_PERMS = {{ role_perms | tojson }};
+
+const roleSelect = document.getElementById("role-select");
+if (roleSelect) {
+  roleSelect.addEventListener("change", function () {
+    const role = this.value;
+    const grants = ROLE_PERMS[role] || [];
+    const hasAll = grants.includes("*");
+
+    document.querySelectorAll(".agent-checkbox").forEach(function (cb) {
+      const aid = cb.closest(".agent-row").dataset.agent;
+      const fromRole = hasAll || grants.includes(aid);
+      const label = document.getElementById("label_" + aid);
+
+      cb.checked = fromRole;
+      cb.dataset.fromRole = fromRole ? "true" : "false";
+
+      if (label) {
+        label.className = label.className.replace(/text-\w+-\d+/g, "").trim();
+        label.textContent = fromRole ? "por rol" : "sin acceso";
+        label.classList.add(fromRole ? "text-gray-600" : "text-gray-700");
+      }
+    });
+  });
+
+  // Actualizar label al hacer click manual en un checkbox
+  document.querySelectorAll(".agent-checkbox").forEach(function (cb) {
+    cb.addEventListener("change", function () {
+      const aid = cb.closest(".agent-row").dataset.agent;
+      const role = roleSelect.value;
+      const grants = ROLE_PERMS[role] || [];
+      const hasAll = grants.includes("*");
+      const fromRole = hasAll || grants.includes(aid);
+      const label = document.getElementById("label_" + aid);
+
+      if (!label) return;
+      label.className = label.className.replace(/text-\w+-\d+/g, "").trim();
+
+      if (cb.checked && !fromRole) {
+        label.textContent = "+ otorgado";
+        label.classList.add("text-emerald-400");
+      } else if (!cb.checked && fromRole) {
+        label.textContent = "— revocado";
+        label.classList.add("text-red-400");
+      } else if (cb.checked) {
+        label.textContent = "por rol";
+        label.classList.add("text-gray-600");
+      } else {
+        label.textContent = "sin acceso";
+        label.classList.add("text-gray-700");
+      }
+    });
+  });
+}
+</script>
 {% endblock %}

--- a/backoffice/templates/users.html
+++ b/backoffice/templates/users.html
@@ -17,7 +17,7 @@
       <tr class="border-b border-gray-800 text-gray-400 text-xs uppercase tracking-wider">
         <th class="px-4 py-3 text-left">Usuario</th>
         <th class="px-4 py-3 text-left">Rol</th>
-        <th class="px-4 py-3 text-left">Relación</th>
+        <th class="px-4 py-3 text-left">Agentes</th>
         <th class="px-4 py-3 text-left">WhatsApp</th>
         <th class="px-4 py-3 text-center">Speaker</th>
         <th class="px-4 py-3 text-right">Acciones</th>
@@ -25,6 +25,11 @@
     </thead>
     <tbody class="divide-y divide-gray-800">
       {% for uid, u in users.items() %}
+      {# Calcular acceso efectivo a cada agente #}
+      {% set role_grants = role_perms.get(u.role, []) %}
+      {% set has_all = "*" in role_grants %}
+      {% set user_grants = u.get("agent_ids", []) %}
+      {% set user_revokes = u.get("revoked_agents", []) %}
       <tr id="user-row-{{ uid }}" class="hover:bg-gray-800/50">
         <td class="px-4 py-3">
           <div class="font-medium">{{ u.name }}</div>
@@ -35,13 +40,38 @@
           <span class="px-2 py-0.5 bg-purple-900/50 text-purple-400 rounded text-xs">{{ u.role }}</span>
           {% elif u.role == "familiar" %}
           <span class="px-2 py-0.5 bg-blue-900/50 text-blue-400 rounded text-xs">{{ u.role }}</span>
+          {% elif u.role == "adolescente" %}
+          <span class="px-2 py-0.5 bg-cyan-900/50 text-cyan-400 rounded text-xs">{{ u.role }}</span>
           {% elif u.role == "niño" %}
           <span class="px-2 py-0.5 bg-green-900/50 text-green-400 rounded text-xs">{{ u.role }}</span>
           {% else %}
           <span class="px-2 py-0.5 bg-gray-800 text-gray-400 rounded text-xs">{{ u.role }}</span>
           {% endif %}
         </td>
-        <td class="px-4 py-3 text-gray-300">{{ u.relationship }}</td>
+        <td class="px-4 py-3">
+          <div class="flex flex-wrap gap-1">
+            {% for aid, info in agents.items() %}
+              {% set from_role = has_all or aid in role_grants %}
+              {% set explicitly_granted = aid in user_grants %}
+              {% set explicitly_revoked = aid in user_revokes %}
+              {% set can_access = (from_role and not explicitly_revoked) or explicitly_granted %}
+              {% if can_access %}
+                {% if explicitly_granted %}
+                <span class="px-1.5 py-0.5 bg-emerald-900/40 text-emerald-400 border border-emerald-800/50 rounded text-xs"
+                      title="{{ info.name }} — otorgado individualmente">{{ info.icon }}</span>
+                {% else %}
+                <span class="px-1.5 py-0.5 bg-gray-800/60 text-gray-300 rounded text-xs"
+                      title="{{ info.name }}">{{ info.icon }}</span>
+                {% endif %}
+              {% else %}
+                {% if explicitly_revoked %}
+                <span class="px-1.5 py-0.5 bg-red-900/30 text-red-600 border border-red-900/50 rounded text-xs line-through"
+                      title="{{ info.name }} — revocado individualmente">{{ info.icon }}</span>
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          </div>
+        </td>
         <td class="px-4 py-3 font-mono text-xs text-gray-400">
           {{ u.wa_phone if u.wa_phone else "—" }}
         </td>
@@ -72,6 +102,13 @@
     </tbody>
   </table>
 </div>
+
+<div class="mt-3 flex gap-4 text-xs text-gray-600">
+  <span><span class="text-gray-300">🔲</span> acceso por rol</span>
+  <span><span class="text-emerald-400">🟩</span> otorgado individualmente</span>
+  <span><span class="text-red-600 line-through">🔴</span> revocado individualmente</span>
+</div>
+
 {% else %}
 <div class="text-center py-16 text-gray-600">
   <p class="text-4xl mb-3">👥</p>


### PR DESCRIPTION
## Summary
- Tabla `/users` muestra acceso efectivo de cada usuario (iconos por agente con estado visual)
- Formulario create/edit agrega sección de checkboxes por agente con labels reactivos:
  - "por rol" — el rol lo concede por defecto
  - "+ otorgado" — override individual (grant)
  - "— revocado" — override individual (revocación)
  - "sin acceso" — ni el rol ni un grant lo otorgan
- Al cambiar de rol, los checkboxes se actualizan via JS con los defaults del nuevo rol
- El backoffice computa los overrides mínimos (`agent_ids`, `revoked_agents`) y los envía al core
- Nuevo rol `adolescente` aparece en el select

## Requiere
PR core #32 ya mergeado (rbac overrides + endpoint `/rbac/roles`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)