### PR TITLE
feat: backoffice — estado parcial para health check OAuth2 por usuario

### DIFF
--- a/backoffice/templates/agent_detail.html
+++ b/backoffice/templates/agent_detail.html
@@ -108,6 +108,8 @@
         <span class="text-sm text-gray-400">Conectividad</span>
         {% if agent.reachable is none %}
           <span class="text-gray-600 text-xs">sin health check</span>
+        {% elif agent.reachable == "partial" %}
+          <span class="flex items-center gap-1.5 text-amber-400 text-sm">● parcialmente accesible</span>
         {% elif agent.reachable %}
           <span class="flex items-center gap-1.5 text-emerald-400 text-sm">● accesible</span>
         {% else %}
@@ -142,6 +144,8 @@
                   {% endif %}
                   {% if b.reachable is none %}
                     <span class="text-xs text-gray-600">sin check</span>
+                  {% elif b.reachable == "partial" %}
+                    <span class="flex items-center gap-1 text-xs text-amber-400">● parcial</span>
                   {% elif b.reachable %}
                     <span class="flex items-center gap-1 text-xs text-emerald-400">● online</span>
                   {% else %}
@@ -150,6 +154,11 @@
                 </div>
               </div>
               <div class="text-xs text-gray-600 mt-0.5">{{ meta.name }}</div>
+              {% if b.reachable == "partial" and b.users_fail is defined %}
+                <div class="text-xs text-amber-600 mt-1">
+                  Sin token: {{ b.users_fail | join(", ") }}
+                </div>
+              {% endif %}
               {% if b.model %}
                 <code class="text-xs bg-gray-800 text-indigo-300 px-1.5 py-0.5 rounded mt-1 inline-block">
                   {{ b.model }}

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -73,7 +73,10 @@
     {% if agent.reachable is not none %}
     <p class="mt-3 text-xs text-gray-600">
       Conectividad:
-      {% if agent.reachable %}
+      {% if agent.reachable == "partial" %}
+        <span class="text-amber-400">● parcialmente accesible</span>
+        — algunos usuarios no tienen token OAuth
+      {% elif agent.reachable %}
         <span class="text-emerald-400">● accesible</span>
       {% else %}
         <span class="text-red-400">● no accesible</span>

--- a/backoffice/templates/agents.html
+++ b/backoffice/templates/agents.html
@@ -84,6 +84,8 @@
         <td class="px-4 py-3 text-center">
           {% if info.reachable is none %}
             <span class="text-gray-600 text-xs">—</span>
+          {% elif info.reachable == "partial" %}
+            <span title="Parcialmente accesible" class="text-amber-400">●</span>
           {% elif info.reachable %}
             <span title="Accesible" class="text-emerald-400">●</span>
           {% else %}


### PR DESCRIPTION
## Summary

- `agents.html`: dot ámbar con title "Parcialmente accesible" para `reachable == "partial"`
- `agent_detail.html`: badge "● parcial" en amber para cada backend, más lista de usuarios sin token (`users_fail`) debajo del badge
- `agent_edit.html`: texto "parcialmente accesible — algunos usuarios no tienen token OAuth"
- Bump submodule `core` → PR #129

## Test plan

- [ ] Agente MP (un usuario con token, otro sin token) → dot ámbar en lista y detalle
- [ ] En detalle del agente MP → backend muestra "● parcial" + nombre del usuario sin token
- [ ] Agente ML (ambos usuarios con token) → dot verde sin cambio
- [ ] Agente ML/MP sin ningún token → dot rojo sin cambio

🤖 Generated with [Claude Code](https://claude.com/claude-code)