### PR TITLE
feat: 20.14 — backoffice OAuth fallback por short_code

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -646,6 +646,70 @@ async def oauth_disconnect(request: Request, service: str):
     return RedirectResponse(f"/agents/{agent_id}/edit", status_code=303)
 
 
+@app.post("/auth/{service}/fetch-shortcode")
+async def oauth_fetch_shortcode(request: Request, service: str):
+    """Recupera el token del oauth app por short_code y lo persiste localmente."""
+    if service not in _OAUTH_SERVICES:
+        raise HTTPException(status_code=404)
+    if not OAUTH_APP_URL:
+        raise HTTPException(status_code=503, detail="OAUTH_APP_URL no configurado")
+    form = await request.form()
+    short_code = str(form.get("short_code", "")).strip()
+    user_id    = str(form.get("user_id", "")).strip()
+    agent_id   = str(form.get("agent_id", "")).strip()
+    if not short_code or not user_id:
+        raise HTTPException(status_code=400, detail="short_code y user_id son requeridos")
+    try:
+        r = requests.get(f"{OAUTH_APP_URL}/tokens/{short_code}", timeout=10)
+        if r.status_code == 404:
+            raise HTTPException(status_code=404, detail="Token no encontrado o expirado (TTL 5 min)")
+        r.raise_for_status()
+        data = r.json()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Error al contactar oauth app: {exc}")
+    import datetime as _dt3
+    token_data = {
+        "access_token":  data.get("access_token", ""),
+        "refresh_token": data.get("refresh_token", ""),
+        "expires_in":    data.get("expires_in", 21600),
+        "expires_at":    time.time() + data.get("expires_in", 21600),
+        "user_id":       data.get("api_user_id", ""),
+        "saved_at":      _dt3.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    _CAPITAN_DIR.mkdir(parents=True, exist_ok=True)
+    _oauth_token_path(service, user_id).write_text(json.dumps(token_data, indent=2))
+    redirect = f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents"
+    return RedirectResponse(redirect, status_code=303)
+
+
+@app.post("/auth/{service}/set-token")
+async def oauth_set_token(request: Request, service: str):
+    """Configura tokens OAuth manualmente, como fallback al circuito WA."""
+    if service not in _OAUTH_SERVICES:
+        raise HTTPException(status_code=404)
+    form = await request.form()
+    user_id       = str(form.get("user_id", "")).strip()
+    agent_id      = str(form.get("agent_id", "")).strip()
+    access_token  = str(form.get("access_token", "")).strip()
+    refresh_token = str(form.get("refresh_token", "")).strip()
+    if not user_id or not access_token:
+        raise HTTPException(status_code=400, detail="user_id y access_token son requeridos")
+    import datetime as _dt2
+    token_data = {
+        "access_token":  access_token,
+        "refresh_token": refresh_token,
+        "expires_in":    21600,
+        "expires_at":    time.time() + 21600,
+        "saved_at":      _dt2.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    _CAPITAN_DIR.mkdir(parents=True, exist_ok=True)
+    _oauth_token_path(service, user_id).write_text(json.dumps(token_data, indent=2))
+    redirect = f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents"
+    return RedirectResponse(redirect, status_code=303)
+
+
 @app.get("/intents", response_class=HTMLResponse)
 def intents_page(request: Request):
     """Vista de primer nivel: todas las intenciones activas de todos los usuarios."""

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -162,7 +162,7 @@
           {% if users %}
             {% for uid, user in users.items() %}
             {% set st = oauth_statuses.get(svc, {}).get(uid, {}) %}
-            <div class="py-3 border-t border-gray-800 first:border-0">
+            <div class="oauth-user-row py-3 border-t border-gray-800 first:border-0">
               <div class="flex items-center justify-between mb-2">
                 <span class="text-xs text-gray-400">{{ user.name }}</span>
                 {% if st.online %}
@@ -178,13 +178,23 @@
                   {% if st.api_user_id %}ID: <code class="text-gray-500">{{ st.api_user_id }}</code> · {% endif %}
                   guardado {{ st.saved_at[:10] if st.saved_at else '' }}
                 </div>
-                <form method="POST" action="/auth/{{ svc }}/disconnect" class="inline">
-                  <input type="hidden" name="user_id" value="{{ uid }}">
-                  <input type="hidden" name="agent_id" value="{{ agent_id }}">
-                  <button type="submit" class="text-xs text-red-400 hover:text-red-300 transition-colors">
-                    Desconectar
+                <div class="flex items-center gap-3 flex-wrap">
+                  <form method="POST" action="/auth/{{ svc }}/disconnect" class="inline">
+                    <input type="hidden" name="user_id" value="{{ uid }}">
+                    <input type="hidden" name="agent_id" value="{{ agent_id }}">
+                    <button type="submit" class="text-xs text-red-400 hover:text-red-300 transition-colors">
+                      Desconectar
+                    </button>
+                  </form>
+                  <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.add('hidden')"
+                          class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
+                    Recuperar por short_code
                   </button>
-                </form>
+                  <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.add('hidden')"
+                          class="text-xs text-gray-500 hover:text-gray-300 transition-colors">
+                    Actualizar manualmente
+                  </button>
+                </div>
               {% else %}
                 {% if oauth_app_url %}
                   <a href="{{ oauth_app_url }}/auth/{{ svc }}/login?user_id={{ uid }}&agent_id={{ agent_id }}"
@@ -196,7 +206,70 @@
                 {% else %}
                   <span class="text-xs text-gray-600">Configurar OAUTH_APP_URL en backoffice/.env</span>
                 {% endif %}
+                <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.add('hidden')"
+                        class="ml-2 text-xs text-indigo-400 hover:text-indigo-300 transition-colors underline">
+                  Recuperar por short_code
+                </button>
+                <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.add('hidden')"
+                        class="ml-2 text-xs text-gray-500 hover:text-gray-300 transition-colors underline">
+                  Configurar manualmente
+                </button>
               {% endif %}
+              <!-- Formulario de recuperación por short_code -->
+              <form method="POST" action="/auth/{{ svc }}/fetch-shortcode"
+                    class="shortcode-form hidden mt-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3 space-y-2">
+                <input type="hidden" name="user_id" value="{{ uid }}">
+                <input type="hidden" name="agent_id" value="{{ agent_id }}">
+                <p class="text-xs text-gray-500 mb-1">Pegá el <code class="text-gray-400">short_code</code> del log o de la pantalla de confirmación ML:</p>
+                <div>
+                  <label class="block text-xs text-gray-400 mb-0.5">short_code</label>
+                  <input type="text" name="short_code" required placeholder="uu9Fj..."
+                         class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1
+                                text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
+                </div>
+                <p class="text-xs text-gray-600">El short_code expira a los 5 minutos de completar la autorización ML.</p>
+                <div class="flex gap-2 pt-1">
+                  <button type="submit"
+                          class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded transition-colors">
+                    Recuperar token
+                  </button>
+                  <button type="button"
+                          onclick="this.closest('.shortcode-form').classList.add('hidden')"
+                          class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs rounded transition-colors">
+                    Cancelar
+                  </button>
+                </div>
+              </form>
+              <!-- Formulario de configuración manual de tokens -->
+              <form method="POST" action="/auth/{{ svc }}/set-token"
+                    class="manual-token-form hidden mt-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3 space-y-2">
+                <input type="hidden" name="user_id" value="{{ uid }}">
+                <input type="hidden" name="agent_id" value="{{ agent_id }}">
+                <p class="text-xs text-gray-500 mb-1">Pegá los tokens obtenidos del flujo OAuth:</p>
+                <div>
+                  <label class="block text-xs text-gray-400 mb-0.5">access_token</label>
+                  <input type="text" name="access_token" required placeholder="eyJ..."
+                         class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1
+                                text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
+                </div>
+                <div>
+                  <label class="block text-xs text-gray-400 mb-0.5">refresh_token <span class="text-gray-600">(opcional)</span></label>
+                  <input type="text" name="refresh_token" placeholder="TG-..."
+                         class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1
+                                text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
+                </div>
+                <div class="flex gap-2 pt-1">
+                  <button type="submit"
+                          class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded transition-colors">
+                    Guardar tokens
+                  </button>
+                  <button type="button"
+                          onclick="this.closest('.manual-token-form').classList.add('hidden')"
+                          class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs rounded transition-colors">
+                    Cancelar
+                  </button>
+                </div>
+              </form>
             </div>
             {% endfor %}
           {% else %}

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -1526,6 +1526,21 @@ Site:     MLU (Uruguay) por defecto; configurable via ML_SITE en .env (MLA, MLB,
             `add_to_wishlist(item_id)` — guardar ítem desde el flujo conversacional.
             Si el usuario no autenticó, operaciones degradan a modo público con aviso.
 
+- [x] 20.13 **oauth-app Cloud Run** — migración del servidor OAuth temporal (local :8766) a
+            servicio permanente en `capitan.blasi.ar` (repo `home-agents-oauth`). App FastAPI que
+            gestiona flujos ML y MP: recibe callback, intercambia code por tokens, guarda
+            temporalmente con `short_code` (TTL 5 min), notifica al bot via WA Cloud API.
+            Estado: elimina el servidor temporal en core; oauth-app es el punto de entrada público.
+
+- [x] 20.14 **Backoffice: fallback de token por short_code** — cuando WA falla (ej: token 401),
+            el token queda disponible en el oauth app por `GET /tokens/{short_code}`.
+            Nuevo endpoint `POST /auth/{service}/fetch-shortcode` en `backoffice/server.py`:
+            llama al oauth app y persiste el token en `~/.local/share/capitan/{svc}_token_{uid}.json`.
+            UI en `agent_edit.html`: botón "Recuperar por short_code" (indigo) en la sección OAuth2
+            de cada usuario del agente; los dos formularios (short_code y manual) se muestran
+            exclusivos entre sí. El short_code aparece en los logs del oauth app y en la página de
+            confirmación de ML.
+
 Estado:   COMPLETA
 
 ---


### PR DESCRIPTION
## Summary

- Nuevo endpoint `POST /auth/{service}/fetch-shortcode` en `backoffice/server.py`: cuando WA falla (401 u otras causas), el token queda accesible por `GET /tokens/{short_code}` en el oauth app; el backoffice lo recupera y persiste localmente
- UI en `agent_edit.html`: botón "Recuperar por short_code" (indigo) en la sección OAuth2 de cada usuario; los formularios de short_code y tokens manuales son mutuamente exclusivos
- `estado.md`: agrega tareas 20.13 (oauth-app Cloud Run) y 20.14 (este fallback); FASE 20 sigue COMPLETA

## Test plan

- [ ] Iniciar flujo OAuth ML → completar autorización en browser → verificar que WA falla con 401 → copiar `short_code` del log del oauth app
- [ ] En backoffice → agente ML → usuario → "Recuperar por short_code" → pegar el short_code → "Recuperar token" → verifica redirect con `?connected=1`
- [ ] Verificar que `~/.local/share/capitan/ml_token_{uid}.json` fue creado con access_token correcto
- [ ] Verificar que si el short_code expiró (>5 min), devuelve error 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)