### PR TITLE
feat: fase 22.10 — backoffice Goals y tipado de intents

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -674,6 +674,56 @@ def delete_intent_proxy(uid: str, intent_id: str):
     return HTMLResponse("")
 
 
+@app.post("/users/{uid}/intents/{intent_id}/capture", response_class=HTMLResponse)
+async def capture_intent_proxy(uid: str, intent_id: str, request: Request):
+    """Captura manual de respuesta para un request intent (22.10)."""
+    ct = request.headers.get("content-type", "")
+    if "application/json" in ct:
+        body = await request.json()
+    else:
+        form = await request.form()
+        body = dict(form)
+    reply = body.get("reply", "").strip()
+    if reply:
+        _core(f"/users/{uid}/intents/{intent_id}/capture", method="POST", json={"reply": reply})
+    row_id = f"intent-row-{intent_id}"
+    return HTMLResponse(
+        f'<div id="{row_id}" class="px-4 py-3 text-xs text-orange-400 bg-orange-950/30 border border-orange-900/40 rounded-xl">'
+        f'✓ Respuesta capturada'
+        f'<script>setTimeout(()=>document.getElementById("{row_id}")?.remove(),2000)</script>'
+        f'</div>'
+    )
+
+
+# ── Goals (22.10) ─────────────────────────────────────────────────────────────
+
+@app.get("/goals", response_class=HTMLResponse)
+def goals_page(request: Request):
+    users_data  = _core("/users") or {}
+    agents_data = _core("/agents", timeout=10) or {}
+    all_goals   = _core("/goals") or []
+    return _render(request, "goals.html", "goals",
+                   goals=all_goals, users=users_data, agents=agents_data)
+
+
+@app.post("/goals/{uid}/{goal_id}/transition", response_class=HTMLResponse)
+async def transition_goal_proxy(uid: str, goal_id: str, request: Request):
+    ct = request.headers.get("content-type", "")
+    if "application/json" in ct:
+        body = await request.json()
+    else:
+        form = await request.form()
+        body = dict(form)
+    _core(f"/users/{uid}/goals/{goal_id}/transition", method="POST", json=body)
+    return HTMLResponse("")
+
+
+@app.delete("/goals/{uid}/{goal_id}", response_class=HTMLResponse)
+def delete_goal_proxy(uid: str, goal_id: str):
+    _core(f"/users/{uid}/goals/{goal_id}", method="DELETE")
+    return HTMLResponse("")
+
+
 @app.post("/users/{uid}/intents/{intent_id}/respond", response_class=HTMLResponse)
 async def respond_intent_proxy(uid: str, intent_id: str, request: Request):
     ct = request.headers.get("content-type", "")

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -65,6 +65,7 @@
         <p class="sb-section px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-600">Sistema</p>
         <a href="/agents"       title="Agentes"        class="{{ link_active if section == 'agents'       else link_base }}"><span>🤖</span><span class="sb-text">Agentes</span></a>
         <a href="/intents"      title="Intenciones"    class="{{ link_active if section == 'intents'      else link_base }}"><span>🎯</span><span class="sb-text">Intenciones</span></a>
+        <a href="/goals"        title="Goals"          class="{{ link_active if section == 'goals'        else link_base }}"><span>🏆</span><span class="sb-text">Goals</span></a>
         <a href="/conversations"title="Conversaciones" class="{{ link_active if section == 'conversations'else link_base }}"><span>💬</span><span class="sb-text">Conversaciones</span></a>
         <a href="/shared-state" title="Shared State"   class="{{ link_active if section == 'shared-state' else link_base }}"><span>🔗</span><span class="sb-text">Shared State</span></a>
         <a href="/plan"         title="Plan"           class="{{ link_active if section == 'plan'         else link_base }}"><span>🗺️</span><span class="sb-text">Plan</span></a>

--- a/backoffice/templates/goals.html
+++ b/backoffice/templates/goals.html
@@ -1,0 +1,163 @@
+{% extends "base.html" %}
+{% block title %}Goals{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold">Goals activos</h1>
+    <p class="text-xs text-gray-500 mt-1">
+      Objetivos cross-agente descubiertos proactivamente — árbol de sub-goals, colaboración multi-agente.
+    </p>
+  </div>
+  <div class="flex items-center gap-3">
+    <a href="/intents" class="text-xs text-gray-500 hover:text-gray-400 transition-colors">← Intenciones</a>
+    <span class="text-xs text-gray-600">{{ goals | length }} goal{{ 's' if goals | length != 1 }}</span>
+  </div>
+</div>
+
+{% if not goals %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-8 text-center">
+  <div class="text-4xl mb-3">🎯</div>
+  <p class="text-gray-400 text-sm">No hay goals activos.</p>
+  <p class="text-gray-600 text-xs mt-1">
+    Los agentes crean goals cuando detectan intenciones reales del usuario que requieren múltiples pasos.
+  </p>
+</div>
+{% else %}
+
+{% set status_colors = {
+  'discovered':  'bg-indigo-900/40 text-indigo-400 border-indigo-800/50',
+  'planning':    'bg-yellow-900/40 text-yellow-400 border-yellow-800/50',
+  'in_progress': 'bg-blue-900/40 text-blue-400 border-blue-800/50',
+  'completed':   'bg-emerald-900/40 text-emerald-400 border-emerald-800/50',
+  'abandoned':   'bg-gray-800 text-gray-500 border-gray-700/50',
+  'blocked':     'bg-red-900/40 text-red-400 border-red-800/50',
+} %}
+{% set status_labels = {
+  'discovered':  'descubierto',
+  'planning':    'planificando',
+  'in_progress': 'en curso',
+  'completed':   'completado',
+  'abandoned':   'abandonado',
+  'blocked':     'bloqueado',
+} %}
+{% set next_statuses = {
+  'discovered':  [['planning', 'planificar'], ['abandoned', 'abandonar']],
+  'planning':    [['in_progress', 'iniciar'], ['abandoned', 'abandonar']],
+  'in_progress': [['completed', 'completar'], ['blocked', 'bloquear'], ['abandoned', 'abandonar']],
+  'blocked':     [['in_progress', 'reintentar'], ['abandoned', 'abandonar']],
+} %}
+
+<div class="space-y-4">
+{% for goal in goals %}
+{% set scolor = status_colors.get(goal.status, 'bg-gray-800 text-gray-400 border-gray-700') %}
+{% set slabel = status_labels.get(goal.status, goal.status) %}
+{% set user_info = users.get(goal.user_id, {}) %}
+{% set days_old = ((now - goal.updated_at) / 86400) | round(0, 'floor') | int %}
+{% set transitions = next_statuses.get(goal.status, []) %}
+{% set notes = goal.get('notes', []) %}
+{% set is_root = not goal.get('parent_id') %}
+
+<div class="bg-gray-900 border {% if goal.status == 'blocked' %}border-red-800/50{% else %}border-gray-800{% endif %} rounded-xl p-4"
+     id="goal-row-{{ goal.intent_id }}">
+
+  <div class="flex items-start gap-3">
+    <!-- Indicador de root/child -->
+    <div class="text-xl shrink-0 pt-0.5">{{ '🎯' if is_root else '↳' }}</div>
+
+    <!-- Contenido principal -->
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2 flex-wrap mb-1">
+        <span class="text-sm font-semibold text-gray-100">{{ goal.title }}</span>
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-medium border {{ scolor }}">
+          {{ slabel }}
+        </span>
+        {% if goal.get('child_ids') %}
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-800 text-gray-400 border border-gray-700">
+          {{ goal.child_ids | length }} sub-goal{{ 's' if goal.child_ids | length != 1 }}
+        </span>
+        {% endif %}
+      </div>
+
+      {% if goal.description %}
+      <p class="text-xs text-gray-400 mb-2">{{ goal.description }}</p>
+      {% endif %}
+
+      <!-- Colaboradores -->
+      {% set collabs = goal.get('collaborating_agents', []) %}
+      {% if collabs %}
+      <div class="flex flex-wrap gap-1 mb-2">
+        {% for aid in collabs %}
+        {% set ainfo = agents.get(aid, {}) %}
+        <span class="text-[10px] bg-gray-800 text-gray-400 px-2 py-0.5 rounded border border-gray-700/50">
+          {{ ainfo.get('icon', '🤖') }} {{ ainfo.get('name', aid) }}
+        </span>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      <!-- Notas (últimas 3) -->
+      {% if notes %}
+      <div class="mb-2 space-y-1">
+        {% for note in notes[-3:] %}
+        {% set nainfo = agents.get(note.agent_id, {}) %}
+        <div class="flex items-start gap-2 text-[10px] text-gray-500">
+          <span class="shrink-0">{{ nainfo.get('icon', '·') }}</span>
+          <span class="text-gray-400">{{ note.text }}</span>
+        </div>
+        {% endfor %}
+        {% if notes | length > 3 %}
+        <span class="text-[10px] text-gray-600">+ {{ notes | length - 3 }} nota{{ 's' if notes | length - 3 != 1 }} más</span>
+        {% endif %}
+      </div>
+      {% endif %}
+
+      <div class="flex items-center gap-3 text-[10px] text-gray-600">
+        <span>descubierto por {{ agents.get(goal.discovered_by, {}).get('name', goal.discovered_by) }}</span>
+        <span>·</span>
+        <a href="/users/{{ goal.user_id }}/edit" class="hover:text-gray-400 transition-colors">
+          {{ user_info.get('name', goal.user_id) }}
+        </a>
+        <span>·</span>
+        <span>actualizado hace {{ days_old }}d</span>
+      </div>
+    </div>
+
+    <!-- Acciones de transición -->
+    <div class="shrink-0 flex flex-col gap-1.5 items-end">
+      {% for new_status, label in transitions %}
+      <button
+        hx-post="/goals/{{ goal.user_id }}/{{ goal.intent_id }}/transition"
+        hx-vals='{"new_status": "{{ new_status }}", "agent_id": "backoffice"}'
+        hx-target="#goal-row-{{ goal.intent_id }}"
+        hx-swap="outerHTML"
+        hx-headers='{"Content-Type": "application/json"}'
+        class="px-2 py-1 text-xs rounded transition-colors border whitespace-nowrap
+               {% if new_status == 'abandoned' %}
+               text-gray-600 hover:text-red-400 hover:bg-red-900/20 border-gray-700/50
+               {% elif new_status == 'completed' %}
+               text-emerald-400 hover:text-emerald-300 hover:bg-emerald-900/20 border-emerald-800/50
+               {% elif new_status == 'blocked' %}
+               text-red-400 hover:text-red-300 hover:bg-red-900/20 border-red-800/50
+               {% else %}
+               text-blue-400 hover:text-blue-300 hover:bg-blue-900/20 border-blue-800/50
+               {% endif %}">
+        {{ label }}
+      </button>
+      {% endfor %}
+      <button
+        hx-delete="/goals/{{ goal.user_id }}/{{ goal.intent_id }}"
+        hx-target="#goal-row-{{ goal.intent_id }}"
+        hx-swap="outerHTML"
+        hx-confirm="¿Eliminar este goal?"
+        class="px-2 py-1 text-xs text-gray-600 hover:text-red-400 hover:bg-red-900/20
+               rounded transition-colors">
+        ✕
+      </button>
+    </div>
+  </div>
+</div>
+{% endfor %}
+</div>
+{% endif %}
+{% endblock %}

--- a/backoffice/templates/intents.html
+++ b/backoffice/templates/intents.html
@@ -6,10 +6,13 @@
   <div>
     <h1 class="text-2xl font-bold">Intenciones activas</h1>
     <p class="text-xs text-gray-500 mt-1">
-      Acciones pendientes detectadas por los agentes — persisten entre sesiones y pueden disparar recordatorios.
+      Advise (notificaciones TTL) y Request (preguntas al usuario) — los Goals tienen su propia vista.
     </p>
   </div>
-  <span class="text-xs text-gray-600">{{ intents | length }} activa{{ 's' if intents | length != 1 }}</span>
+  <div class="flex items-center gap-3">
+    <a href="/goals" class="text-xs text-cyan-400 hover:text-cyan-300 transition-colors">Ver Goals →</a>
+    <span class="text-xs text-gray-600">{{ intents | length }} activa{{ 's' if intents | length != 1 }}</span>
+  </div>
 </div>
 
 {% if not intents %}
@@ -23,25 +26,44 @@
 {% else %}
 
 {% set status_colors = {
+  'active':      'bg-purple-900/40 text-purple-400 border-purple-800/50',
   'pending':     'bg-yellow-900/40 text-yellow-400 border-yellow-800/50',
   'in_progress': 'bg-blue-900/40 text-blue-400 border-blue-800/50',
+  'succeeded':   'bg-emerald-900/40 text-emerald-400 border-emerald-800/50',
   'done':        'bg-emerald-900/40 text-emerald-400 border-emerald-800/50',
+  'acknowledged':'bg-gray-800 text-gray-500 border-gray-700/50',
   'cancelled':   'bg-gray-800 text-gray-500 border-gray-700/50',
+  'expired':     'bg-gray-800 text-gray-500 border-gray-700/50',
 } %}
 {% set status_labels = {
-  'pending':     'pendiente',
+  'active':      'activa',
+  'pending':     'esperando respuesta',
   'in_progress': 'en curso',
+  'succeeded':   'respondida',
   'done':        'completada',
+  'acknowledged':'vista',
   'cancelled':   'cancelada',
+  'expired':     'expirada',
+} %}
+{% set type_colors = {
+  'advise':  'bg-purple-900/30 text-purple-300 border-purple-700/30',
+  'request': 'bg-orange-900/30 text-orange-300 border-orange-700/30',
+} %}
+{% set type_labels = {
+  'advise':  'aviso',
+  'request': 'request',
 } %}
 
 <div class="space-y-3">
 {% for intent in intents %}
-{% set agent_info  = agents.get(intent.agent_id, {}) %}
-{% set user_info   = users.get(intent.user_id, {}) %}
-{% set scolor      = status_colors.get(intent.status, 'bg-gray-800 text-gray-400 border-gray-700') %}
-{% set slabel      = status_labels.get(intent.status, intent.status) %}
-{% set days_old    = ((now - intent.updated_at) / 86400) | round(0, 'floor') | int %}
+{% set agent_info = agents.get(intent.agent_id, {}) %}
+{% set user_info  = users.get(intent.user_id, {}) %}
+{% set scolor     = status_colors.get(intent.status, 'bg-gray-800 text-gray-400 border-gray-700') %}
+{% set slabel     = status_labels.get(intent.status, intent.status) %}
+{% set itype      = intent.get('intent_type', 'advise') %}
+{% set tcolor     = type_colors.get(itype, 'bg-gray-800/30 text-gray-400 border-gray-700/30') %}
+{% set tlabel     = type_labels.get(itype, itype) %}
+{% set days_old   = ((now - intent.updated_at) / 86400) | round(0, 'floor') | int %}
 
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-4
             hover:border-gray-700 transition-colors"
@@ -55,6 +77,11 @@
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2 flex-wrap mb-1">
         <span class="text-sm font-semibold text-gray-100">{{ intent.title }}</span>
+        <!-- Badge tipo -->
+        <span class="px-2 py-0.5 rounded-full text-[10px] font-medium border {{ tcolor }}">
+          {{ tlabel }}
+        </span>
+        <!-- Badge estado -->
         <span class="px-2 py-0.5 rounded-full text-[10px] font-medium border {{ scolor }}">
           {{ slabel }}
         </span>
@@ -62,6 +89,20 @@
 
       {% if intent.description %}
       <p class="text-xs text-gray-400 mb-2">{{ intent.description }}</p>
+      {% endif %}
+
+      <!-- Question (request intent) -->
+      {% if itype == 'request' and intent.get('question') %}
+      <div class="mb-2 px-2 py-1.5 bg-orange-900/20 border border-orange-800/30 rounded text-xs text-orange-300">
+        ❓ {{ intent.question }}
+      </div>
+      {% endif %}
+
+      <!-- Respuesta capturada (request succeeded) -->
+      {% if intent.get('captured_reply') %}
+      <div class="mb-2 px-2 py-1.5 bg-emerald-900/20 border border-emerald-800/30 rounded text-xs text-emerald-300">
+        Respuesta: {{ intent.captured_reply }}
+      </div>
       {% endif %}
 
       {% if intent.context %}
@@ -82,7 +123,7 @@
         </a>
         <span>·</span>
         <span>actualizado hace {{ days_old }}d</span>
-        {% if intent.remind_after_days %}
+        {% if intent.remind_after_days and itype != 'advise' %}
         <span>·</span>
         <span>recordatorio cada {{ intent.remind_after_days }}d</span>
         {% endif %}
@@ -91,28 +132,40 @@
 
     <!-- Acciones -->
     <div class="shrink-0 flex gap-2 items-start">
-      {% if intent.status in ['pending', 'in_progress'] %}
-        {% set req_field = intent.context.get('required_field') if intent.context else None %}
-        {% if req_field %}
+      {% if itype == 'advise' and intent.status == 'active' %}
+        <!-- Advise: botón de ack -->
+        <button
+          hx-patch="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}"
+          hx-vals='{"status": "acknowledged"}'
+          hx-target="#intent-row-{{ intent.intent_id }}"
+          hx-swap="outerHTML"
+          hx-headers='{"Content-Type": "application/json"}'
+          title="Marcar como visto"
+          class="px-2 py-1 text-xs text-purple-400 hover:text-purple-300 hover:bg-purple-900/20
+                 rounded transition-colors border border-purple-800/50">
+          ✓ visto
+        </button>
+      {% elif itype == 'request' and intent.status == 'pending' %}
+        <!-- Request: form de captura manual -->
         <form
-          hx-post="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}/respond"
+          hx-post="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}/capture"
           hx-target="#intent-row-{{ intent.intent_id }}"
           hx-swap="outerHTML"
           class="flex gap-1 items-center">
           <input
             type="text"
-            name="value"
+            name="reply"
             required
-            placeholder="{{ intent.context.get('required_field_placeholder', '') }}"
+            placeholder="Respuesta..."
             class="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200
-                   placeholder-gray-600 focus:outline-none focus:border-emerald-600 w-44">
+                   placeholder-gray-600 focus:outline-none focus:border-orange-600 w-36">
           <button type="submit"
-            class="px-2 py-1 text-xs text-emerald-400 hover:text-emerald-300 hover:bg-emerald-900/20
-                   rounded transition-colors border border-emerald-800/50 whitespace-nowrap">
-            ✓ guardar
+            class="px-2 py-1 text-xs text-orange-400 hover:text-orange-300 hover:bg-orange-900/20
+                   rounded transition-colors border border-orange-800/50 whitespace-nowrap">
+            ✓ capturar
           </button>
         </form>
-        {% else %}
+      {% elif intent.status in ['pending', 'in_progress'] %}
         <button
           hx-patch="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}"
           hx-vals='{"status": "done"}'
@@ -124,7 +177,6 @@
                  rounded transition-colors border border-emerald-800/50">
           ✓ completar
         </button>
-        {% endif %}
       {% endif %}
       <button
         hx-delete="/users/{{ intent.user_id }}/intents/{{ intent.intent_id }}"


### PR DESCRIPTION
## Summary
- **intents.html**: badge de tipo (advise=morado, request=naranja) + badge de estado. Advise activo → botón 'visto'. Request pendiente → form de captura manual con reply. Muestra `captured_reply` si está respondido. Link a /goals.
- **goals.html** (nuevo): lista de goals activos con status badge, sub-goals count, colaboradores, últimas 3 notas, botones de transición según estado (validados por la máquina de estados).
- **base.html**: link Goals en sidebar.
- **server.py**: rutas para goals y para `capture` de request intents. Proxy a `/goals` de core.

## Test plan
- [ ] `/intents` muestra badges de tipo diferenciados
- [ ] Intent advise activo → botón 'visto' → desaparece
- [ ] Intent request pendiente → form captura → muestra `captured_reply`
- [ ] `/goals` muestra goals activos con botones de transición
- [ ] Transición inválida (ej: discovered → completed) → core retorna 400, UI no explota

🤖 Generated with [Claude Code](https://claude.com/claude-code)