### PR TITLE
feat: backoffice — OAuth2 connect/callback para ML y MP

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -598,40 +598,26 @@ def delete_agent_htmx(agent_id: str):
     return HTMLResponse("")
 
 
-# ── OAuth2 backends (token manual) ─────────────────────────────────────────────
+# ── OAuth2 backends ─────────────────────────────────────────────────────────────
 
-@app.post("/auth/{service}/token", response_class=HTMLResponse)
-async def oauth_save_token(request: Request, service: str):
-    if service not in _OAUTH_SERVICES:
-        raise HTTPException(status_code=404)
-    form = await request.form()
-    user_id = str(form.get("user_id", "")).strip()
-    access_token = str(form.get("access_token", "")).strip()
-    agent_id = str(form.get("agent_id", "")).strip()
-    if not user_id or not access_token:
-        return RedirectResponse(f"/agents/{agent_id}/edit", status_code=303)
+@app.get("/auth/{service}/connect")
+def oauth_connect(service: str, user_id: str, agent_id: str = ""):
+    """Inicia el flujo OAuth2: pide a core la URL y redirige al usuario."""
+    result = _core(f"/auth/{service}/url", params={"user_id": user_id, "agent_id": agent_id})
+    if not result or not result.get("url"):
+        raise HTTPException(status_code=503, detail=f"Core no pudo generar la URL de autorización para {service}")
+    return RedirectResponse(result["url"], status_code=302)
 
-    api_user_id = ""
-    try:
-        r = requests.get(
-            _OAUTH_SERVICES[service]["me_url"],
-            headers={"Authorization": f"Bearer {access_token}"},
-            timeout=10,
-        )
-        if r.status_code == 200:
-            api_user_id = str(r.json().get("id", ""))
-    except Exception:
-        pass
 
-    _CAPITAN_DIR.mkdir(parents=True, exist_ok=True)
-    token_data = {
-        "access_token": access_token,
-        "user_id": api_user_id,
-        "saved_at": _dt.datetime.now().isoformat(timespec="seconds"),
-        "expires_at": time.time() + 3600 * 24 * 30,
-    }
-    _oauth_token_path(service, user_id).write_text(json.dumps(token_data, indent=2))
-    return RedirectResponse(f"/agents/{agent_id}/edit?connected=1", status_code=303)
+@app.get("/auth/{service}/callback")
+def oauth_callback(service: str, code: str = "", state: str = "", error: str = ""):
+    """Recibe el callback de ML/MP con el code, lo envía a core para canjearlo."""
+    if error or not code:
+        return RedirectResponse("/agents", status_code=302)
+    result = _core(f"/auth/{service}/callback", method="POST", json={"code": code, "state": state})
+    agent_id = (result or {}).get("agent_id", "")
+    redirect = f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents"
+    return RedirectResponse(redirect, status_code=302)
 
 
 @app.post("/auth/{service}/disconnect", response_class=HTMLResponse)

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -138,7 +138,7 @@
 
     {% if just_connected %}
     <div class="mb-3 bg-emerald-900/30 border border-emerald-700 text-emerald-300 px-3 py-2 rounded-lg text-xs">
-      Token guardado correctamente.
+      Cuenta conectada correctamente.
     </div>
     {% endif %}
 
@@ -177,24 +177,11 @@
                   </button>
                 </form>
               {% else %}
-                <details class="mt-1">
-                  <summary class="text-xs text-indigo-400 hover:text-indigo-300 cursor-pointer select-none">
-                    Ingresar token →
-                  </summary>
-                  <form method="POST" action="/auth/{{ svc }}/token" class="mt-2 space-y-2">
-                    <input type="hidden" name="user_id" value="{{ uid }}">
-                    <input type="hidden" name="agent_id" value="{{ agent_id }}">
-                    <input type="text" name="access_token" placeholder="access token"
-                           class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1.5
-                                  text-xs text-gray-200 font-mono focus:outline-none focus:ring-1
-                                  focus:ring-indigo-500">
-                    <button type="submit"
-                            class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs
-                                   rounded transition-colors">
-                      Guardar
-                    </button>
-                  </form>
-                </details>
+                <a href="/auth/{{ svc }}/connect?user_id={{ uid }}&agent_id={{ agent_id }}"
+                   class="inline-block mt-1 px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600
+                          text-white text-xs rounded transition-colors">
+                  Conectar cuenta →
+                </a>
               {% endif %}
             </div>
             {% endfor %}


### PR DESCRIPTION
## Cambios

- `GET /auth/{service}/connect?user_id=X&agent_id=Y` — llama a core para obtener la URL, redirige al usuario a ML/MP
- `GET /auth/{service}/callback?code=X&state=Y` — recibe el redirect de ML/MP, delega a core para canjear tokens, redirige a agent_edit
- Eliminado `POST /auth/{service}/token` (formulario manual)
- `agent_edit.html`: botón "Conectar cuenta →" en lugar del form de token manual

Depende del PR #118 en home-agents-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)