### PR TITLE
feat: card de agentes activos en la home del dashboard

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -104,10 +104,10 @@ app.add_middleware(AuthMiddleware)
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
-def _core(path: str, method: str = "GET", **kwargs):
+def _core(path: str, method: str = "GET", timeout: int = 3, **kwargs):
     """Llama al core con timeout corto; devuelve None si falla."""
     try:
-        r = requests.request(method, f"{CORE_URL}{path}", timeout=3, **kwargs)
+        r = requests.request(method, f"{CORE_URL}{path}", timeout=timeout, **kwargs)
         r.raise_for_status()
         return r.json()
     except Exception:
@@ -208,12 +208,15 @@ def dashboard(request: Request):
     avg = {k: round(sum(v)/len(v), 2) if v else None for k, v in lats.items()}
 
     speaker = _read_json("speaker.json") or {}
+    agents_data = _core("/agents", timeout=10) or {}
+    active_agents = {k: v for k, v in agents_data.items() if v.get("status") == "active"}
 
     return _render(request, "dashboard.html", "dashboard",
                    core_ok=core_ok, ollama_ok=ollama_ok,
                    history=history[-10:],
                    alerts=alerts, state=state, speaker=speaker,
-                   avg_lat=avg, history_count=len(history))
+                   avg_lat=avg, history_count=len(history),
+                   active_agents=active_agents)
 
 
 @app.get("/agents", response_class=HTMLResponse)

--- a/backoffice/templates/dashboard.html
+++ b/backoffice/templates/dashboard.html
@@ -88,6 +88,33 @@
   </div>
 </div>
 
+<!-- Agentes activos -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-6">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-semibold text-gray-400">Agentes activos</h2>
+    <a href="/agents" class="text-xs text-gray-600 hover:text-gray-400 transition-colors">ver todos →</a>
+  </div>
+  {% if active_agents %}
+  <div class="flex flex-wrap gap-2">
+    {% for aid, info in active_agents.items() %}
+    <a href="/agents/{{ aid }}/edit"
+       class="flex items-center gap-1.5 bg-gray-800 hover:bg-gray-700 border border-gray-700
+              hover:border-gray-500 rounded-lg px-3 py-1.5 transition-colors group">
+      <span class="text-base leading-none">{{ info.icon or "🤖" }}</span>
+      <span class="text-xs font-medium text-gray-200 group-hover:text-white transition-colors">
+        {{ info.name }}
+      </span>
+      {% if info.reachable == false %}
+      <span class="text-red-500 text-xs" title="No accesible">●</span>
+      {% endif %}
+    </a>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p class="text-sm text-gray-600">Sin agentes activos</p>
+  {% endif %}
+</div>
+
 <!-- Últimos comandos -->
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
   <h2 class="text-sm font-semibold text-gray-400 mb-3">Últimos comandos</h2>

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -339,41 +339,49 @@ Estado:   COMPLETA
 ### FASE 5 - Agente Agenda
 ```
 Objetivo: Gestión de agenda por voz, privada y local
-Estado:   Pendiente
+Estado:   COMPLETA (5.2 postergada, google-free; alarma luces → HAOS nativo)
 ```
-- [ ] 5.1  CalDAV local (Radicale en HAOS o servidor dedicado)
+- [x] 5.1  CalDAV local (Radicale en HAOS o servidor dedicado)
 - [ ] 5.2  Sincronización opcional con Google Calendar
-- [ ] 5.3  Consultas por voz:
+- [x] 5.3  Consultas por voz:
            "¿qué tengo mañana?"
            "agendá reunión el viernes a las 10"
-           "¿cuándo es el próximo feriado?"
-- [ ] 5.4  Integración con domótica:
-           alarma de agenda → encender luces gradualmente
-           reunión en 15min → recordatorio por voz
-- [ ] 5.5  Recordatorios proactivos sin trigger de voz
-- [ ] 5.6  Vista de agenda en panel de HAOS
+           "¿cuándo es el próximo feriado?" — feriados UY via Nager.Date API
+- [x] 5.4  Integración con domótica:
+           alarma de agenda → encender luces gradualmente [postergado → HAOS nativo]
+           reunión en 15min → recordatorio por voz ✓ (thread 1min, reminder_minutes configurable)
+- [x] 5.5  Recordatorios proactivos sin trigger de voz (briefing matutino + resumen vespertino, hora configurable)
+- [x] 5.6  Vista de agenda en panel de HAOS
+           Radicale expuesto en LAN (0.0.0.0:5232); integración CalDAV en HA via config flow API;
+           entidades: calendar.personal + calendar.feriados; tarjeta Calendar en el dashboard de HA
 
 ---
 
 ### FASE 6 - Agente Inversiones
 ```
 Objetivo: Consultas financieras por voz, datos privados locales
-Estado:   Pendiente
-Nota:     Datos sensibles, nunca salen de la red local
+Estado:   EN CURSO (6/7 — solo queda 6.6)
+Nota:     Modo dummy (recomendaciones + P&L hipotética). Portfolio por usuario (FASE 2.5).
+          Fuentes: yfinance (acciones/crypto/FX) + dolarapi.com (dólar oficial/blue/MEP/CCL).
 ```
-- [ ] 6.1  Definir fuentes de datos:
-           Yahoo Finance (acciones internacionales)
-           BCRA API (dólar, tasas Argentina)
-           Ambito/Infobae scraping (mercado local)
-- [ ] 6.2  Scraper/poller de cotizaciones (actualización periódica)
-- [ ] 6.3  Portfolio local (tus activos, cifras, completamente privado)
-- [ ] 6.4  Consultas por voz:
-           "¿cómo está el dólar?"
-           "¿cómo va mi portfolio hoy?"
-           "¿cuánto subió GGAL esta semana?"
-- [ ] 6.5  Alertas configurables (precio objetivo, variación %)
+- [x] 6.1  Definir fuentes de datos:
+           yfinance (acciones internacionales, crypto, pares FX)
+           dolarapi.com (dólar oficial/blue/MEP/CCL/tarjeta)
+           yfinance UYU=X (peso uruguayo)
+- [x] 6.2  Cliente de cotizaciones con cache (finance_client.py):
+           get_quote(), get_history(), get_price_at_date(), get_dollar_rates(), get_uyu_rate()
+           Cache 10min por símbolo, 15min para dólar
+- [x] 6.3  Portfolio por usuario en modo dummy (portfolio.py):
+           Watchlist por usuario, registro de recomendaciones (buy/sell/hold/watch),
+           P&L hipotética calculada con precio actual, persistencia ~/.local/share/capitan/
+- [x] 6.4  Consultas por voz (finance_agent.py):
+           "¿cómo está el dólar?" "¿cuánto vale GGAL?" "¿qué me recomendás?"
+           "¿cómo fueron tus recomendaciones?" — etiqueta [REC:accion:TICKER] registra automáticamente
+- [x] 6.5  Alertas configurables (finance_alerts.py):
+           Brecha blue/oficial > 10%, BTC ±5%, watchlist ±5%. Umbrales via .env.
 - [ ] 6.6  RAG sobre noticias financieras (scraping + embeddings)
-- [ ] 6.7  Resumen diario automático al llegar a casa
+- [x] 6.7  Resumen diario automático (en finance_alerts.check()):
+           Dólar oficial/blue, UYU, movimientos de watchlist. Emite a FINANCE_BRIEFING_HOUR (8am).
 
 ---
 


### PR DESCRIPTION
## Summary
- `backoffice/templates/dashboard.html`: nueva card "Agentes activos" entre latencias y últimos comandos
- Pills clickeables por agente (icon + nombre), linkeados a la página de edición
- `backoffice/server.py`: fetcha `/agents` con timeout 10s en el dashboard (el endpoint verifica `availability_url` de cada agente, es más lento que las otras rutas)
- `_core()` acepta parámetro `timeout` opcional (default 3s, sin cambio para el resto)
- `FinanceAgent` ya registrado aparece automáticamente en la card

## Test plan
- [x] Card aparece en el HTML del dashboard con los 6 agentes activos
- [x] Pills con icon y nombre correctos