### PR TITLE
feat: contexto de usuario editable desde el perfil

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1307,6 +1307,20 @@ def delete_user_context_field_proxy(uid: str, agent_id: str, field: str):
     return HTMLResponse("")
 
 
+@app.post("/users/{uid}/context/{agent_id}/{field}", response_class=HTMLResponse)
+async def set_user_context_field(uid: str, agent_id: str, field: str, request: Request):
+    form  = await request.form()
+    value = str(form.get("value", "")).strip()
+    if value:
+        _core(f"/users/{uid}/context/{agent_id}", method="PATCH", json={field: value})
+    return HTMLResponse(
+        f'<span id="ctx-saved-{agent_id}-{field}" class="text-xs text-emerald-400">'
+        f'✓ Guardado'
+        f'<script>setTimeout(()=>document.getElementById("ctx-saved-{agent_id}-{field}")?.remove(),2000)</script>'
+        f'</span>'
+    )
+
+
 @app.post("/users/{uid}/gcal", response_class=HTMLResponse)
 async def save_gcal_credentials(request: Request, uid: str):
     form     = await request.form()

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -544,14 +544,94 @@ async function runAllProactive(uid) {
   {% endif %}
 </div>
 
-<!-- Contexto aprendido -->
-{% if user_context %}
+<!-- Contexto por agente -->
+{% set agents_with_schema = agents.items() | selectattr('1.user_context_schema') | list %}
+{% set agents_with_freeform = [] %}
+{% for aid, fields in user_context.items() %}
+  {% if not agents.get(aid, {}).get('user_context_schema') and aid != 'proactive_enabled' %}
+    {% set _ = agents_with_freeform.append((aid, fields)) %}
+  {% endif %}
+{% endfor %}
+
+{% if agents_with_schema or agents_with_freeform or user_context %}
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
-  <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Contexto aprendido</h2>
+  <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">Contexto por agente</h2>
   <p class="text-xs text-gray-600 mb-4">
-    Datos que los agentes recuerdan de este usuario.
+    Preferencias y datos aprendidos por agente. Los campos con schema son editables desde aquí.
   </p>
-  {% for agent_id, fields in user_context.items() %}
+
+  <!-- Agentes con schema declarado → campos editables -->
+  {% for agent_id, agent_info in agents_with_schema %}
+  {% set schema = agent_info.get('user_context_schema', []) %}
+  {% set agent_ctx = user_context.get(agent_id, {}) %}
+  <details class="mb-2 group" {% if agent_ctx %}open{% endif %}>
+    <summary class="flex items-center gap-2 cursor-pointer py-2 border-b border-gray-800 hover:border-gray-700 list-none select-none">
+      <span class="text-base">{{ agent_info.get('icon', '🤖') }}</span>
+      <span class="text-sm font-medium text-gray-300">{{ agent_info.get('name', agent_id) }}</span>
+      <span class="text-xs text-gray-600 ml-1">{{ schema | length }} campo{{ 's' if schema | length != 1 }}</span>
+      <span class="ml-auto text-gray-600 text-xs group-open:rotate-180 transition-transform">▾</span>
+    </summary>
+    <div class="pt-3 space-y-3">
+      {% for fd in schema %}
+      {% set fname = fd.get('field') %}
+      {% set current = agent_ctx.get(fname) %}
+      {% set current_val = current.value if current else '' %}
+      {% set updated_days = ((now - current.updated_at) / 86400) | round(0, 'floor') | int if current else none %}
+      {% set ttl_remaining = [current.ttl_days - updated_days, 0] | max if current else none %}
+      <div class="flex items-start gap-3 py-2 border-b border-gray-800/50">
+        <div class="flex-1 min-w-0">
+          <div class="text-xs font-mono text-gray-500 mb-1">{{ fname }}
+            {% if fd.get('desc') %}<span class="text-gray-600 font-sans normal-case ml-1">— {{ fd.desc }}</span>{% endif %}
+          </div>
+          <form hx-post="/users/{{ uid }}/context/{{ agent_id }}/{{ fname }}"
+                hx-target="#ctx-saved-{{ agent_id }}-{{ fname }}"
+                hx-swap="outerHTML"
+                class="flex items-center gap-2">
+            {% if fd.get('type') == 'select' %}
+            <select name="value"
+                    class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200
+                           focus:outline-none focus:ring-1 focus:ring-indigo-500">
+              <option value="">— sin definir —</option>
+              {% for opt in fd.get('options', []) %}
+              <option value="{{ opt }}" {% if current_val == opt %}selected{% endif %}>{{ opt }}</option>
+              {% endfor %}
+            </select>
+            {% else %}
+            <input type="text" name="value" value="{{ current_val }}"
+                   placeholder="sin definir"
+                   class="flex-1 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200
+                          focus:outline-none focus:ring-1 focus:ring-indigo-500">
+            {% endif %}
+            <button type="submit"
+                    class="px-2 py-1 text-xs bg-indigo-700 hover:bg-indigo-600 text-white rounded transition-colors">
+              Guardar
+            </button>
+            <span id="ctx-saved-{{ agent_id }}-{{ fname }}"></span>
+          </form>
+          {% if current %}
+          <div class="text-xs text-gray-600 mt-1">
+            actualizado hace {{ updated_days }}d — expira en {{ ttl_remaining }}d
+          </div>
+          {% endif %}
+        </div>
+        {% if current %}
+        <button
+          hx-delete="/users/{{ uid }}/context/{{ agent_id }}/{{ fname }}"
+          hx-target="closest div.flex"
+          hx-swap="innerHTML"
+          hx-confirm="¿Eliminar {{ fname }}?"
+          class="shrink-0 px-1.5 py-0.5 text-[10px] text-gray-600 hover:text-red-400 hover:bg-red-900/20 rounded transition-colors mt-6">
+          ✕
+        </button>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
+  </details>
+  {% endfor %}
+
+  <!-- Campos aprendidos sin schema (read-only + delete) -->
+  {% for agent_id, fields in agents_with_freeform %}
   {% set agent_info = agents.get(agent_id, {}) %}
   <details class="mb-2 group">
     <summary class="flex items-center gap-2 cursor-pointer py-2 border-b border-gray-800 hover:border-gray-700 list-none select-none">
@@ -585,11 +665,7 @@ async function runAllProactive(uid) {
     </div>
   </details>
   {% endfor %}
-</div>
-{% else %}
-<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
-  <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Contexto aprendido</h2>
-  <p class="text-sm text-gray-600">Sin datos aprendidos todavía.</p>
+
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Summary

- `backoffice/server.py`: nuevo endpoint `POST /users/{uid}/context/{agent_id}/{field}` que persiste un campo de contexto vía HTMX
- `user_detail.html`: sección "Contexto por agente" — agentes con `user_context_schema` muestran campos editables (input o select según tipo, pre-rellenos con el valor actual); agentes sin schema mantienen el display read-only anterior

## Cómo funciona

Cada agente que declare `user_context_schema` (actualmente `weather` con `preferred_location` y `finance` con `risk_profile`) expone sus campos como controles editables en el perfil del usuario. Al guardar, HTMX postea al nuevo endpoint y muestra confirmación inline. Si el campo ya tiene valor aparece pre-seleccionado; si no existe aparece vacío listo para configurar.

## Test plan
- [x] Template renderiza 200 con `preferred_location` y `risk_profile` visibles
- [x] Select de `risk_profile` muestra opciones conservador/moderado/agresivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)