### PR TITLE
fix: sendSeen() en acks silenciosos

### DIFF
--- a/wa/index.js
+++ b/wa/index.js
@@ -153,6 +153,13 @@ async function handleText(msg, phone, fromLid, text) {
   }
 
   const data = await res.json();
+
+  // Marcar como leído siempre — incluso cuando la respuesta es vacía (ej. ack silencioso)
+  try {
+    const chat = await msg.getChat();
+    await chat.sendSeen();
+  } catch (_) { /* noop */ }
+
   if (data.response) {
     let sentMsg = null;
 


### PR DESCRIPTION
## Problema
Al responder "Ok" a una notificación, el intent se cerraba correctamente pero el
mensaje quedaba sin el doble tilde azul (no marcado como leído).

## Causa
`sendSeen()` se llama implícitamente en whatsapp-web.js solo cuando se hace `reply()`.
Para respuestas vacías (ack silencioso), nunca se llamaba.

## Fix
`chat.sendSeen()` explícito justo después de recibir cualquier respuesta del core,
antes de evaluar si hay texto para enviar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)