### PR TITLE
feat: fase 14.6-14.8 — edición de agentes desde el backoffice

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -205,8 +205,71 @@ def agents_page(request: Request):
 
 @app.post("/agents/{agent_id}/toggle", response_class=HTMLResponse)
 async def toggle_agent(agent_id: str):
-    # Stub: toggle requiere endpoint en core (tarea futura)
-    return HTMLResponse(f'<span class="text-yellow-400 text-xs">toggle pendiente</span>')
+    info = _core(f"/agents/{agent_id}") or {}
+    current = info.get("status", "planned")
+    new_status = "planned" if current == "active" else "active"
+    _core(f"/agents/{agent_id}/status", method="PATCH", json={"status": new_status})
+
+    if new_status == "active":
+        css = "bg-emerald-900/50 text-emerald-400 hover:bg-emerald-900"
+    else:
+        css = "bg-gray-800 text-gray-500 hover:bg-gray-700"
+
+    return HTMLResponse(
+        f'<button hx-post="/agents/{agent_id}/toggle" '
+        f'hx-target="#status-cell-{agent_id}" hx-swap="innerHTML" '
+        f'title="Click para cambiar estado" '
+        f'class="cursor-pointer px-2 py-1 rounded text-xs font-medium transition-colors {css}">'
+        f'{new_status}</button>'
+    )
+
+
+@app.get("/agents/{agent_id}/edit", response_class=HTMLResponse)
+def agent_edit_page(request: Request, agent_id: str):
+    agent = _core(f"/agents/{agent_id}")
+    if not agent:
+        return RedirectResponse("/agents", status_code=303)
+    return _render(request, "agent_edit.html", "agents",
+                   agent=agent, agent_id=agent_id, error="")
+
+
+@app.post("/agents/{agent_id}/edit")
+async def agent_edit_submit(request: Request, agent_id: str):
+    form = await request.form()
+
+    # Status
+    status = str(form.get("status", "")).strip()
+    if status:
+        _core(f"/agents/{agent_id}/status", method="PATCH", json={"status": status})
+
+    # Keywords: una por línea
+    kw_raw = str(form.get("keywords", ""))
+    keywords = [k.strip() for k in kw_raw.splitlines() if k.strip()]
+    _core(f"/agents/{agent_id}/keywords", method="PATCH", json={"keywords": keywords})
+
+    # Config: campos dinámicos según config_schema del agente
+    agent_info = _core(f"/agents/{agent_id}") or {}
+    schema = agent_info.get("config_schema") or {}
+    config: dict = {}
+    for key, meta in schema.items():
+        raw_val = form.get(f"config_{key}")
+        if raw_val is None:
+            continue
+        val_str = str(raw_val).strip()
+        t = meta.get("type", "str")
+        try:
+            if t == "float":
+                config[key] = float(val_str)
+            elif t == "int":
+                config[key] = int(val_str)
+            else:
+                config[key] = val_str
+        except (ValueError, TypeError):
+            config[key] = val_str
+    if config:
+        _core(f"/agents/{agent_id}/config", method="PATCH", json=config)
+
+    return RedirectResponse("/agents", status_code=303)
 
 
 @app.get("/shared-state", response_class=HTMLResponse)

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+{% block title %}Editar agente {{ agent_id }}{% endblock %}
+
+{% block content %}
+<div class="flex items-center gap-3 mb-6">
+  <a href="/agents" class="text-gray-500 hover:text-gray-300 text-sm">← Agentes</a>
+  <span class="text-gray-700">/</span>
+  <h1 class="text-2xl font-bold">
+    {{ agent.icon }} {{ agent.name }}
+    <span class="text-gray-500 text-base font-normal ml-1">{{ agent_id }}</span>
+  </h1>
+</div>
+
+{% if error %}
+<div class="mb-4 bg-red-900/30 border border-red-700 text-red-300 px-4 py-3 rounded-lg text-sm">
+  {{ error }}
+</div>
+{% endif %}
+
+<form method="POST" action="/agents/{{ agent_id }}/edit">
+
+  <!-- Sección 1: Status -->
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
+    <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Estado</h2>
+    <div class="flex gap-4">
+      {% for st, label, desc in [
+          ('active',      'Activo',       'Responde comandos y aparece en el dispatcher'),
+          ('planned',     'Planificado',  'No responde comandos; visible como próximo agente'),
+          ('unavailable', 'No disponible','Temporalmente fuera de servicio')
+      ] %}
+      <label class="flex-1 cursor-pointer">
+        <input type="radio" name="status" value="{{ st }}"
+               {% if agent.status == st %}checked{% endif %}
+               class="sr-only peer">
+        <div class="border rounded-lg px-4 py-3 transition-colors
+          peer-checked:border-indigo-500 peer-checked:bg-indigo-900/20
+          border-gray-700 hover:border-gray-500 bg-gray-800/50">
+          <div class="font-medium text-sm
+            {% if st == 'active' %}text-emerald-400
+            {% elif st == 'planned' %}text-gray-400
+            {% else %}text-red-400{% endif %}">{{ label }}</div>
+          <div class="text-xs text-gray-500 mt-0.5">{{ desc }}</div>
+        </div>
+      </label>
+      {% endfor %}
+    </div>
+    {% if agent.reachable is not none %}
+    <p class="mt-3 text-xs text-gray-600">
+      Conectividad:
+      {% if agent.reachable %}
+        <span class="text-emerald-400">● accesible</span>
+      {% else %}
+        <span class="text-red-400">● no accesible</span>
+        — revisar la URL del servicio asociado
+      {% endif %}
+    </p>
+    {% endif %}
+  </div>
+
+  <!-- Sección 2: Keywords -->
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
+    <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-1">Keywords del dispatcher</h2>
+    <p class="text-xs text-gray-600 mb-3">Una keyword por línea. El dispatcher usa estas palabras para enrutar comandos a este agente.</p>
+    <textarea
+      name="keywords"
+      rows="10"
+      class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 font-mono
+             focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 resize-y"
+      placeholder="una keyword por línea">{{ (agent.keywords or []) | join('\n') }}</textarea>
+    <p class="mt-1 text-xs text-gray-600">
+      {{ (agent.keywords or []) | length }} keywords actuales.
+      Los cambios de keywords aplican al reiniciar el core.
+    </p>
+  </div>
+
+  <!-- Sección 3: Configuración específica -->
+  {% if agent.config_schema %}
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
+    <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-1">Configuración</h2>
+    <p class="text-xs text-gray-600 mb-4">Los cambios de configuración aplican al reiniciar el core.</p>
+    <div class="grid grid-cols-1 gap-4">
+      {% for key, meta in agent.config_schema.items() %}
+      {% set cur_val = agent.config.get(key, meta.default) %}
+      <div>
+        <label class="block text-xs font-medium text-gray-400 mb-1">
+          {{ meta.label }}
+          <span class="text-gray-600 font-normal ml-1">({{ key }})</span>
+        </label>
+        {% if meta.type == 'int' or meta.type == 'float' %}
+        <input
+          type="number"
+          name="config_{{ key }}"
+          value="{{ cur_val }}"
+          {% if meta.type == 'float' %}step="any"{% endif %}
+          class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
+                 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
+        {% else %}
+        <input
+          type="text"
+          name="config_{{ key }}"
+          value="{{ cur_val }}"
+          class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
+                 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
+        {% endif %}
+        <p class="mt-0.5 text-xs text-gray-600">Default: <code class="bg-gray-800 px-1 rounded">{{ meta.default }}</code></p>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="flex gap-3">
+    <button type="submit"
+            class="px-5 py-2 bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium rounded-lg transition-colors">
+      Guardar cambios
+    </button>
+    <a href="/agents"
+       class="px-5 py-2 bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm font-medium rounded-lg transition-colors">
+      Cancelar
+    </a>
+  </div>
+
+</form>
+{% endblock %}

--- a/backoffice/templates/agents.html
+++ b/backoffice/templates/agents.html
@@ -2,7 +2,12 @@
 {% block title %}Agentes{% endblock %}
 
 {% block content %}
-<h1 class="text-2xl font-bold mb-6">Agentes</h1>
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Agentes</h1>
+  <div id="restart-banner" class="hidden bg-yellow-900/30 border border-yellow-700 text-yellow-300 text-xs px-3 py-2 rounded-lg">
+    ⚠️ Hay cambios de config/keywords pendientes — reiniciar el core para aplicar.
+  </div>
+</div>
 
 <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
   <table class="w-full text-sm">
@@ -12,6 +17,8 @@
         <th class="px-4 py-3 text-left">Descripción</th>
         <th class="px-4 py-3 text-left">Keywords</th>
         <th class="px-4 py-3 text-center">Estado</th>
+        <th class="px-4 py-3 text-center">Accesible</th>
+        <th class="px-4 py-3 text-center">Editar</th>
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-800">
@@ -37,18 +44,50 @@
             {% endif %}
           </div>
         </td>
+        <td class="px-4 py-3 text-center" id="status-cell-{{ aid }}">
+          {% set st = info.status %}
+          <button
+            hx-post="/agents/{{ aid }}/toggle"
+            hx-target="#status-cell-{{ aid }}"
+            hx-swap="innerHTML"
+            title="Click para cambiar estado"
+            class="cursor-pointer px-2 py-1 rounded text-xs font-medium transition-colors
+              {% if st == 'active' %}bg-emerald-900/50 text-emerald-400 hover:bg-emerald-900{% elif st == 'planned' %}bg-gray-800 text-gray-500 hover:bg-gray-700{% else %}bg-red-900/50 text-red-400 hover:bg-red-900{% endif %}">
+            {{ st }}
+          </button>
+        </td>
         <td class="px-4 py-3 text-center">
-          {% if info.status == "active" %}
-          <span class="px-2 py-1 bg-emerald-900/50 text-emerald-400 rounded text-xs font-medium">activo</span>
-          {% elif info.status == "planned" %}
-          <span class="px-2 py-1 bg-gray-800 text-gray-500 rounded text-xs font-medium">planificado</span>
+          {% if info.reachable is none %}
+            <span class="text-gray-600 text-xs">—</span>
+          {% elif info.reachable %}
+            <span title="Accesible" class="text-emerald-400">●</span>
           {% else %}
-          <span class="px-2 py-1 bg-red-900/50 text-red-400 rounded text-xs font-medium">{{ info.status }}</span>
+            <span title="No accesible" class="text-red-400">●</span>
           {% endif %}
+        </td>
+        <td class="px-4 py-3 text-center">
+          <a href="/agents/{{ aid }}/edit"
+             class="px-2 py-1 bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white rounded text-xs transition-colors">
+            Editar
+          </a>
         </td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
+
+<script>
+  // Mostrar banner de restart cuando haya cambios de keywords/config
+  document.addEventListener('htmx:afterRequest', function(e) {
+    if (e.detail.pathInfo && e.detail.pathInfo.requestPath &&
+        e.detail.pathInfo.requestPath.includes('/toggle')) {
+      document.getElementById('restart-banner').classList.add('hidden');
+    }
+  });
+
+  function showRestartBanner() {
+    document.getElementById('restart-banner').classList.remove('hidden');
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- **14.6** `agents.html` — toggle HTMX real por fila, columna Accesible (●/—), columna Editar
- **14.7** `agent_edit.html` (nuevo) — form con 3 secciones: status (radio + indicador conectividad), keywords (textarea una por línea), config dinámica (campos según config_schema con tipos)
- **14.8** `backoffice/server.py` — toggle real via PATCH al core; rutas GET/POST `/agents/{id}/edit` con conversión de tipos para config

## Test plan

- [ ] Abrir `/agents` → ver columna Accesible y columna Editar
- [ ] Click en badge de status → alterna entre active/planned sin recargar página
- [ ] Click en "Editar" para haos → form con status (3 opciones), keywords (lista), config (model, top_k_entities, max_retries)
- [ ] Cambiar un keyword → guardar → verificar en `/agents` y en `~/.local/share/capitan/agents.json`
- [ ] Cambiar config (ej top_k_entities=8) → guardar → reiniciar core → verificar comportamiento

🤖 Generated with [Claude Code](https://claude.com/claude-code)