### PR TITLE
feat: fancy names para agentes + eliminar wa_lid

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -482,6 +482,7 @@ async def agent_new_submit(request: Request):
     payload = {
         "id":            str(form.get("id", "")).strip().lower().replace(" ", "_"),
         "name":          str(form.get("name", "")).strip(),
+        "fancy_name":    str(form.get("fancy_name", "")).strip(),
         "icon":          str(form.get("icon", "")).strip(),
         "desc":          str(form.get("desc", "")).strip(),
         "status":        str(form.get("status", "planned")),
@@ -529,14 +530,15 @@ def agent_edit_page(request: Request, agent_id: str, connected: str = ""):
 async def agent_edit_submit(request: Request, agent_id: str):
     form = await request.form()
 
-    # Nombre, icono y descripción (agent card)
-    name = str(form.get("name", "")).strip()
-    icon = str(form.get("icon", "")).strip()
-    desc = str(form.get("desc", "")).strip()
-    if name or icon or desc:
+    # Nombre, nombre de fantasía, icono y descripción (agent card)
+    name       = str(form.get("name", "")).strip()
+    fancy_name = str(form.get("fancy_name", "")).strip()
+    icon       = str(form.get("icon", "")).strip()
+    desc       = str(form.get("desc", "")).strip()
+    if name or fancy_name or icon or desc:
         _core(f"/agents/{agent_id}/metadata", method="PATCH",
-              json={"name": name or None, "icon": icon or None,
-                    "desc": desc or None})
+              json={"name": name or None, "fancy_name": fancy_name or None,
+                    "icon": icon or None, "desc": desc or None})
 
     # Status
     status = str(form.get("status", "")).strip()
@@ -820,7 +822,6 @@ async def create_user_submit(request: Request):
         "role":           role,
         "relationship":   str(form.get("relationship", "invitado")),
         "wa_phone":       str(form.get("wa_phone", "")).strip() or None,
-        "wa_lid":         str(form.get("wa_lid", "")).strip() or None,
         "agent_ids":      agent_ids,
         "revoked_agents": revoked_agents,
     }
@@ -886,7 +887,6 @@ async def update_user_submit(request: Request, uid: str):
         "role":           role,
         "relationship":   str(form.get("relationship", "invitado")),
         "wa_phone":       str(form.get("wa_phone", "")).strip() or None,
-        "wa_lid":         str(form.get("wa_lid", "")).strip() or None,
         "agent_ids":      agent_ids,
         "revoked_agents": revoked_agents,
     }

--- a/backoffice/templates/agent_detail.html
+++ b/backoffice/templates/agent_detail.html
@@ -7,6 +7,7 @@
   <span class="text-gray-700">/</span>
   <h1 class="text-2xl font-bold">
     {{ agent.icon }} {{ agent.name }}
+    {% if agent.fancy_name %}<span class="text-indigo-300 text-base font-normal ml-2 italic">{{ agent.fancy_name }}</span>{% endif %}
     <span class="text-gray-500 text-base font-normal ml-1">{{ agent_id }}</span>
     {% if agent.dynamic %}<span class="ml-2 text-xs text-indigo-400 bg-indigo-900/30 border border-indigo-800 px-2 py-0.5 rounded-full">dinámico</span>{% endif %}
     {% if proactive_info %}<span class="ml-2 text-xs text-violet-400 bg-violet-900/20 border border-violet-800 px-2 py-0.5 rounded-full">🔄 proactivo</span>{% endif %}

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -30,11 +30,18 @@
                       focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-400 mb-1">Icono (emoji)</label>
-        <input type="text" name="icon" value="{{ agent.icon }}"
-               class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 text-center text-lg
+        <label class="block text-xs font-medium text-gray-400 mb-1">Nombre de fantasía</label>
+        <input type="text" name="fancy_name" value="{{ agent.fancy_name or '' }}"
+               placeholder="ej: El Contador"
+               class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
                       focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
       </div>
+    </div>
+    <div class="mt-3">
+      <label class="block text-xs font-medium text-gray-400 mb-1">Icono (emoji)</label>
+      <input type="text" name="icon" value="{{ agent.icon }}"
+             class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 text-center text-lg
+                    focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
     </div>
   </div>
 

--- a/backoffice/templates/agent_new.html
+++ b/backoffice/templates/agent_new.html
@@ -47,12 +47,19 @@
                       focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-400 mb-1">Descripción breve</label>
-        <input type="text" name="desc"
-               placeholder="ej: Gastos, presupuesto y ahorro"
+        <label class="block text-xs font-medium text-gray-400 mb-1">Nombre de fantasía <span class="text-gray-600">(se sugiere automático)</span></label>
+        <input type="text" name="fancy_name"
+               placeholder="ej: El Contador"
                class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
                       focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
       </div>
+    </div>
+    <div>
+      <label class="block text-xs font-medium text-gray-400 mb-1">Descripción breve</label>
+      <input type="text" name="desc"
+             placeholder="ej: Gastos, presupuesto y ahorro"
+             class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
+                    focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
     </div>
   </div>
 

--- a/backoffice/templates/agents.html
+++ b/backoffice/templates/agents.html
@@ -43,7 +43,7 @@
           <div class="flex items-center gap-2">
             <span class="text-lg">{{ info.icon }}</span>
             <div>
-              <div class="font-medium">{{ info.name }}</div>
+              <div class="font-medium">{{ info.name }}{% if info.fancy_name %} <span class="text-indigo-300 font-normal italic text-sm">{{ info.fancy_name }}</span>{% endif %}</div>
               <div class="text-xs text-gray-500">
                 {{ aid }}
                 {% if info.dynamic %}<span class="ml-1 text-indigo-400 text-xs">dinámico</span>{% endif %}

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -41,9 +41,6 @@
     <div>
       <span class="text-gray-500 text-xs uppercase tracking-wider block mb-0.5">WhatsApp</span>
       <code class="text-gray-300 font-mono text-xs">{{ user.wa_phone or "—" }}</code>
-      {% if user.wa_lid %}
-      <code class="text-yellow-600 font-mono text-xs block mt-0.5" title="WhatsApp LID (linked identity)">LID: {{ user.wa_lid }}</code>
-      {% endif %}
     </div>
     {% if user.wa_phone %}
     <div>

--- a/backoffice/templates/user_form.html
+++ b/backoffice/templates/user_form.html
@@ -130,20 +130,6 @@
       </p>
     </div>
 
-    <div>
-      <label class="block text-xs text-gray-400 mb-1 uppercase tracking-wider">
-        WhatsApp LID <span class="text-gray-600 normal-case">(opcional — solo si el número no matchea)</span>
-      </label>
-      <input type="text" name="wa_lid"
-             value="{{ user.wa_lid if user and user.wa_lid else '' }}"
-             placeholder="205432714997979"
-             class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm
-                    focus:border-blue-500 focus:outline-none font-mono">
-      <p class="text-xs text-gray-600 mt-1">
-        Identificador interno de WA (linked identity). Visible en /conversations cuando aparece en amarillo.
-      </p>
-    </div>
-
     <div class="flex gap-2 pt-2">
       <button type="submit"
               class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm

--- a/wa/index.js
+++ b/wa/index.js
@@ -138,7 +138,7 @@ function _updatePendingState(sender, data) {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-async function _sendResponse(msg, phone, fromLid, data) {
+async function _sendResponse(msg, phone, data) {
   try {
     const chat = await msg.getChat();
     await chat.sendSeen();
@@ -170,7 +170,7 @@ async function _sendResponse(msg, phone, fromLid, data) {
     sentMsg = await msg.reply(data.response).catch(() => null);
   }
 
-  console.log(`[WA] → ${phone || fromLid}: ${data.response.slice(0, 80)}`);
+  console.log(`[WA] → ${phone}: ${data.response.slice(0, 80)}`);
 
   if (!data.needs_reply) {
     try { await msg.react("✅"); } catch (_) { /* noop */ }
@@ -179,14 +179,12 @@ async function _sendResponse(msg, phone, fromLid, data) {
   return sentMsg;
 }
 
-async function handleText(msg, phone, fromLid, text) {
-  const sender = phone || fromLid;
+async function handleText(msg, phone, text) {
   const body = { text, message_id: msg.id.id };
-  if (phone)   body.from_number = phone;
-  if (fromLid) body.from_lid    = fromLid;
+  if (phone) body.from_number = phone;
 
   // Retomar conversación pendiente por teléfono (pending_field en curso)
-  const pendingConvId = _resolvePendingByPhone(sender);
+  const pendingConvId = _resolvePendingByPhone(phone);
   if (pendingConvId) {
     body.conversation_id = pendingConvId;
     console.log(`[WA] pending phone → conv ${pendingConvId}`);
@@ -214,16 +212,15 @@ async function handleText(msg, phone, fromLid, text) {
   }
 
   const data = await res.json();
-  _updatePendingState(sender, data);
-  await _sendResponse(msg, phone, fromLid, data);
+  _updatePendingState(phone, data);
+  await _sendResponse(msg, phone, data);
 }
 
-async function handleMedia(msg, phone, fromLid, mediaType) {
-  const sender = phone || fromLid;
-  const pendingConvId = _resolvePendingByPhone(sender);
+async function handleMedia(msg, phone, mediaType) {
+  const pendingConvId = _resolvePendingByPhone(phone);
 
   if (!pendingConvId) {
-    console.log(`[WA] media ${mediaType} de ${sender} sin conversación pendiente — ignorando`);
+    console.log(`[WA] media ${mediaType} de ${phone} sin conversación pendiente — ignorando`);
     try {
       const chat = await msg.getChat();
       await chat.sendSeen();
@@ -234,12 +231,12 @@ async function handleMedia(msg, phone, fromLid, mediaType) {
 
   const media = await msg.downloadMedia();
   if (!media) {
-    console.error(`[WA] No se pudo descargar ${mediaType} de ${sender}`);
+    console.error(`[WA] No se pudo descargar ${mediaType} de ${phone}`);
     await msg.reply("No pude descargar el archivo. Intentá de nuevo.").catch(() => {});
     return;
   }
 
-  console.log(`[WA] media ${mediaType} de ${sender} → conv ${pendingConvId}`);
+  console.log(`[WA] media ${mediaType} de ${phone} → conv ${pendingConvId}`);
 
   const body = {
     text:           "",
@@ -250,8 +247,7 @@ async function handleMedia(msg, phone, fromLid, mediaType) {
     media_type:     mediaType,
     media_filename: media.filename || null,
   };
-  if (phone)   body.from_number = phone;
-  if (fromLid) body.from_lid    = fromLid;
+  if (phone) body.from_number = phone;
 
   const res = await fetch(`${CORE_URL}/wa/inbound`, {
     method: "POST",
@@ -266,21 +262,19 @@ async function handleMedia(msg, phone, fromLid, mediaType) {
   }
 
   const data = await res.json();
-  _updatePendingState(sender, data);
-  await _sendResponse(msg, phone, fromLid, data);
+  _updatePendingState(phone, data);
+  await _sendResponse(msg, phone, data);
 }
 
-async function handleAudio(msg, phone, fromLid) {
+async function handleAudio(msg, phone) {
   const media = await msg.downloadMedia();
   if (!media) {
-    console.error(`[WA] No se pudo descargar el audio de ${phone || fromLid}`);
+    console.error(`[WA] No se pudo descargar el audio de ${phone}`);
     return;
   }
 
   const body = { audio_b64: media.data, message_id: msg.id.id };
-  if (phone)   body.from_number = phone;
-  if (fromLid) body.from_lid    = fromLid;
-
+  if (phone) body.from_number = phone;
   const res = await fetch(`${CORE_URL}/wa/inbound/audio`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -294,7 +288,7 @@ async function handleAudio(msg, phone, fromLid) {
   }
 
   const data = await res.json();
-  console.log(`[WA] STT ${phone || fromLid}: "${data.transcription}"`);
+  console.log(`[WA] STT ${phone}: "${data.transcription}"`);
 
   if (data.audio_b64) {
     const voiceNote = new MessageMedia(
@@ -304,10 +298,10 @@ async function handleAudio(msg, phone, fromLid) {
     );
     const chat = await msg.getChat();
     await chat.sendMessage(voiceNote, { sendAudioAsVoice: true });
-    console.log(`[WA] → ${phone || fromLid}: [nota de voz] ${data.response.slice(0, 60)}`);
+    console.log(`[WA] → ${phone}: [nota de voz] ${data.response.slice(0, 60)}`);
   } else if (data.response) {
     await msg.reply(data.response);
-    console.log(`[WA] → ${phone || fromLid}: ${data.response.slice(0, 80)}`);
+    console.log(`[WA] → ${phone}: ${data.response.slice(0, 80)}`);
   }
 }
 
@@ -316,10 +310,7 @@ async function handleAudio(msg, phone, fromLid) {
 client.on("message", async (msg) => {
   if (msg.isGroupMsg) return;
 
-  // msg.from puede ser "5491155...@c.us" o "205432...@lid" (linked identity, WA moderno).
-  // Estrategia: getChat() → contact.id → msg.from (en ese orden de confiabilidad).
   let phone = null;
-  let fromLid = null;
 
   try {
     const chat  = await msg.getChat();
@@ -328,40 +319,30 @@ client.on("message", async (msg) => {
     if (chatId.endsWith("@c.us")) {
       phone = "+" + chat.id.user;
     } else {
-      // Chat también en @lid — extraer LID para match en el core
-      if (chatId.endsWith("@lid")) fromLid = chat.id.user;
-
-      // Intentar vía contacto
+      // Intentar vía contacto para obtener número real
       const contact = await msg.getContact();
       if (contact.id._serialized.endsWith("@c.us")) {
         phone = "+" + contact.id.user;
-      } else if (contact.id._serialized.endsWith("@lid")) {
-        fromLid = fromLid || contact.id.user;
       }
     }
   } catch (_) {
-    // noop — usamos fromLid o fallback
+    // noop
   }
 
-  if (!phone && !fromLid) {
-    // Último recurso: extraer lo que sea del from
-    fromLid = msg.from.replace(/@\S+/, "");
-  }
-
-  console.log(`[WA] from=${msg.from} → phone=${phone} lid=${fromLid}`);
+  console.log(`[WA] from=${msg.from} → phone=${phone}`);
 
   try {
     if (msg.type === "chat") {
       const text = msg.body.trim();
       if (!text) return;
-      console.log(`[WA] texto ${phone || fromLid}: ${text}`);
-      await handleText(msg, phone, fromLid, text);
+      console.log(`[WA] texto ${phone}: ${text}`);
+      await handleText(msg, phone, text);
     } else if (msg.type === "ptt" || msg.type === "audio") {
-      console.log(`[WA] audio ${phone || fromLid} (${msg.type})`);
-      await handleAudio(msg, phone, fromLid);
+      console.log(`[WA] audio ${phone} (${msg.type})`);
+      await handleAudio(msg, phone);
     } else if (msg.type === "image" || msg.type === "document") {
-      console.log(`[WA] media ${msg.type} ${phone || fromLid}`);
-      await handleMedia(msg, phone, fromLid, msg.type);
+      console.log(`[WA] media ${msg.type} ${phone}`);
+      await handleMedia(msg, phone, msg.type);
     }
   } catch (err) {
     console.error(`[WA] Error inesperado: ${err.message}`);


### PR DESCRIPTION
## Summary

- Agentes con nombre de fantasía visible en lista, detalle y formularios del backoffice
- Formularios de creación/edición de agentes incluyen campo `fancy_name` (genera automático si vacío)
- Eliminado campo `wa_lid` de formulario y vista de usuario
- `wa/index.js`: eliminada toda la lógica `@lid`/`fromLid` — solo se usa `from_number`
- Actualiza submodule `core` al PR #121 (fancy names + wa_lid removal)

## Test plan
- [ ] Lista `/agents` muestra nombre de fantasía en cursiva junto al nombre
- [ ] Formulario de nuevo agente permite ingresar `fancy_name` (o dejarlo vacío para auto-generar)
- [ ] Vista de detalle de agente muestra fancy_name en header
- [ ] Formulario de usuario ya no tiene campo WhatsApp LID
- [ ] Bot WA sigue funcionando con contactos @c.us normales

🤖 Generated with [Claude Code](https://claude.com/claude-code)