### PR TITLE
feat: fase 9.23-9.27 — intenciones como entidad de primer nivel

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -210,13 +210,15 @@ def dashboard(request: Request):
     speaker = _read_json("speaker.json") or {}
     agents_data = _core("/agents", timeout=10) or {}
     active_agents = {k: v for k, v in agents_data.items() if v.get("status") == "active"}
+    active_intents = _core("/intents") or []
 
     return _render(request, "dashboard.html", "dashboard",
                    core_ok=core_ok, ollama_ok=ollama_ok,
                    history=history[-10:],
                    alerts=alerts, state=state, speaker=speaker,
                    avg_lat=avg, history_count=len(history),
-                   active_agents=active_agents)
+                   active_agents=active_agents,
+                   active_intents=active_intents[:5])
 
 
 @app.get("/agents", response_class=HTMLResponse)
@@ -426,6 +428,29 @@ def delete_agent_htmx(agent_id: str):
     return HTMLResponse("")
 
 
+@app.get("/intents", response_class=HTMLResponse)
+def intents_page(request: Request):
+    """Vista de primer nivel: todas las intenciones activas de todos los usuarios."""
+    users_data  = _core("/users") or {}
+    agents_data = _core("/agents", timeout=10) or {}
+    all_intents = _core("/intents") or []
+    return _render(request, "intents.html", "intents",
+                   intents=all_intents, users=users_data, agents=agents_data)
+
+
+@app.patch("/users/{uid}/intents/{intent_id}", response_class=HTMLResponse)
+async def update_intent_proxy(uid: str, intent_id: str, request: Request):
+    body = await request.json()
+    _core(f"/users/{uid}/intents/{intent_id}", method="PATCH", json=body)
+    return HTMLResponse("")
+
+
+@app.delete("/users/{uid}/intents/{intent_id}", response_class=HTMLResponse)
+def delete_intent_proxy(uid: str, intent_id: str):
+    _core(f"/users/{uid}/intents/{intent_id}", method="DELETE")
+    return HTMLResponse("")
+
+
 @app.get("/shared-state", response_class=HTMLResponse)
 def shared_state_page(request: Request):
     data = _core("/shared-state") or {}
@@ -569,10 +594,11 @@ def edit_user_page(request: Request, uid: str):
     ww_metrics   = _core(f"/users/{uid}/wakeword/metrics") or {"tp": 0, "fp": 0, "rbac_deny": 0}
     train_status = _core("/wakeword/train/status") or {"status": "idle"}
     user_context = _core(f"/users/{uid}/context/raw") or {}
+    user_intents = _core(f"/users/{uid}/intents", params={"active_only": True}) or []
     return _render(request, "user_form.html", "users",
                    user=user, uid=uid, error="", agents=agents, role_perms=role_perms,
                    ww_samples=ww_samples, ww_metrics=ww_metrics, train_status=train_status,
-                   user_context=user_context)
+                   user_context=user_context, user_intents=user_intents)
 
 
 @app.post("/users/{uid}/update")

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -41,6 +41,7 @@
       <div class="flex flex-col gap-1">
         <p class="px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-600">Sistema</p>
         <a href="/agents"       class="{{ link_active if section == 'agents'       else link_base }}">🤖 Agentes</a>
+        <a href="/intents"      class="{{ link_active if section == 'intents'      else link_base }}">🎯 Intenciones</a>
         <a href="/conversations"class="{{ link_active if section == 'conversations'else link_base }}">💬 Conversaciones</a>
         <a href="/shared-state" class="{{ link_active if section == 'shared-state' else link_base }}">🔗 Shared State</a>
         <a href="/plan"         class="{{ link_active if section == 'plan'         else link_base }}">🗺️ Plan</a>

--- a/backoffice/templates/dashboard.html
+++ b/backoffice/templates/dashboard.html
@@ -115,6 +115,26 @@
   {% endif %}
 </div>
 
+<!-- Intenciones activas -->
+{% if active_intents %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-6">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-semibold text-gray-400">Intenciones activas</h2>
+    <a href="/intents" class="text-xs text-indigo-400 hover:text-indigo-300">Ver todas →</a>
+  </div>
+  <div class="space-y-2">
+    {% for intent in active_intents %}
+    <div class="flex items-center gap-3 text-xs py-1.5 border-b border-gray-800/50 last:border-0">
+      <span class="w-2 h-2 rounded-full shrink-0 {{ 'bg-yellow-400' if intent.status == 'pending' else 'bg-blue-400' }}"></span>
+      <span class="flex-1 text-gray-300 truncate">{{ intent.title }}</span>
+      <span class="text-gray-600 shrink-0">{{ intent.agent_id }}</span>
+      <span class="text-gray-600 shrink-0">{{ intent.user_id }}</span>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 <!-- Últimos comandos -->
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
   <h2 class="text-sm font-semibold text-gray-400 mb-3">Últimos comandos</h2>

--- a/backoffice/templates/intents.html
+++ b/backoffice/templates/intents.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+{% block title %}Intenciones{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold">Intenciones activas</h1>
+    <p class="text-xs text-gray-500 mt-1">
+      Acciones pendientes detectadas por los agentes — persisten entre sesiones y pueden disparar recordatorios.
+    </p>
+  </div>
+  <span class="text-xs text-gray-600">{{ intents | length }} activa{{ 's' if intents | length != 1 }}</span>
+</div>
+
+{% if not intents %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-8 text-center">
+  <div class="text-4xl mb-3">🎯</div>
+  <p class="text-gray-400 text-sm">No hay intenciones activas.</p>
+  <p class="text-gray-600 text-xs mt-1">
+    Los agentes crean intenciones cuando detectan que el usuario tiene algo pendiente.
+  </p>
+</div>
+{% else %}
+
+{% set status_colors = {
+  'pending':     'bg-yellow-900/40 text-yellow-400 border-yellow-800/50',
+  'in_progress': 'bg-blue-900/40 text-blue-400 border-blue-800/50',
+  'done':        'bg-emerald-900/40 text-emerald-400 border-emerald-800/50',
+  'cancelled':   'bg-gray-800 text-gray-500 border-gray-700/50',
+} %}
+{% set status_labels = {
+  'pending':     'pendiente',
+  'in_progress': 'en curso',
+  'done':        'completada',
+  'cancelled':   'cancelada',
+} %}
+
+<div class="space-y-3">
+{% for intent in intents %}
+{% set agent_info  = agents.get(intent.agent_id, {}) %}
+{% set user_info   = users.get(intent.user_id, {}) %}
+{% set scolor      = status_colors.get(intent.status, 'bg-gray-800 text-gray-400 border-gray-700') %}
+{% set slabel      = status_labels.get(intent.status, intent.status) %}
+{% set days_old    = ((now - intent.updated_at) / 86400) | round(0, 'floor') | int %}
+
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-4
+            hover:border-gray-700 transition-colors"
+     id="intent-row-{{ intent.intent_id }}">
+
+  <div class="flex items-start gap-3">
+    <!-- Icono agente -->
+    <div class="text-2xl shrink-0 pt-0.5">{{ agent_info.get('icon', '🤖') }}</div>
+
+    <!-- Contenido -->
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2 flex-wrap mb-1">
+        <span class="text-sm font-semibold text-gray-100">{{ intent.title }}</span>
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-medium border {{ scolor }}">
+          {{ slabel }}
+        </span>
+      </div>
+
+      {% if intent.description %}
+      <p class="text-xs text-gray-400 mb-2">{{ intent.description }}</p>
+      {% endif %}
+
+      {% if intent.context %}
+      <div class="flex flex-wrap gap-2 mb-2">
+        {% for k, v in intent.context.items() %}
+        <span class="text-[10px] bg-gray-800 text-gray-400 px-2 py-0.5 rounded font-mono">
+          {{ k }}: {{ v }}
+        </span>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <div class="flex items-center gap-3 text-[10px] text-gray-600">
+        <span>{{ agent_info.get('name', intent.agent_id) }}</span>
+        <span>·</span>
+        <a href="/users/{{ intent.user_id }}/edit" class="hover:text-gray-400 transition-colors">
+          {{ user_info.get('name', intent.user_id) }}
+        </a>
+        <span>·</span>
+        <span>actualizado hace {{ days_old }}d</span>
+        {% if intent.remind_after_days %}
+        <span>·</span>
+        <span>recordatorio cada {{ intent.remind_after_days }}d</span>
+        {% endif %}
+      </div>
+    </div>
+
+    <!-- Acciones -->
+    <div class="shrink-0 flex gap-2">
+      {% if intent.status in ['pending', 'in_progress'] %}
+      <button
+        hx-patch="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}"
+        hx-vals='{"status": "done"}'
+        hx-target="#intent-row-{{ intent.intent_id }}"
+        hx-swap="outerHTML"
+        hx-headers='{"Content-Type": "application/json"}'
+        title="Marcar como completada"
+        class="px-2 py-1 text-xs text-emerald-400 hover:text-emerald-300 hover:bg-emerald-900/20
+               rounded transition-colors border border-emerald-800/50">
+        ✓ completar
+      </button>
+      {% endif %}
+      <button
+        hx-delete="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}"
+        hx-target="#intent-row-{{ intent.intent_id }}"
+        hx-swap="outerHTML"
+        hx-confirm="¿Eliminar esta intención?"
+        title="Eliminar intención"
+        class="px-2 py-1 text-xs text-gray-600 hover:text-red-400 hover:bg-red-900/20
+               rounded transition-colors">
+        ✕
+      </button>
+    </div>
+  </div>
+</div>
+{% endfor %}
+</div>
+{% endif %}
+{% endblock %}

--- a/backoffice/templates/user_form.html
+++ b/backoffice/templates/user_form.html
@@ -256,6 +256,62 @@
 </div>
 {% endif %}
 
+{% if uid and user_intents %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-6 max-w-lg mt-6">
+  <div class="flex items-center justify-between mb-1">
+    <h2 class="text-sm font-semibold text-gray-300 uppercase tracking-wider">Intenciones activas</h2>
+    <a href="/intents" class="text-xs text-indigo-400 hover:text-indigo-300">Ver todas →</a>
+  </div>
+  <p class="text-xs text-gray-600 mb-4">
+    Acciones pendientes que los agentes recuerdan para este usuario.
+  </p>
+
+  {% set status_colors = {
+    'pending':     'text-yellow-400',
+    'in_progress': 'text-blue-400',
+    'done':        'text-emerald-400',
+    'cancelled':   'text-gray-500',
+  } %}
+  {% set status_labels = {
+    'pending':     'pendiente',
+    'in_progress': 'en curso',
+    'done':        'completada',
+    'cancelled':   'cancelada',
+  } %}
+
+  <div class="space-y-2">
+  {% for intent in user_intents %}
+  {% set agent_info = agents.get(intent.agent_id, {}) %}
+  <div class="flex items-start gap-3 py-2 border-b border-gray-800/50"
+       id="intent-user-row-{{ intent.intent_id }}">
+    <span class="text-base shrink-0">{{ agent_info.get('icon', '🤖') }}</span>
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2 flex-wrap">
+        <span class="text-sm text-gray-200">{{ intent.title }}</span>
+        <span class="text-[10px] {{ status_colors.get(intent.status, 'text-gray-500') }}">
+          {{ status_labels.get(intent.status, intent.status) }}
+        </span>
+      </div>
+      {% if intent.description %}
+      <div class="text-xs text-gray-500 mt-0.5">{{ intent.description }}</div>
+      {% endif %}
+      <div class="text-[10px] text-gray-600 mt-0.5">{{ agent_info.get('name', intent.agent_id) }}</div>
+    </div>
+    <button
+      hx-delete="/users/{{ uid }}/intents/{{ intent.intent_id }}"
+      hx-target="#intent-user-row-{{ intent.intent_id }}"
+      hx-swap="outerHTML"
+      class="shrink-0 text-xs text-gray-600 hover:text-red-400 transition-colors px-2 py-1">
+      ✕
+    </button>
+  </div>
+  {% else %}
+  <p class="text-xs text-gray-600">Sin intenciones activas.</p>
+  {% endfor %}
+  </div>
+</div>
+{% endif %}
+
 {% if uid and user_context %}
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-6 max-w-lg mt-6">
   <h2 class="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-1">Contexto aprendido</h2>

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -572,7 +572,7 @@ Total estimado:               ~2-3s        (vs 8s actual warm)
 ```
 Objetivo: Reemplazar el router de reglas por un LLM coordinador capaz de descomponer
           requests complejos, rutear a múltiples agentes y agregar respuestas.
-Estado:   EN CURSO (22/27 — etapas A+B+C+D+E completas, iniciando etapa F)
+Estado:   COMPLETA
 Deps:     FASE 3.2 (orquestador), FASE 3.3 (router de reglas como baseline),
           FASE 2.10 (contexto multi-turno), ≥2 agentes de dominio estables.
 Cuándo empezar: cuando el router de reglas muestre limitaciones reales en uso diario
@@ -708,37 +708,32 @@ información que cada agente guarda sobre él.
 #### Etapa F — Intenciones persistentes y continuación proactiva
 
 ```
-Los agentes detectan intenciones "en curso" que el usuario no completó
-(una inversión a evaluar, un viaje en planificación, etc.) y las guardan
-como intent_state en user_context. Cuando el usuario vuelve a hablar con
-ese agente, se le recuerda dónde quedó. Si pasa demasiado tiempo, el agente
-lo propone proactivamente via el mecanismo de alertas.
+Las intenciones son una entidad de primer nivel (separada del user_context): representan
+acciones que el usuario quiere hacer, monitoreadas por un agente entre sesiones.
+Tienen ciclo de vida (pending → in_progress → done/cancelled), pueden disparar alertas
+proactivas y son visibles en el backoffice como página propia (/intents).
+Storage: ~/.local/share/capitan/intents/{user_id}.json
 ```
-- [ ] 9.23 `core/intent_state.py` — estructura de intención persistente:
-           `{intent_id, agent_id, user_id, action, context: dict, status: pending|in_progress|done,
-           created_at, updated_at, expires_at, last_reminded_at}`.
-           Almacenada en `user_context` bajo la clave `intent:{intent_id}` (TTL configurable).
-           API interna: `upsert_intent()`, `get_pending_intents(user_id, agent_id)`,
-           `complete_intent()`, `all_pending(user_id)`.
-- [ ] 9.24 Detección de intenciones en agentes — cada agente que aplique (finance, travel,
-           scheduler, haos) puede devolver en su respuesta estructurada un campo
-           `intent_updates: [{intent_id, action, context, status}]`.
-           `server.py` persiste esas actualizaciones vía `intent_state.upsert_intent()`.
-           Ejemplos: FinanceAgent detecta "quiero analizar GGAL cuando baje" → intent pending.
-           TravelAgent detecta "estoy pensando un viaje a Tokio en septiembre" → intent pending.
-- [ ] 9.25 Retoma proactiva al inicio de sesión — cuando un usuario conocido inicia interacción,
-           el dispatcher consulta `intent_state.get_pending_intents()` del agente activado.
-           Si hay intenciones pendientes, el agente las menciona naturalmente al inicio:
-           "Por cierto, ¿cómo terminó lo de GGAL que estabas analizando?"
-           Umbral configurable: solo retoma si la intención tiene más de N días sin actividad.
-- [ ] 9.26 Alertas proactivas de intenciones — si una intención lleva más de `remind_after_days`
-           sin actividad y el estado sigue `pending`, se agrega a la cola de alertas del agente
-           (mismo mecanismo que clima o finanzas usa hoy). El usuario recibe por voz o WA:
-           "Tenés una planificación de viaje a Tokio sin completar. ¿Querés retomar?"
-           `last_reminded_at` previene spam — una alerta por intención por día como máximo.
-- [ ] 9.27 Backoffice `/users/{id}` — sección "Intenciones activas": tabla de intenciones
-           pendientes/en_curso por agente (acción, contexto resumido, fecha, días sin actividad),
-           botones para marcar como completa o descartar. El usuario controla qué el sistema recuerda.
+- [x] 9.23 `core/intent_state.py` — módulo propio (no anidado en user_context):
+           `{intent_id, agent_id, user_id, title, description, status, context: dict,
+           created_at, updated_at, expires_at, last_reminded_at, remind_after_days}`.
+           API: `upsert()`, `get()`, `get_active()`, `get_active_for_agent()`,
+           `update_status()`, `update_context()`, `delete()`, `get_all_needing_reminder()`,
+           `get_all_active_across_users()` (vista admin).
+- [x] 9.24 Detección de intenciones en agentes — agentes pueden devolver
+           `(resp, action, {"context_updates": [...], "intent_updates": [...]})`.
+           `_apply_agent_updates()` en `server.py` persiste ambos tipos.
+           Backwards compatible: 3-tuple con lista directa sigue siendo context_updates.
+- [x] 9.25 Retoma proactiva al inicio de sesión — `_build_agent_prefix()` en `server.py`
+           inyecta contexto + intenciones activas como system message antes de cada llamada
+           al agente (single-step y multi-step). El LLM las ve y las retoma naturalmente.
+- [x] 9.26 Alertas proactivas de intenciones — `_alert_poller()` verifica
+           `get_all_needing_reminder()` en cada ciclo; genera alerta y actualiza
+           `last_reminded_at` para evitar spam.
+- [x] 9.27 Backoffice: `/intents` como página de primer nivel con vista de todas las
+           intenciones activas de todos los usuarios; widget en dashboard; acordeón en
+           `/users/{id}` con intenciones activas por agente. Acciones: completar / eliminar
+           vía HTMX. Nav link "🎯 Intenciones" en la barra lateral.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Core** (home-agents-core#92): `intent_state.py` + integración en `server.py`
- **Backoffice**:
  - `/intents` — página propia con todas las intenciones activas de todos los usuarios
  - Nav link `🎯 Intenciones` en la barra lateral
  - Widget en dashboard (top 5 intenciones activas)
  - Acordeón "Intenciones activas" en `/users/{id}` con delete vía HTMX
- **Plan**: FASE 9 marcada COMPLETA; Etapa F reescrita con diseño de primer nivel

## Test plan

- [ ] `/intents` carga sin errores (vacío o con datos)
- [ ] Nav link activo al entrar a `/intents`
- [ ] Dashboard muestra widget cuando hay intenciones
- [ ] Usuario con intenciones activas las ve en su perfil
- [ ] Botón ✕ elimina intención vía HTMX

🤖 Generated with [Claude Code](https://claude.com/claude-code)