### PR TITLE
feat: 9.32–9.33 — UI proactividad en backoffice

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -40,6 +40,15 @@ TEMPLATES_DIR = Path(__file__).parent / "templates"
 app = FastAPI(title="capitan-backoffice", version="1.0")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
+import datetime as _dt
+def _datetimefmt(ts: float | int) -> str:
+    try:
+        return _dt.datetime.fromtimestamp(float(ts)).strftime("%d/%m %H:%M")
+    except Exception:
+        return "—"
+
+templates.env.filters["datetimefmt"] = _datetimefmt
+
 # ── Auth ───────────────────────────────────────────────────────────────────────
 
 _SESSION_COOKIE = "capitan_session"
@@ -265,13 +274,17 @@ def agent_detail_page(request: Request, agent_id: str):
     all_intents = _core("/intents") or []
     agent_intents = [i for i in all_intents if i.get("agent_id") == agent_id]
 
+    proactive_status = _core("/proactive/status", timeout=3) or {}
+    proactive_info   = proactive_status.get(agent_id)
+
     return _render(request, "agent_detail.html", "agents",
                    agent_id=agent_id, agent=agent,
                    recent_history=agent_history[-15:],
                    stats=stats,
                    roles_with_access=roles_with_access,
                    conversations=conversations,
-                   agent_intents=agent_intents)
+                   agent_intents=agent_intents,
+                   proactive_info=proactive_info)
 
 
 @app.post("/agents/{agent_id}/toggle", response_class=HTMLResponse)
@@ -292,6 +305,21 @@ async def toggle_agent(agent_id: str):
         f'title="Click para cambiar estado" '
         f'class="cursor-pointer px-2 py-1 rounded text-xs font-medium transition-colors {css}">'
         f'{new_status}</button>'
+    )
+
+
+@app.post("/agents/{agent_id}/proactive/run", response_class=HTMLResponse)
+async def proactive_run(agent_id: str, request: Request):
+    result = _core(f"/proactive/{agent_id}/run", method="POST", timeout=120)
+    if not result:
+        return HTMLResponse(
+            '<span class="text-red-400">Error al ejecutar — el agente no está registrado o el core no responde.</span>'
+        )
+    users_checked   = result.get("users_checked", 0)
+    intents_created = result.get("intents_created", 0)
+    return HTMLResponse(
+        f'<span class="text-violet-300">✓ Ejecutado — {users_checked} usuario(s) evaluado(s), '
+        f'{intents_created} intento(s) creado(s).</span>'
     )
 
 

--- a/backoffice/templates/agent_detail.html
+++ b/backoffice/templates/agent_detail.html
@@ -9,6 +9,7 @@
     {{ agent.icon }} {{ agent.name }}
     <span class="text-gray-500 text-base font-normal ml-1">{{ agent_id }}</span>
     {% if agent.dynamic %}<span class="ml-2 text-xs text-indigo-400 bg-indigo-900/30 border border-indigo-800 px-2 py-0.5 rounded-full">dinámico</span>{% endif %}
+    {% if proactive_info %}<span class="ml-2 text-xs text-violet-400 bg-violet-900/20 border border-violet-800 px-2 py-0.5 rounded-full">🔄 proactivo</span>{% endif %}
   </h1>
   <div class="ml-auto flex gap-2">
     <a href="/agents/{{ agent_id }}/edit"
@@ -216,6 +217,56 @@
   <p class="text-sm text-gray-600">Sin roles asignados (solo admin implícito).</p>
   {% endif %}
 </div>
+
+<!-- Proactividad (9.32) -->
+{% if proactive_info %}
+{% set pi = proactive_info %}
+<div class="bg-gray-900 border border-violet-900/40 rounded-xl p-5 mb-4">
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h2 class="text-xs font-semibold text-violet-400 uppercase tracking-wider">Proactividad</h2>
+      <p class="text-xs text-gray-600 mt-0.5">Este agente genera intenciones automáticamente en segundo plano</p>
+    </div>
+    <button
+      id="proactive-run-btn"
+      hx-post="/agents/{{ agent_id }}/proactive/run"
+      hx-target="#proactive-run-result"
+      hx-swap="innerHTML"
+      hx-indicator="#proactive-run-btn"
+      class="px-3 py-1.5 bg-violet-900/40 hover:bg-violet-800/60 border border-violet-700 text-violet-300 text-xs font-medium rounded-lg transition-colors">
+      Ejecutar ahora
+    </button>
+  </div>
+  <div class="grid grid-cols-4 gap-4 mb-4">
+    <div class="text-center">
+      <div class="text-base font-semibold text-white">
+        {% set secs = pi.interval_seconds %}
+        {% if secs >= 3600 %}{{ (secs // 3600) }}h{% else %}{{ (secs // 60) }}min{% endif %}
+      </div>
+      <div class="text-xs text-gray-500 mt-1">intervalo</div>
+    </div>
+    <div class="text-center">
+      <div class="text-base font-semibold {% if pi.last_run_at %}text-white{% else %}text-gray-600{% endif %}">
+        {% if pi.last_run_at %}
+          {{ pi.last_run_at | int | datetimefmt }}
+        {% else %}—{% endif %}
+      </div>
+      <div class="text-xs text-gray-500 mt-1">último run</div>
+    </div>
+    <div class="text-center">
+      <div class="text-base font-semibold text-white">{{ pi.last_intents_created }}</div>
+      <div class="text-xs text-gray-500 mt-1">intents (último)</div>
+    </div>
+    <div class="text-center">
+      <div class="text-base font-semibold text-gray-300">
+        {% if pi.next_run_at %}{{ pi.next_run_at | int | datetimefmt }}{% else %}—{% endif %}
+      </div>
+      <div class="text-xs text-gray-500 mt-1">próximo run</div>
+    </div>
+  </div>
+  <div id="proactive-run-result" class="text-xs text-gray-400 empty:hidden"></div>
+</div>
+{% endif %}
 
 <!-- Estadísticas -->
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">


### PR DESCRIPTION
## Summary

- **9.32** `backoffice/templates/agent_detail.html`: badge `🔄 proactivo` junto al nombre, sección "Proactividad" con intervalo/último run/intents creados/próximo run + botón "Ejecutar ahora" vía HTMX
- **9.33** `backoffice/server.py`: filtro `datetimefmt` en Jinja2, `proactive_info` pasado al template desde `/proactive/status`, `POST /agents/{id}/proactive/run` retorna fragmento HTML inline
- Submodule `core` apuntado al commit de Etapa G (9.28–9.31, PR #95)

## Test plan

- [ ] Backoffice `/agents/weather/detail` muestra badge "🔄 proactivo" y sección Proactividad
- [ ] "Ejecutar ahora" llama al core y muestra resultado inline (sin recargar página)
- [ ] Agentes sin `proactive_schedule` no muestran la sección

🤖 Generated with [Claude Code](https://claude.com/claude-code)