### PR TITLE
feat: integraciones — Core API y Ear + accesibilidad agentes dinámicos

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -709,10 +709,10 @@ def logs_stream(service: str = "all"):
 
 @app.get("/integrations", response_class=HTMLResponse)
 def integrations_page(request: Request):
-    health = _core("/health") or {}
-    agents = _core("/agents") or {}
+    health    = _core("/health") or {}
+    core_ok   = health is not None and health.get("status") == "ok"
+    ear_state = _ear_state()
 
-    # Test Ollama models
     ollama_models = []
     try:
         r = requests.get(f"{OLLAMA_URL}/api/tags", timeout=3)
@@ -722,7 +722,11 @@ def integrations_page(request: Request):
         pass
 
     return _render(request, "integrations.html", "integrations",
-                   health=health, agents=agents, ollama_models=ollama_models)
+                   health=health,
+                   core_ok=core_ok,
+                   core_url=CORE_URL,
+                   ear_state=ear_state,
+                   ollama_models=ollama_models)
 
 
 # ── Plan ───────────────────────────────────────────────────────────────────────

--- a/backoffice/templates/integrations.html
+++ b/backoffice/templates/integrations.html
@@ -10,6 +10,28 @@
   <a href="/agents" class="text-blue-500 hover:underline">Agentes</a>.
 </p>
 
+<!-- Core API -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-4">
+  <div class="flex items-center justify-between mb-3">
+    <div>
+      <h2 class="text-sm font-semibold text-gray-300">Core API</h2>
+      <p class="text-xs text-gray-600 mt-0.5">Servidor de agentes — dispatcher + orquestador</p>
+    </div>
+    <span class="text-lg">{{ "🟢" if core_ok else "🔴" }}</span>
+  </div>
+  <div class="text-xs text-gray-500 space-y-1">
+    <div>Estado: <span class="{{ 'text-emerald-400' if core_ok else 'text-red-400' }}">
+      {{ "online" if core_ok else "offline" }}
+    </span></div>
+    <div>URL: <code class="text-gray-400">{{ core_url }}</code></div>
+    {% if core_ok %}
+    <div>Ollama: <span class="{{ 'text-emerald-400' if health.get('ollama') else 'text-red-400' }}">{{ "ok" if health.get('ollama') else "down" }}</span>
+      &nbsp; HAOS: <span class="{{ 'text-emerald-400' if health.get('haos') else 'text-red-400' }}">{{ "ok" if health.get('haos') else "down" }}</span>
+    </div>
+    {% endif %}
+  </div>
+</div>
+
 <!-- Ollama -->
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-4">
   <div class="flex items-center justify-between mb-3">
@@ -27,7 +49,7 @@
   </div>
   {% if ollama_models %}
   <div class="mt-3 pt-3 border-t border-gray-800">
-    <div class="text-xs text-gray-500 mb-2">Modelos cargados:</div>
+    <div class="text-xs text-gray-500 mb-2">Modelos disponibles:</div>
     <div class="flex flex-wrap gap-1">
       {% for m in ollama_models %}
       <span class="px-2 py-0.5 bg-gray-800 text-gray-300 rounded text-xs font-mono">{{ m }}</span>
@@ -35,6 +57,26 @@
     </div>
   </div>
   {% endif %}
+</div>
+
+<!-- Ear -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-4">
+  {% set ear_ok = ear_state is not none %}
+  <div class="flex items-center justify-between mb-3">
+    <div>
+      <h2 class="text-sm font-semibold text-gray-300">Ear</h2>
+      <p class="text-xs text-gray-600 mt-0.5">Pipeline de voz — wake word → STT → TTS</p>
+    </div>
+    <span class="text-lg">{{ "🟢" if ear_ok else "🔴" }}</span>
+  </div>
+  <div class="text-xs text-gray-500 space-y-1">
+    <div>Estado: <span class="{{ 'text-emerald-400' if ear_ok else 'text-red-400' }}">
+      {% if ear_ok %}{{ ear_state.get("state", "running") }}{% else %}offline{% endif %}
+    </span></div>
+    {% if ear_ok and ear_state.get("device") %}
+    <div>Dispositivo: <code class="text-gray-400">{{ ear_state.get("device") }}</code></div>
+    {% endif %}
+  </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- Página `/integrations` ahora muestra tres servicios: Core API, Ollama, Ear
- Core API: estado online/offline, URL, y sub-estado de Ollama+HAOS (cuando está up)
- Ear: estado del pipeline (listening/recording/etc.) y dispositivo de audio
- Actualiza puntero del submodule `core` con `GenericAgent.is_reachable()` + ajuste de `_agent_reachable`

## Test plan
- [ ] Abrir `/integrations` con todos los servicios activos → 3 tarjetas en 🟢
- [ ] Apagar core → Core API en 🔴, Ollama refleja estado previo (datos cacheados del último `/health`)
- [ ] Apagar ear → Ear en 🔴
- [ ] `GET /agents/<dynamic-id>` muestra `reachable: true/false` según disponibilidad de Ollama y modelo