### PR TITLE
fix: selector de usuario siempre visible en el chat

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -192,8 +192,8 @@ def root():
 @app.get("/chat", response_class=HTMLResponse)
 def chat_page(request: Request):
     _require_auth(request)
-    users_resp = _core("/users") or []
-    users = users_resp if isinstance(users_resp, list) else []
+    users_resp = _core("/users") or {}
+    users = list(users_resp.values()) if isinstance(users_resp, dict) else (users_resp if isinstance(users_resp, list) else [])
     return templates.TemplateResponse(request, "chat.html", {"users": users})
 
 

--- a/backoffice/templates/chat.html
+++ b/backoffice/templates/chat.html
@@ -30,7 +30,6 @@
               title="Exportar conversación">
         ↓ Exportar
       </button>
-      {% if users %}
       <select id="user-select"
               onchange="onUserChange()"
               class="text-sm bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-gray-300 focus:outline-none focus:ring-1 focus:ring-blue-500">
@@ -39,7 +38,6 @@
         <option value="{{ u.id }}">{{ u.name }}</option>
         {% endfor %}
       </select>
-      {% endif %}
       <a href="/dashboard" class="text-sm text-gray-400 hover:text-white transition-colors px-2 py-1">
         Administración →
       </a>


### PR DESCRIPTION
El endpoint /users del core devuelve un dict {uid: user}, no una lista. El backoffice convertía mal el formato y users quedaba vacío, ocultando el select. Fix: usar .values() + quitar el {% if users %} para que el select siempre se renderice.