### PR TITLE
feat: fase 19.2 — auto-confirmar notificaciones de solo-aviso

### DIFF
--- a/wa/index.js
+++ b/wa/index.js
@@ -139,6 +139,14 @@ async function handleText(msg, phone, fromLid, text) {
       _storePending(sentMsg.id.id, data.conversation_id);
       console.log(`[WA] pendiente: msg ${sentMsg.id.id} → conv ${data.conversation_id}`);
     }
+    // 19.2: si el intent fue procesado sin necesidad de respuesta, confirmar con reacción
+    if (!data.needs_reply) {
+      try {
+        await msg.react("✅");
+      } catch (_) {
+        // react no soportado; fallback silencioso (la respuesta ya fue enviada)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Cuando el core responde `needs_reply: false`, reacciona con ✅ al mensaje original del usuario
- Marca visualmente que el intent fue procesado sin requerir acción adicional
- Fallback silencioso si `react()` falla (whatsapp-web.js API limitation)

## Test plan
- [ ] Comando de acción simple (ej. "prende la luz") → ✅ en el mensaje del usuario
- [ ] Pregunta que genera aclaración (`needs_reply: true`) → sin reacción
- [ ] Mensajes de audio: no afectados (solo texto por ahora)

🤖 Generated with [Claude Code](https://claude.com/claude-code)