### PR TITLE
feat: Google Calendar por usuario — CalDAV vía App Password

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1286,6 +1286,28 @@ def delete_user_context_field_proxy(uid: str, agent_id: str, field: str):
     return HTMLResponse("")
 
 
+@app.post("/users/{uid}/gcal", response_class=HTMLResponse)
+async def save_gcal_credentials(request: Request, uid: str):
+    form     = await request.form()
+    email    = str(form.get("gcal_email",        "")).strip()
+    password = str(form.get("gcal_app_password", "")).strip()
+    # Remover espacios del app password (Google los muestra en grupos de 4)
+    password = password.replace(" ", "")
+    payload: dict = {"gcal_email": email or None}
+    if password:
+        payload["gcal_app_password"] = password
+    result = _core(f"/users/{uid}", method="PATCH", json=payload)
+    if result is None:
+        return HTMLResponse('<span class="text-red-400">Error al guardar</span>')
+    return HTMLResponse('<span class="text-emerald-400">Guardado</span>')
+
+
+@app.delete("/users/{uid}/gcal", response_class=HTMLResponse)
+def delete_gcal_credentials(uid: str):
+    _core(f"/users/{uid}/gcal", method="DELETE")
+    return HTMLResponse('<span class="text-gray-400">Eliminado — recargá la página</span>')
+
+
 @app.post("/users/{uid}/preferences/{key}/toggle", response_class=HTMLResponse)
 def toggle_user_preference(uid: str, key: str):
     user = _core(f"/users/{uid}") or {}

--- a/backoffice/templates/agent_detail.html
+++ b/backoffice/templates/agent_detail.html
@@ -37,7 +37,7 @@
   "openmeteo": {"icon": "🌤", "name": "Open-Meteo API"},
   "yfinance":  {"icon": "📈", "name": "Yahoo Finance"},
   "dolarapi":  {"icon": "💹", "name": "DolarAPI"},
-  "caldav":    {"icon": "📅", "name": "CalDAV / Radicale"},
+  "caldav":    {"icon": "📅", "name": "Google Calendar (CalDAV)"},
   "core":      {"icon": "⚙️", "name": "Core REST API"},
   "windy":     {"icon": "🌬", "name": "Windy API"},
   "custom":    {"icon": "🔌", "name": "Backend externo"},

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -58,6 +58,65 @@
   </div>
 </div>
 
+<!-- Google Calendar -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Google Calendar</h2>
+      <p class="text-xs text-gray-600 mt-0.5">Credenciales CalDAV por usuario — App Password de Google</p>
+    </div>
+    {% if user.gcal_email %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-emerald-900/40 text-emerald-400 border border-emerald-700/40">configurado</span>
+    {% else %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-yellow-900/40 text-yellow-400 border border-yellow-700/40">sin configurar</span>
+    {% endif %}
+  </div>
+
+  {% if user.gcal_email %}
+  <div class="text-xs text-gray-500 mb-4">
+    <span class="text-gray-400">Cuenta:</span>
+    <code class="text-gray-300 ml-1">{{ user.gcal_email }}</code>
+  </div>
+  {% endif %}
+
+  <form hx-post="/users/{{ uid }}/gcal" hx-target="#gcal-status" hx-swap="innerHTML" class="space-y-3">
+    <div>
+      <label class="text-xs text-gray-500 block mb-1">Email de Google</label>
+      <input type="email" name="gcal_email" value="{{ user.gcal_email or '' }}"
+        placeholder="tu@gmail.com"
+        class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
+               placeholder-gray-600 focus:outline-none focus:border-gray-500">
+    </div>
+    <div>
+      <label class="text-xs text-gray-500 block mb-1">App Password (16 caracteres sin espacios)</label>
+      <input type="password" name="gcal_app_password"
+        placeholder="{{ '••••••••••••••••' if user.gcal_app_password else 'App Password de Google' }}"
+        class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
+               placeholder-gray-600 focus:outline-none focus:border-gray-500">
+      <p class="text-xs text-gray-600 mt-1">
+        Generalo en <a href="https://myaccount.google.com/apppasswords" target="_blank"
+          class="text-blue-500 hover:underline">myaccount.google.com/apppasswords</a>
+      </p>
+    </div>
+    <div class="flex items-center gap-3 pt-1">
+      <button type="submit"
+        class="px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors">
+        Guardar
+      </button>
+      {% if user.gcal_email %}
+      <button type="button"
+        hx-delete="/users/{{ uid }}/gcal"
+        hx-target="#gcal-status" hx-swap="innerHTML"
+        hx-confirm="¿Eliminar configuración de Google Calendar?"
+        class="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 text-gray-400 text-xs font-medium rounded-lg transition-colors">
+        Eliminar
+      </button>
+      {% endif %}
+      <span id="gcal-status" class="text-xs"></span>
+    </div>
+  </form>
+</div>
+
 <!-- Wake word -->
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
   <div class="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary

- Backoffice → usuario → sección **Google Calendar**: form para configurar email + App Password, badge de estado, botón eliminar
- Label en agent_detail: "CalDAV / Radicale" → "Google Calendar (CalDAV)"
- Endpoints backoffice: `POST /users/{uid}/gcal` y `DELETE /users/{uid}/gcal`
- Core submodule actualizado (ver PR core #158)

## Test plan
- [ ] Abrir backoffice → usuario → sección Google Calendar visible
- [ ] Ingresar email + App Password → guardar → badge cambia a "configurado"
- [ ] Botón eliminar → borra credenciales
- [ ] Agente de calendario responde con eventos de Google Calendar tras configurar
- [ ] Sin configurar → responde con mensaje de configuración pendiente

🤖 Generated with [Claude Code](https://claude.com/claude-code)