### PR TITLE
refactor: backoffice chequea Ollama directo, sin depender de /health

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -114,6 +114,13 @@ def _core(path: str, method: str = "GET", **kwargs):
         return None
 
 
+def _ollama_ok() -> bool:
+    try:
+        return requests.get(f"{OLLAMA_URL}/api/tags", timeout=2).status_code == 200
+    except Exception:
+        return False
+
+
 def _get_ollama_models() -> list[str]:
     """Devuelve los nombres de modelos disponibles en Ollama."""
     try:
@@ -145,9 +152,8 @@ def _render(request: Request, template: str, section: str, **ctx):
 
 @app.get("/api/status", response_class=HTMLResponse)
 def api_status():
-    health   = _core("/health") or {}
-    ollama_ok = health.get("ollama", False)
-    core_ok   = health is not None
+    core_ok   = _core("/health") is not None
+    ollama_ok = _ollama_ok()
     ear_state = _ear_state()
     ear_ok    = ear_state is not None and ear_state.get("state") != "stopped"
 
@@ -186,10 +192,11 @@ def _ear_state() -> dict | None:
 
 @app.get("/dashboard", response_class=HTMLResponse)
 def dashboard(request: Request):
-    health  = _core("/health") or {}
-    history = _read_json("history.json") or []
-    alerts  = _core("/alerts") or []
-    state   = _ear_state()
+    core_ok   = _core("/health") is not None
+    ollama_ok = _ollama_ok()
+    history   = _read_json("history.json") or []
+    alerts    = _core("/alerts") or []
+    state     = _ear_state()
 
     # Latencias promedio de la sesión
     lats = {"stt": [], "llm": [], "total": []}
@@ -203,7 +210,8 @@ def dashboard(request: Request):
     speaker = _read_json("speaker.json") or {}
 
     return _render(request, "dashboard.html", "dashboard",
-                   health=health, history=history[-10:],
+                   core_ok=core_ok, ollama_ok=ollama_ok,
+                   history=history[-10:],
                    alerts=alerts, state=state, speaker=speaker,
                    avg_lat=avg, history_count=len(history))
 
@@ -709,24 +717,17 @@ def logs_stream(service: str = "all"):
 
 @app.get("/integrations", response_class=HTMLResponse)
 def integrations_page(request: Request):
-    health    = _core("/health") or {}
-    core_ok   = health is not None and health.get("status") == "ok"
-    ear_state = _ear_state()
-
-    ollama_models = []
-    try:
-        r = requests.get(f"{OLLAMA_URL}/api/tags", timeout=3)
-        if r.status_code == 200:
-            ollama_models = [m["name"] for m in r.json().get("models", [])]
-    except Exception:
-        pass
+    core_ok       = _core("/health") is not None
+    ollama_models = _get_ollama_models()
+    ollama_ok     = bool(ollama_models) or _ollama_ok()
+    ear_state     = _ear_state()
 
     return _render(request, "integrations.html", "integrations",
-                   health=health,
                    core_ok=core_ok,
                    core_url=CORE_URL,
-                   ear_state=ear_state,
-                   ollama_models=ollama_models)
+                   ollama_ok=ollama_ok,
+                   ollama_models=ollama_models,
+                   ear_state=ear_state)
 
 
 # ── Plan ───────────────────────────────────────────────────────────────────────

--- a/backoffice/templates/dashboard.html
+++ b/backoffice/templates/dashboard.html
@@ -8,7 +8,6 @@
 <div class="grid grid-cols-3 gap-4 mb-6">
 
   <!-- Core API -->
-  {% set core_ok = health.get("status") == "ok" %}
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
     <div class="flex items-center justify-between mb-1">
       <span class="text-sm font-medium text-gray-300">Core API</span>
@@ -21,7 +20,6 @@
   </div>
 
   <!-- Ollama -->
-  {% set ollama_ok = health.get("ollama", false) %}
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
     <div class="flex items-center justify-between mb-1">
       <span class="text-sm font-medium text-gray-300">Ollama</span>

--- a/backoffice/templates/integrations.html
+++ b/backoffice/templates/integrations.html
@@ -24,11 +24,6 @@
       {{ "online" if core_ok else "offline" }}
     </span></div>
     <div>URL: <code class="text-gray-400">{{ core_url }}</code></div>
-    {% if core_ok %}
-    <div>Ollama: <span class="{{ 'text-emerald-400' if health.get('ollama') else 'text-red-400' }}">{{ "ok" if health.get('ollama') else "down" }}</span>
-      &nbsp; HAOS: <span class="{{ 'text-emerald-400' if health.get('haos') else 'text-red-400' }}">{{ "ok" if health.get('haos') else "down" }}</span>
-    </div>
-    {% endif %}
   </div>
 </div>
 
@@ -39,11 +34,11 @@
       <h2 class="text-sm font-semibold text-gray-300">Ollama</h2>
       <p class="text-xs text-gray-600 mt-0.5">Motor de inferencia local — LLM para todos los agentes</p>
     </div>
-    <span class="text-lg">{{ "🟢" if health.get("ollama") else "🔴" }}</span>
+    <span class="text-lg">{{ "🟢" if ollama_ok else "🔴" }}</span>
   </div>
   <div class="text-xs text-gray-500 space-y-1">
-    <div>Estado: <span class="{{ 'text-emerald-400' if health.get('ollama') else 'text-red-400' }}">
-      {{ "online" if health.get("ollama") else "offline" }}
+    <div>Estado: <span class="{{ 'text-emerald-400' if ollama_ok else 'text-red-400' }}">
+      {{ "online" if ollama_ok else "offline" }}
     </span></div>
     <div>URL: <code class="text-gray-400">localhost:11434</code></div>
   </div>


### PR DESCRIPTION
## Summary
- `_ollama_ok()`: helper directo al `/api/tags` de Ollama, independiente del core
- `api_status()`, `dashboard()`, `integrations_page()`: usan `_ollama_ok()` en lugar de `health.get("ollama")`
- Dashboard y integraciones reciben `core_ok`/`ollama_ok` en lugar del dict `health`
- Card Core API en integraciones: muestra solo online/offline, sin sub-estado de dependencias
- Actualiza puntero de `core` (simplificación de `/health`)