### PR TITLE
fix: /agents — timeout 15s + banner de error cuando core no responde

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -221,8 +221,9 @@ def dashboard(request: Request):
 
 @app.get("/agents", response_class=HTMLResponse)
 def agents_page(request: Request):
-    data = _core("/agents") or {}
-    return _render(request, "agents.html", "agents", agents=data)
+    data = _core("/agents", timeout=15)
+    core_ok = data is not None
+    return _render(request, "agents.html", "agents", agents=data or {}, core_ok=core_ok)
 
 
 @app.get("/agents/{agent_id}/detail", response_class=HTMLResponse)

--- a/backoffice/templates/agents.html
+++ b/backoffice/templates/agents.html
@@ -15,6 +15,14 @@
   </div>
 </div>
 
+{% if not core_ok %}
+<div class="mb-4 bg-red-900/30 border border-red-700 text-red-300 text-sm px-4 py-3 rounded-xl flex items-center gap-2">
+  <span>⚠️</span>
+  <span>No se pudo conectar al core (<code>localhost:8765</code>). Los agentes no están disponibles.</span>
+  <a href="/agents" class="ml-auto text-xs underline hover:text-red-200">Reintentar</a>
+</div>
+{% endif %}
+
 <div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
   <table class="w-full text-sm">
     <thead>


### PR DESCRIPTION
## Summary
- `backoffice/server.py`: timeout de 3s → 15s para `_core("/agents")` (el endpoint hace reachability checks que podían superar 3s)
- `backoffice/agents.html`: banner de error visible cuando `core_ok=False`, en lugar de tabla vacía silenciosa
- `core` submodule: apunta al merge de #71 (reachability en paralelo — de N×1.5s a 1.5s)

## Test plan
- [ ] Abrir `/agents` con el core corriendo — carga correctamente
- [ ] Detener el core, abrir `/agents` — muestra banner rojo "No se pudo conectar al core" con botón Reintentar

🤖 Generated with [Claude Code](https://claude.com/claude-code)