### PR TITLE
feat: fase 2.6.8 — sección reconocimiento de voz en backoffice

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -546,8 +546,12 @@ def edit_user_page(request: Request, uid: str):
     if not user:
         return RedirectResponse("/users", status_code=303)
     agents, role_perms = _load_rbac_context()
+    ww_samples = _core(f"/users/{uid}/wakeword/samples") or {"count": 0, "required": 30, "samples": []}
+    ww_metrics = _core(f"/users/{uid}/wakeword/metrics") or {"tp": 0, "fp": 0, "rbac_deny": 0}
+    train_status = _core("/wakeword/train/status") or {"status": "idle"}
     return _render(request, "user_form.html", "users",
-                   user=user, uid=uid, error="", agents=agents, role_perms=role_perms)
+                   user=user, uid=uid, error="", agents=agents, role_perms=role_perms,
+                   ww_samples=ww_samples, ww_metrics=ww_metrics, train_status=train_status)
 
 
 @app.post("/users/{uid}/update")
@@ -568,10 +572,14 @@ async def update_user_submit(request: Request, uid: str):
     }
     result = _core(f"/users/{uid}", method="PATCH", json=payload)
     if result is None:
+        ww_samples   = _core(f"/users/{uid}/wakeword/samples") or {"count": 0, "required": 30, "samples": []}
+        ww_metrics   = _core(f"/users/{uid}/wakeword/metrics") or {"tp": 0, "fp": 0, "rbac_deny": 0}
+        train_status = _core("/wakeword/train/status") or {"status": "idle"}
         return _render(request, "user_form.html", "users",
                        user={**payload, "id": uid}, uid=uid,
                        error="No se pudo actualizar el usuario",
-                       agents=agents, role_perms=role_perms)
+                       agents=agents, role_perms=role_perms,
+                       ww_samples=ww_samples, ww_metrics=ww_metrics, train_status=train_status)
     return RedirectResponse("/users", status_code=303)
 
 
@@ -579,6 +587,47 @@ async def update_user_submit(request: Request, uid: str):
 def delete_user_htmx(uid: str):
     _core(f"/users/{uid}", method="DELETE")
     return HTMLResponse("")
+
+
+_POLLING_SPAN = (
+    '<span class="text-blue-400 text-xs animate-pulse"'
+    ' hx-get="/wakeword/train/status"'
+    ' hx-trigger="every 3s"'
+    ' hx-target="#train-status"'
+    ' hx-swap="innerHTML">⟳ Entrenando…</span>'
+)
+
+
+@app.post("/wakeword/train/start", response_class=HTMLResponse)
+def start_wakeword_train():
+    """Proxy para lanzar reentrenamiento desde el backoffice (HTMX)."""
+    result = _core("/wakeword/train", method="POST") or {}
+    status = result.get("status", "error")
+    if status == "started":
+        return HTMLResponse(_POLLING_SPAN)
+    elif status == "conflict":
+        return HTMLResponse('<span class="text-orange-400 text-xs">Ya hay un entrenamiento en curso</span>')
+    return HTMLResponse('<span class="text-red-400 text-xs">Error al iniciar entrenamiento</span>')
+
+
+@app.get("/wakeword/train/status", response_class=HTMLResponse)
+def wakeword_train_status_fragment():
+    """Fragmento HTMX (innerHTML de #train-status) con el estado actual del entrenamiento."""
+    result = _core("/wakeword/train/status") or {"status": "idle"}
+    status = result.get("status", "idle")
+    if status == "running":
+        return HTMLResponse(_POLLING_SPAN)
+    elif status == "done":
+        n_pos = result.get("n_positive", "?")
+        n_real = result.get("n_positive_real", 0)
+        dur = result.get("duration_s", "?")
+        return HTMLResponse(
+            f'<span class="text-emerald-400 text-xs">✓ Listo — {n_pos} positivos ({n_real} reales), {dur}s</span>'
+        )
+    elif status == "error":
+        err = result.get("error", "desconocido")
+        return HTMLResponse(f'<span class="text-red-400 text-xs">✗ Error: {err[:60]}</span>')
+    return HTMLResponse('<span class="text-gray-600 text-xs">Sin entrenamientos recientes</span>')
 
 
 # ── RBAC roles ─────────────────────────────────────────────────────────────────

--- a/backoffice/templates/user_form.html
+++ b/backoffice/templates/user_form.html
@@ -145,6 +145,115 @@
   </form>
 </div>
 
+{% if uid %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-6 max-w-lg mt-6">
+  <h2 class="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-4">
+    Reconocimiento de voz
+  </h2>
+
+  {# ── Estado onboarding ─────────────────────────────────────────────────────── #}
+  {% set step = user.onboarding_step if user and user.onboarding_step else "completo" %}
+  <div class="flex items-center gap-3 mb-4">
+    <span class="text-sm text-gray-400">Onboarding:</span>
+    {% if step == "completo" %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-emerald-900/50 text-emerald-400 border border-emerald-700/50">completo</span>
+    {% elif step == "frases_speaker_id" %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-yellow-900/50 text-yellow-400 border border-yellow-700/50">frases de identificación</span>
+    {% elif step == "muestras_wake_word" %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-blue-900/50 text-blue-400 border border-blue-700/50">muestras de wake word</span>
+    {% else %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-yellow-900/50 text-yellow-400 border border-yellow-700/50">{{ step }}</span>
+    {% endif %}
+  </div>
+
+  {# ── Métricas ──────────────────────────────────────────────────────────────── #}
+  {% set tp = ww_metrics.tp | default(0) | int %}
+  {% set fp = ww_metrics.fp | default(0) | int %}
+  {% set ww_total = tp + fp %}
+  {% set count = ww_samples.count | default(0) | int %}
+  {% set required = ww_samples.required | default(30) | int %}
+
+  <div class="grid grid-cols-3 gap-3 mb-4">
+    <div class="bg-gray-800/50 border border-gray-700/50 rounded-lg px-3 py-2 text-center">
+      <div class="text-xs text-gray-500 mb-1">Muestras</div>
+      <div class="text-lg font-bold {{ 'text-emerald-400' if count >= required else 'text-yellow-400' }}">{{ count }}</div>
+      <div class="text-xs text-gray-600">/ {{ required }}</div>
+    </div>
+    <div class="bg-gray-800/50 border border-gray-700/50 rounded-lg px-3 py-2 text-center">
+      <div class="text-xs text-gray-500 mb-1">Precisión</div>
+      {% if ww_total > 0 %}
+        {% set precision = ((tp / ww_total * 100) | round(1)) %}
+        <div class="text-lg font-bold
+          {{ 'text-emerald-400' if precision >= 85 else ('text-yellow-400' if precision >= 70 else 'text-red-400') }}">
+          {{ precision }}%
+        </div>
+        <div class="text-xs text-gray-600">TP={{ tp }} FP={{ fp }}</div>
+      {% else %}
+        <div class="text-lg font-bold text-gray-600">—</div>
+        <div class="text-xs text-gray-600">sin datos</div>
+      {% endif %}
+    </div>
+    <div class="bg-gray-800/50 border border-gray-700/50 rounded-lg px-3 py-2 text-center">
+      <div class="text-xs text-gray-500 mb-1">Última muestra</div>
+      {% if ww_samples.samples %}
+        <div class="text-xs text-gray-300 mt-2 leading-relaxed">
+          {{ ww_samples.samples[-1].timestamp[:10] if ww_samples.samples[-1].timestamp else "—" }}
+        </div>
+      {% else %}
+        <div class="text-lg font-bold text-gray-600">—</div>
+      {% endif %}
+    </div>
+  </div>
+
+  {# ── Sugerencias ───────────────────────────────────────────────────────────── #}
+  {% if count < 20 or (ww_total > 0 and fp > 5 and (tp / ww_total * 100) < 85) %}
+  <div class="mb-4 space-y-1.5">
+    {% if count < 20 %}
+    <div class="flex items-start gap-2 text-xs text-yellow-300">
+      <span class="shrink-0 mt-0.5">⚠</span>
+      <span>Pocas muestras de wake word ({{ count }}/{{ required }} — se recomiendan al menos 20).</span>
+    </div>
+    {% endif %}
+    {% if ww_total > 0 and fp > 5 and (tp / ww_total * 100) < 85 %}
+    <div class="flex items-start gap-2 text-xs text-yellow-300">
+      <span class="shrink-0 mt-0.5">⚠</span>
+      <span>Precisión baja — el modelo activa con voces que no son la tuya. Reentrenar puede ayudar.</span>
+    </div>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# ── Entrenamiento del modelo ──────────────────────────────────────────────── #}
+  <div class="flex items-center gap-3 pt-1">
+    <button
+      hx-post="/wakeword/train/start"
+      hx-target="#train-status"
+      hx-swap="innerHTML"
+      {% if train_status.status == "running" %}disabled{% endif %}
+      class="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50
+             disabled:cursor-not-allowed text-white rounded-lg text-xs font-medium
+             transition-colors">
+      Entrenar modelo
+    </button>
+    <div id="train-status">
+      {% if train_status.status == "running" %}
+        <span class="text-xs text-blue-400 animate-pulse"
+              hx-get="/wakeword/train/status"
+              hx-trigger="every 3s"
+              hx-target="#train-status"
+              hx-swap="innerHTML">⟳ Entrenando…</span>
+      {% elif train_status.status == "done" %}
+        <span class="text-xs text-emerald-400">✓ Modelo entrenado ({{ train_status.duration_s }}s — {{ train_status.n_positive }} positivos)</span>
+      {% elif train_status.status == "error" %}
+        <span class="text-xs text-red-400">✗ Error: {{ train_status.error | default("desconocido") }}</span>
+      {% else %}
+        <span class="text-xs text-gray-600">Modelo sin entrenar recientemente</span>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <script>
 // Permisos por rol (inyectados desde el servidor)
 const ROLE_PERMS = {{ role_perms | tojson }};


### PR DESCRIPTION
## Summary

- **user_form.html**: nuevo card «Reconocimiento de voz» visible solo al editar usuario existente
  - Badge de onboarding step (completo / frases de identificación / muestras de wake word)
  - 3 métricas: muestras (count/required), precisión TP/FP%, fecha última muestra
  - Sugerencias automáticas: pocas muestras (<20), precisión baja (FP alto)
  - Botón «Entrenar modelo» con polling HTMX self-contained (no recarga página)
- **server.py**: `edit_user_page` carga `ww_samples`, `ww_metrics`, `train_status` del core
  - `POST /wakeword/train/start`: proxy HTMX → lanza training y retorna span con polling
  - `GET /wakeword/train/status`: fragmento innerHTML para `#train-status`
  - Fix: error path en `update_user_submit` también pasa las variables wakeword

## Test plan

- [ ] Abrir `/users/{uid}/edit` de un usuario existente → ver card «Reconocimiento de voz»
- [ ] Verificar badge según `onboarding_step` del usuario
- [ ] Click «Entrenar modelo» → span cambia a «⟳ Entrenando…» y hace polling cada 3s
- [ ] Esperar fin de entrenamiento → span muestra resultado con positivos y duración
- [ ] Crear usuario nuevo (`/users/new`) → card NO aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)