### PR TITLE
fix: guard outbound /send con _clientReady

### DIFF
--- a/wa/index.js
+++ b/wa/index.js
@@ -53,12 +53,15 @@ client.on("qr", (qr) => {
   qrcode.generate(qr, { small: true });
 });
 
+let _clientReady = false;
+
 client.on("authenticated", () => {
   console.log("[WA] Sesión autenticada");
 });
 
 client.on("ready", () => {
   console.log(`[WA] Cliente listo. Core: ${CORE_URL}`);
+  _clientReady = true;
 });
 
 client.on("auth_failure", (msg) => {
@@ -68,6 +71,7 @@ client.on("auth_failure", (msg) => {
 
 client.on("disconnected", (reason) => {
   console.log(`[WA] Desconectado (${reason}). Reconectando en 10s...`);
+  _clientReady = false;
   setTimeout(() => client.initialize(), 10_000);
 });
 
@@ -285,6 +289,11 @@ http.createServer(async (req, res) => {
   let body = "";
   req.on("data", (chunk) => { body += chunk; });
   req.on("end", async () => {
+    if (!_clientReady) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "WA client not ready" }));
+      return;
+    }
     try {
       const { to, text, audio_b64, media_url, link_preview } = JSON.parse(body);
       if (!to || (!text && !audio_b64 && !media_url)) {


### PR DESCRIPTION
## Problema
El servidor HTTP outbound levanta en ~0s, pero el cliente WA tarda ~5s en estar listo.
Las notificaciones proactivas que disparan durante ese gap causaban:
> `[WA] Error outbound: Cannot read properties of undefined (reading 'getChat')`

## Causa
`client.getChatById()` o `client.sendMessage()` con linkPreview llaman internamente
a métodos de whatsapp-web.js que requieren que el cliente esté inicializado.

## Fix
- `_clientReady = true` solo en el evento `ready`
- `_clientReady = false` en `disconnected` (también cubre reconexiones)
- El outbound `/send` retorna **503** si `!_clientReady`
- `wa_notifier.py` ya logea el 503 como warning y sigue sin crashear

🤖 Generated with [Claude Code](https://claude.com/claude-code)