### PR TITLE
feat: configuración OAuth/CalDAV migrada al perfil de usuario

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -636,9 +636,11 @@ def delete_agent_htmx(agent_id: str):
 # ── OAuth2 backends ─────────────────────────────────────────────────────────────
 
 @app.get("/auth/{service}/connect")
-def oauth_connect(service: str, user_id: str, agent_id: str = ""):
+def oauth_connect(service: str, user_id: str, agent_id: str = "", redirect_to: str = ""):
     """Inicia el flujo OAuth2: pide a core la URL y redirige al usuario."""
-    result = _core(f"/auth/{service}/url", params={"user_id": user_id, "agent_id": agent_id})
+    result = _core(f"/auth/{service}/url", params={
+        "user_id": user_id, "agent_id": agent_id, "redirect_to": redirect_to,
+    })
     if not result or not result.get("url"):
         raise HTTPException(status_code=503, detail=f"Core no pudo generar la URL de autorización para {service}")
     return RedirectResponse(result["url"], status_code=302)
@@ -649,9 +651,15 @@ def oauth_callback(service: str, code: str = "", state: str = "", error: str = "
     """Recibe el callback de ML/MP con el code, lo envía a core para canjearlo."""
     if error or not code:
         return RedirectResponse("/agents", status_code=302)
-    result = _core(f"/auth/{service}/callback", method="POST", json={"code": code, "state": state})
-    agent_id = (result or {}).get("agent_id", "")
-    redirect = f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents"
+    result      = _core(f"/auth/{service}/callback", method="POST", json={"code": code, "state": state})
+    redirect_to = (result or {}).get("redirect_to", "")
+    agent_id    = (result or {}).get("agent_id", "")
+    if redirect_to:
+        redirect = f"{redirect_to}?connected=1"
+    elif agent_id:
+        redirect = f"/agents/{agent_id}/edit?connected=1"
+    else:
+        redirect = "/agents"
     return RedirectResponse(redirect, status_code=302)
 
 
@@ -659,21 +667,26 @@ def oauth_callback(service: str, code: str = "", state: str = "", error: str = "
 async def oauth_disconnect(request: Request, service: str):
     if service not in _OAUTH_SERVICES:
         raise HTTPException(status_code=404)
-    form = await request.form()
-    user_id = str(form.get("user_id", "")).strip()
-    agent_id = str(form.get("agent_id", "")).strip()
+    form        = await request.form()
+    user_id     = str(form.get("user_id",     "")).strip()
+    agent_id    = str(form.get("agent_id",    "")).strip()
+    redirect_to = str(form.get("redirect_to", "")).strip()
     _oauth_token_path(service, user_id).unlink(missing_ok=True)
-    return RedirectResponse(f"/agents/{agent_id}/edit", status_code=303)
+    dest = redirect_to or (f"/agents/{agent_id}/edit" if agent_id else "/agents")
+    return RedirectResponse(dest, status_code=303)
 
 
 @app.post("/auth/{service}/fetch-shortcode")
 async def oauth_fetch_shortcode(request: Request, service: str):
     """Recupera el token del oauth app por short_code y lo persiste localmente."""
-    form = await request.form()
-    user_id  = str(form.get("user_id", "")).strip()
-    agent_id = str(form.get("agent_id", "")).strip()
+    form        = await request.form()
+    user_id     = str(form.get("user_id",     "")).strip()
+    agent_id    = str(form.get("agent_id",    "")).strip()
+    redirect_to = str(form.get("redirect_to", "")).strip()
 
     def _err(msg: str):
+        if redirect_to:
+            return RedirectResponse(f"{redirect_to}?oauth_error={msg}", status_code=303)
         err_redirect = f"/agents/{agent_id}/edit?oauth_error={msg}" if agent_id else "/agents"
         return RedirectResponse(err_redirect, status_code=303)
 
@@ -705,20 +718,23 @@ async def oauth_fetch_shortcode(request: Request, service: str):
     }
     _CAPITAN_DIR.mkdir(parents=True, exist_ok=True)
     _oauth_token_path(service, user_id).write_text(json.dumps(token_data, indent=2))
-    redirect = f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents"
-    return RedirectResponse(redirect, status_code=303)
+    dest = redirect_to or (f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents")
+    return RedirectResponse(dest if "?" in dest else f"{dest}?connected=1", status_code=303)
 
 
 @app.post("/auth/{service}/set-token")
 async def oauth_set_token(request: Request, service: str):
     """Configura tokens OAuth manualmente, como fallback al circuito WA."""
-    form = await request.form()
-    user_id       = str(form.get("user_id", "")).strip()
-    agent_id      = str(form.get("agent_id", "")).strip()
-    access_token  = str(form.get("access_token", "")).strip()
+    form          = await request.form()
+    user_id       = str(form.get("user_id",       "")).strip()
+    agent_id      = str(form.get("agent_id",      "")).strip()
+    redirect_to   = str(form.get("redirect_to",   "")).strip()
+    access_token  = str(form.get("access_token",  "")).strip()
     refresh_token = str(form.get("refresh_token", "")).strip()
 
     def _err(msg: str):
+        if redirect_to:
+            return RedirectResponse(f"{redirect_to}?oauth_error={msg}", status_code=303)
         err_redirect = f"/agents/{agent_id}/edit?oauth_error={msg}" if agent_id else "/agents"
         return RedirectResponse(err_redirect, status_code=303)
 
@@ -736,8 +752,8 @@ async def oauth_set_token(request: Request, service: str):
     }
     _CAPITAN_DIR.mkdir(parents=True, exist_ok=True)
     _oauth_token_path(service, user_id).write_text(json.dumps(token_data, indent=2))
-    redirect = f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents"
-    return RedirectResponse(redirect, status_code=303)
+    dest = redirect_to or (f"/agents/{agent_id}/edit?connected=1" if agent_id else "/agents")
+    return RedirectResponse(dest if "?" in dest else f"{dest}?connected=1", status_code=303)
 
 
 @app.get("/intents", response_class=HTMLResponse)
@@ -1219,13 +1235,18 @@ def user_detail_page(request: Request, uid: str):
     }
     # proactive_enabled per agent from plain context (not raw)
     user_ctx_plain   = _core(f"/users/{uid}/context") or {}
+    ml_oauth_status  = _oauth_status("ml", uid)
     return _render(request, "user_detail.html", "users",
                    user=user, uid=uid, agents=agents,
                    ww_samples=ww_samples, ww_metrics=ww_metrics,
                    train_status=train_status,
                    user_context=user_context, user_intents=user_intents,
                    proactive_status=proactive_status,
-                   user_ctx_plain=user_ctx_plain)
+                   user_ctx_plain=user_ctx_plain,
+                   ml_oauth_status=ml_oauth_status,
+                   oauth_app_url=OAUTH_APP_URL,
+                   connected=request.query_params.get("connected", ""),
+                   oauth_error=request.query_params.get("oauth_error", ""))
 
 
 @app.get("/users/{uid}/edit", response_class=HTMLResponse)

--- a/backoffice/templates/agent_detail.html
+++ b/backoffice/templates/agent_detail.html
@@ -165,10 +165,19 @@
                 </div>
               </div>
               <div class="text-xs text-gray-600 mt-0.5">{{ meta.name }}</div>
-              {% if b.reachable == "partial" and b.users_fail is defined %}
+              {% if b.type == "oauth2" or b.type == "caldav" %}
+                {% if b.reachable == "partial" %}
                 <div class="text-xs text-amber-600 mt-1">
-                  Sin token: {{ b.users_fail | join(", ") }}
+                  Sin configurar:
+                  {% for uid in (b.users_fail or []) %}
+                  <a href="/users/{{ uid }}" class="underline hover:text-amber-400">{{ uid }}</a>{% if not loop.last %}, {% endif %}
+                  {% endfor %}
                 </div>
+                {% elif not b.reachable %}
+                <div class="text-xs text-red-600 mt-1">
+                  Configurar credenciales en el perfil de cada usuario.
+                </div>
+                {% endif %}
               {% endif %}
               {% if b.model %}
                 <code class="text-xs bg-gray-800 text-indigo-300 px-1.5 py-0.5 rounded mt-1 inline-block">

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -132,138 +132,35 @@
       Cambios guardados.
     </div>
     {% endif %}
-    {% if just_connected %}
-    <div class="mb-3 bg-emerald-900/30 border border-emerald-700 text-emerald-300 px-3 py-2 rounded-lg text-xs">
-      Cuenta conectada correctamente.
-    </div>
-    {% endif %}
-    {% if oauth_error %}
-    <div class="mb-3 bg-red-900/30 border border-red-700 text-red-300 px-3 py-2 rounded-lg text-xs">
-      Error OAuth: {{ oauth_error | replace("+", " ") }}
-    </div>
-    {% endif %}
-
     <div class="space-y-4">
       {% for b in agent.backends %}
       {% if b.type == 'oauth2' %}
         {% set svc = b.service %}
         <div class="border border-gray-700 rounded-lg p-4">
-          <div class="flex items-center gap-2 mb-3">
+          <div class="flex items-center gap-2 mb-2">
             <span class="text-sm font-medium text-gray-200">{{ b.label }}</span>
             <span class="text-xs text-indigo-400 bg-indigo-900/30 px-1.5 py-0.5 rounded">oauth2</span>
-            {% if b.url %}<code class="text-xs text-gray-600 ml-1">{{ b.url }}</code>{% endif %}
           </div>
+          <p class="text-xs text-gray-500">
+            La conexión OAuth se configura por usuario.
+            Ir al perfil de cada usuario para conectar o desconectar su cuenta.
+          </p>
           {% if users %}
+          <div class="mt-3 space-y-1">
             {% for uid, user in users.items() %}
             {% set st = oauth_statuses.get(svc, {}).get(uid, {}) %}
-            <div class="oauth-user-row py-3 border-t border-gray-800 first:border-0">
-              <div class="flex items-center justify-between mb-2">
-                <span class="text-xs text-gray-400">{{ user.name }}</span>
-                {% if st.online %}
-                  <span class="text-xs text-emerald-400">● online</span>
-                {% elif st.connected %}
-                  <span class="text-xs text-yellow-500">● token guardado (offline)</span>
-                {% else %}
-                  <span class="text-xs text-gray-600">● no conectado</span>
-                {% endif %}
-              </div>
-              {% if st.connected %}
-                <div class="text-xs text-gray-600 mb-2">
-                  {% if st.api_user_id %}ID: <code class="text-gray-500">{{ st.api_user_id }}</code> · {% endif %}
-                  guardado {{ st.saved_at[:10] if st.saved_at else '' }}
-                </div>
-                <div class="flex items-center gap-3 flex-wrap">
-                  <span class="inline">
-                    <button type="submit" form="form-dc-{{ svc }}-{{ uid }}"
-                            class="text-xs text-red-400 hover:text-red-300 transition-colors">
-                      Desconectar
-                    </button>
-                  </span>
-                  <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.add('hidden')"
-                          class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">
-                    Recuperar por short_code
-                  </button>
-                  <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.add('hidden')"
-                          class="text-xs text-gray-500 hover:text-gray-300 transition-colors">
-                    Actualizar manualmente
-                  </button>
-                </div>
+            <a href="/users/{{ uid }}" class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-gray-800 transition-colors group">
+              <span class="text-xs text-gray-400 group-hover:text-gray-300">{{ user.name }}</span>
+              {% if st.online %}
+                <span class="text-xs text-emerald-400">● online</span>
+              {% elif st.connected %}
+                <span class="text-xs text-yellow-500">● token guardado</span>
               {% else %}
-                {% if oauth_app_url %}
-                  <a href="{{ oauth_app_url }}/auth/{{ svc }}/login?user_id={{ uid }}&agent_id={{ agent_id }}"
-                     target="_blank"
-                     class="inline-block mt-1 px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600
-                            text-white text-xs rounded transition-colors">
-                    Conectar cuenta →
-                  </a>
-                {% else %}
-                  <span class="text-xs text-gray-600">Configurar OAUTH_APP_URL en backoffice/.env</span>
-                {% endif %}
-                <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.add('hidden')"
-                        class="ml-2 text-xs text-indigo-400 hover:text-indigo-300 transition-colors underline">
-                  Recuperar por short_code
-                </button>
-                <button type="button" onclick="this.closest('.oauth-user-row').querySelector('.manual-token-form').classList.toggle('hidden');this.closest('.oauth-user-row').querySelector('.shortcode-form').classList.add('hidden')"
-                        class="ml-2 text-xs text-gray-500 hover:text-gray-300 transition-colors underline">
-                  Configurar manualmente
-                </button>
+                <span class="text-xs text-gray-600">● no conectado</span>
               {% endif %}
-              <!-- Recuperación por short_code -->
-              <div class="shortcode-form hidden mt-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3 space-y-2">
-                <p class="text-xs text-gray-500 mb-1">Pegá el <code class="text-gray-400">short_code</code> del log o de la pantalla de confirmación ML:</p>
-                <div>
-                  <label class="block text-xs text-gray-400 mb-0.5">short_code</label>
-                  <input type="text" name="short_code" required placeholder="uu9Fj..."
-                         form="form-sc-{{ svc }}-{{ uid }}"
-                         class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1
-                                text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
-                </div>
-                <p class="text-xs text-gray-600">El short_code expira a los 5 minutos de completar la autorización ML.</p>
-                <div class="flex gap-2 pt-1">
-                  <button type="submit" form="form-sc-{{ svc }}-{{ uid }}"
-                          class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded transition-colors">
-                    Recuperar token
-                  </button>
-                  <button type="button"
-                          onclick="this.closest('.shortcode-form').classList.add('hidden')"
-                          class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs rounded transition-colors">
-                    Cancelar
-                  </button>
-                </div>
-              </div>
-              <!-- Configuración manual de tokens -->
-              <div class="manual-token-form hidden mt-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3 space-y-2">
-                <p class="text-xs text-gray-500 mb-1">Pegá los tokens obtenidos del flujo OAuth:</p>
-                <div>
-                  <label class="block text-xs text-gray-400 mb-0.5">access_token</label>
-                  <input type="text" name="access_token" required placeholder="eyJ..."
-                         form="form-st-{{ svc }}-{{ uid }}"
-                         class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1
-                                text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
-                </div>
-                <div>
-                  <label class="block text-xs text-gray-400 mb-0.5">refresh_token <span class="text-gray-600">(opcional)</span></label>
-                  <input type="text" name="refresh_token" placeholder="TG-..."
-                         form="form-st-{{ svc }}-{{ uid }}"
-                         class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1
-                                text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
-                </div>
-                <div class="flex gap-2 pt-1">
-                  <button type="submit" form="form-st-{{ svc }}-{{ uid }}"
-                          class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded transition-colors">
-                    Guardar tokens
-                  </button>
-                  <button type="button"
-                          onclick="this.closest('.manual-token-form').classList.add('hidden')"
-                          class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs rounded transition-colors">
-                    Cancelar
-                  </button>
-                </div>
-              </div>
-            </div>
+            </a>
             {% endfor %}
-          {% else %}
-            <p class="text-xs text-gray-600">No hay usuarios registrados.</p>
+          </div>
           {% endif %}
         </div>
       {% else %}
@@ -455,22 +352,6 @@
   </div>
 
 </form>
-
-{% for b in agent.backends %}{% if b.type == 'oauth2' %}{% set svc = b.service %}
-{% for uid, user in users.items() %}
-<form id="form-dc-{{ svc }}-{{ uid }}" method="POST" action="/auth/{{ svc }}/disconnect">
-  <input type="hidden" name="user_id" value="{{ uid }}">
-  <input type="hidden" name="agent_id" value="{{ agent_id }}">
-</form>
-<form id="form-sc-{{ svc }}-{{ uid }}" method="POST" action="/auth/{{ svc }}/fetch-shortcode">
-  <input type="hidden" name="user_id" value="{{ uid }}">
-  <input type="hidden" name="agent_id" value="{{ agent_id }}">
-</form>
-<form id="form-st-{{ svc }}-{{ uid }}" method="POST" action="/auth/{{ svc }}/set-token">
-  <input type="hidden" name="user_id" value="{{ uid }}">
-  <input type="hidden" name="agent_id" value="{{ agent_id }}">
-</form>
-{% endfor %}{% endif %}{% endfor %}
 
 <script>
 function addCtxRow() {

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -58,6 +58,121 @@
   </div>
 </div>
 
+<!-- Notificaciones OAuth -->
+{% if connected %}
+<div class="mb-4 bg-emerald-900/30 border border-emerald-700 text-emerald-300 px-3 py-2 rounded-lg text-xs">
+  Cuenta conectada correctamente.
+</div>
+{% endif %}
+{% if oauth_error %}
+<div class="mb-4 bg-red-900/30 border border-red-700 text-red-300 px-3 py-2 rounded-lg text-xs">
+  Error OAuth: {{ oauth_error | replace("+", " ") }}
+</div>
+{% endif %}
+
+<!-- MercadoLibre -->
+{% set ml = ml_oauth_status or {} %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">MercadoLibre</h2>
+      <p class="text-xs text-gray-600 mt-0.5">Cuenta OAuth2 para el agente de marketplace</p>
+    </div>
+    {% if ml.online %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-emerald-900/40 text-emerald-400 border border-emerald-700/40">online</span>
+    {% elif ml.connected %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-yellow-900/40 text-yellow-400 border border-yellow-700/40">token guardado</span>
+    {% else %}
+      <span class="px-2 py-0.5 text-xs rounded-full bg-gray-800 text-gray-500 border border-gray-700">no conectado</span>
+    {% endif %}
+  </div>
+
+  {% if ml.connected %}
+  <div class="text-xs text-gray-500 mb-4 space-y-0.5">
+    {% if ml.api_user_id %}<div>ID ML: <code class="text-gray-400">{{ ml.api_user_id }}</code></div>{% endif %}
+    {% if ml.saved_at %}<div>Guardado: <span class="text-gray-400">{{ ml.saved_at[:10] }}</span></div>{% endif %}
+  </div>
+  {% endif %}
+
+  <div class="flex flex-wrap items-center gap-3">
+    {% if ml.connected %}
+      <!-- Desconectar -->
+      <form method="POST" action="/auth/ml/disconnect" class="inline">
+        <input type="hidden" name="user_id" value="{{ uid }}">
+        <input type="hidden" name="redirect_to" value="/users/{{ uid }}">
+        <button type="submit"
+          class="px-3 py-1.5 bg-gray-800 hover:bg-red-900/40 text-gray-400 hover:text-red-400
+                 text-xs font-medium rounded-lg border border-gray-700 hover:border-red-700/50 transition-colors">
+          Desconectar
+        </button>
+      </form>
+    {% else %}
+      {% if oauth_app_url %}
+      <a href="/auth/ml/connect?user_id={{ uid }}&redirect_to=/users/{{ uid }}"
+         class="px-3 py-1.5 bg-indigo-700 hover:bg-indigo-600 text-white text-xs font-medium rounded-lg transition-colors">
+        Conectar cuenta →
+      </a>
+      {% else %}
+      <span class="text-xs text-gray-600">Configurar OAUTH_APP_URL en backoffice/.env para habilitar OAuth</span>
+      {% endif %}
+    {% endif %}
+
+    <!-- Recuperar por short_code -->
+    <button type="button" id="sc-toggle-{{ uid }}"
+      onclick="document.getElementById('sc-form-{{ uid }}').classList.toggle('hidden');document.getElementById('mt-form-{{ uid }}').classList.add('hidden')"
+      class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors underline">
+      Recuperar por short_code
+    </button>
+    <!-- Manual -->
+    <button type="button" id="mt-toggle-{{ uid }}"
+      onclick="document.getElementById('mt-form-{{ uid }}').classList.toggle('hidden');document.getElementById('sc-form-{{ uid }}').classList.add('hidden')"
+      class="text-xs text-gray-500 hover:text-gray-300 transition-colors underline">
+      Configurar manualmente
+    </button>
+  </div>
+
+  <!-- Short code form -->
+  <div id="sc-form-{{ uid }}" class="hidden mt-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3 space-y-2">
+    <p class="text-xs text-gray-500">Pegá el <code class="text-gray-400">short_code</code> del log o pantalla ML:</p>
+    <form method="POST" action="/auth/ml/fetch-shortcode" class="space-y-2">
+      <input type="hidden" name="user_id" value="{{ uid }}">
+      <input type="hidden" name="redirect_to" value="/users/{{ uid }}">
+      <input type="text" name="short_code" required placeholder="uu9Fj..."
+        class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
+      <p class="text-xs text-gray-600">El short_code expira a los 5 minutos.</p>
+      <div class="flex gap-2 pt-1">
+        <button type="submit" class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded transition-colors">Recuperar token</button>
+        <button type="button" onclick="document.getElementById('sc-form-{{ uid }}').classList.add('hidden')"
+          class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs rounded transition-colors">Cancelar</button>
+      </div>
+    </form>
+  </div>
+
+  <!-- Manual token form -->
+  <div id="mt-form-{{ uid }}" class="hidden mt-3 bg-gray-800/50 border border-gray-700 rounded-lg p-3 space-y-2">
+    <p class="text-xs text-gray-500">Pegá los tokens obtenidos del flujo OAuth:</p>
+    <form method="POST" action="/auth/ml/set-token" class="space-y-2">
+      <input type="hidden" name="user_id" value="{{ uid }}">
+      <input type="hidden" name="redirect_to" value="/users/{{ uid }}">
+      <div>
+        <label class="block text-xs text-gray-400 mb-0.5">access_token</label>
+        <input type="text" name="access_token" required placeholder="eyJ..."
+          class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
+      </div>
+      <div>
+        <label class="block text-xs text-gray-400 mb-0.5">refresh_token <span class="text-gray-600">(opcional)</span></label>
+        <input type="text" name="refresh_token" placeholder="TG-..."
+          class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs font-mono text-indigo-300 focus:outline-none focus:border-indigo-600">
+      </div>
+      <div class="flex gap-2 pt-1">
+        <button type="submit" class="px-3 py-1 bg-indigo-700 hover:bg-indigo-600 text-white text-xs rounded transition-colors">Guardar tokens</button>
+        <button type="button" onclick="document.getElementById('mt-form-{{ uid }}').classList.add('hidden')"
+          class="px-3 py-1 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs rounded transition-colors">Cancelar</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <!-- Google Calendar -->
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
   <div class="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary

- **`user_detail.html`**: sección MercadoLibre (connect/disconnect/shortcode/manual) + sección Google Calendar. Mismo patrón: badge de estado + formularios en el perfil del usuario.
- **`agent_edit.html`**: OAuth por-usuario → lista de estado con links al perfil. Escala sin crecer con N usuarios.
- **`agent_detail.html`**: backends `oauth2`/`caldav` sin acceso muestran quién falta con link a perfil.
- **`backoffice/server.py`**: todos los endpoints OAuth soportan `redirect_to`; `user_detail_page` pasa estado OAuth al template.
- **Core submodule**: `marketplace_oauth.py` + `server.py` con `redirect_to` en state OAuth.

## Test plan
- [ ] Perfil de usuario → sección MercadoLibre visible con badge correcto
- [ ] Flujo OAuth ML desde perfil → vuelve a `/users/{uid}?connected=1`
- [ ] Shortcode y token manual desde perfil funcionan
- [ ] Desconectar desde perfil funciona
- [ ] Agente ML edit → lista de usuarios con estado + links a perfiles
- [ ] Agente detail → backend oauth2 con link a perfiles para configurar

🤖 Generated with [Claude Code](https://claude.com/claude-code)