### PR TITLE
feat: backoffice finance templates CRUD + planes por usuario

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1141,6 +1141,48 @@ def alerts_page(request: Request):
                    alerts=data, alert_state=alert_keys)
 
 
+@app.get("/finance/templates", response_class=HTMLResponse)
+def finance_templates_page(request: Request):
+    core_ok   = _core("/health", timeout=3) is not None
+    templates = _core("/finance/templates") or [] if core_ok else []
+    return _render(request, "finance_templates.html", "finance-templates",
+                   templates=templates, core_ok=core_ok)
+
+
+@app.post("/finance/templates", response_class=HTMLResponse)
+async def create_finance_template_proxy(request: Request):
+    form     = await request.form()
+    name     = str(form.get("name", "")).strip()
+    raw_pos  = str(form.get("positions_raw", "")).strip()
+    threshold = float(form.get("review_threshold", -10))
+
+    positions: list[dict] = []
+    for part in raw_pos.split(","):
+        part = part.strip()
+        if ":" in part:
+            ticker, pct_s = part.split(":", 1)
+            try:
+                positions.append({"ticker": ticker.strip().upper(), "pct": float(pct_s.strip())})
+            except ValueError:
+                pass
+
+    if not name or not positions:
+        return HTMLResponse('<p class="text-red-400 text-xs">Nombre y posiciones requeridos.</p>', status_code=422)
+
+    _core("/finance/templates", method="POST",
+          json={"name": name, "positions": positions, "review_threshold": threshold})
+
+    templates = _core("/finance/templates") or []
+    return _render(request, "finance_templates.html", "finance-templates",
+                   templates=templates, core_ok=True)
+
+
+@app.delete("/finance/templates/{name}", response_class=HTMLResponse)
+def delete_finance_template_proxy(name: str):
+    _core(f"/finance/templates/{name}", method="DELETE")
+    return HTMLResponse("")
+
+
 @app.get("/config", response_class=HTMLResponse)
 def config_page(request: Request):
     env_path = Path.home() / "workspace/home-agents/core/.env"
@@ -1254,6 +1296,7 @@ def user_detail_page(request: Request, uid: str):
     # proactive_enabled per agent from plain context (not raw)
     user_ctx_plain   = _core(f"/users/{uid}/context") or {}
     ml_oauth_status  = _oauth_status("ml", uid)
+    finance_plans    = _core(f"/finance/plans/{uid}") or []
     return _render(request, "user_detail.html", "users",
                    user=user, uid=uid, agents=agents, agents_meta=agents_meta,
                    ww_samples=ww_samples, ww_metrics=ww_metrics,
@@ -1262,6 +1305,7 @@ def user_detail_page(request: Request, uid: str):
                    proactive_status=proactive_status,
                    user_ctx_plain=user_ctx_plain,
                    ml_oauth_status=ml_oauth_status,
+                   finance_plans=finance_plans,
                    oauth_app_url=OAUTH_APP_URL,
                    connected=request.query_params.get("connected", ""),
                    oauth_error=request.query_params.get("oauth_error", ""))
@@ -1337,6 +1381,12 @@ async def set_user_context_field(uid: str, agent_id: str, field: str, request: R
         f'<script>setTimeout(()=>document.getElementById("ctx-saved-{agent_id}-{field}")?.remove(),2000)</script>'
         f'</span>'
     )
+
+
+@app.delete("/users/{uid}/finance/plans/{plan_name}", response_class=HTMLResponse)
+def delete_user_finance_plan(uid: str, plan_name: str):
+    _core(f"/finance/plans/{uid}/{plan_name}", method="DELETE")
+    return HTMLResponse("")
 
 
 @app.post("/users/{uid}/gcal", response_class=HTMLResponse)

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -76,9 +76,10 @@
       <!-- Configuración -->
       <div class="flex flex-col gap-0.5">
         <p class="sb-section px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-600">Configuración</p>
-        <a href="/users"        title="Usuarios"      class="{{ link_active if section == 'users'        else link_base }}"><span>👥</span><span class="sb-text">Usuarios</span></a>
-        <a href="/integrations" title="Integraciones" class="{{ link_active if section == 'integrations' else link_base }}"><span>🔌</span><span class="sb-text">Integraciones</span></a>
-        <a href="/config"       title="Config (.env)" class="{{ link_active if section == 'config'       else link_base }}"><span>⚙️</span><span class="sb-text">Config (.env)</span></a>
+        <a href="/users"            title="Usuarios"      class="{{ link_active if section == 'users'            else link_base }}"><span>👥</span><span class="sb-text">Usuarios</span></a>
+        <a href="/integrations"     title="Integraciones" class="{{ link_active if section == 'integrations'     else link_base }}"><span>🔌</span><span class="sb-text">Integraciones</span></a>
+        <a href="/finance/templates"title="Templates inv." class="{{ link_active if section == 'finance-templates' else link_base }}"><span>📋</span><span class="sb-text">Templates inv.</span></a>
+        <a href="/config"           title="Config (.env)" class="{{ link_active if section == 'config'           else link_base }}"><span>⚙️</span><span class="sb-text">Config (.env)</span></a>
       </div>
 
     </nav>

--- a/backoffice/templates/finance_templates.html
+++ b/backoffice/templates/finance_templates.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+{% block title %}Templates de inversión{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Templates de inversión</h1>
+  <p class="text-sm text-gray-500">Se usan para crear planes automáticamente por usuario en el ciclo proactivo</p>
+</div>
+
+{% if not core_ok %}
+<div class="mb-4 bg-red-900/30 border border-red-700 text-red-300 text-sm px-4 py-3 rounded-xl">
+  No se pudo conectar al core. Los templates no están disponibles.
+</div>
+{% endif %}
+
+<!-- Lista de templates existentes -->
+<div id="templates-list" class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden mb-6">
+  <table class="w-full text-sm">
+    <thead>
+      <tr class="border-b border-gray-800 text-gray-400 text-xs uppercase tracking-wider">
+        <th class="px-4 py-3 text-left">Nombre</th>
+        <th class="px-4 py-3 text-left">Posiciones</th>
+        <th class="px-4 py-3 text-center">Umbral revisión</th>
+        <th class="px-4 py-3 text-center">Acciones</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-800">
+      {% for tmpl in templates %}
+      <tr id="tmpl-row-{{ loop.index }}" class="hover:bg-gray-800/30">
+        <td class="px-4 py-3 font-medium text-gray-200">{{ tmpl.name }}</td>
+        <td class="px-4 py-3 text-gray-400 text-xs">
+          {% for pos in tmpl.positions %}
+          <span class="inline-block mr-3">
+            <span class="font-mono text-gray-300">{{ pos.ticker }}</span>
+            <span class="text-gray-500">{{ pos.pct | int }}%</span>
+          </span>
+          {% endfor %}
+        </td>
+        <td class="px-4 py-3 text-center text-xs font-mono
+          {% if tmpl.review_threshold >= -5 %}text-amber-400
+          {% elif tmpl.review_threshold >= -10 %}text-yellow-400
+          {% else %}text-red-400{% endif %}">
+          {{ '%+.0f' | format(tmpl.review_threshold) }}%
+        </td>
+        <td class="px-4 py-3 text-center">
+          <button
+            hx-delete="/finance/templates/{{ tmpl.name }}"
+            hx-target="#tmpl-row-{{ loop.index }}"
+            hx-swap="outerHTML"
+            hx-confirm="¿Eliminar el template '{{ tmpl.name }}'? Los planes de usuarios existentes no se eliminan."
+            class="px-2 py-1 bg-red-900/40 hover:bg-red-900/70 text-red-400 hover:text-red-300 rounded text-xs transition-colors">
+            Eliminar
+          </button>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="4" class="px-4 py-6 text-center text-gray-600 text-sm">
+          No hay templates definidos. El agente no podrá crear planes automáticamente.
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Formulario nuevo template -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-5">
+  <h2 class="text-sm font-semibold text-gray-300 mb-4">Nuevo template</h2>
+  <form id="new-tmpl-form" hx-post="/finance/templates" hx-target="#templates-list" hx-swap="outerHTML" hx-select="#templates-list" hx-on::after-request="this.reset()">
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div>
+        <label class="block text-xs text-gray-500 mb-1">Nombre</label>
+        <input type="text" name="name" required placeholder="ej: conservador"
+               class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-indigo-500">
+      </div>
+      <div>
+        <label class="block text-xs text-gray-500 mb-1">Posiciones (TICKER:pct, separadas por coma)</label>
+        <input type="text" name="positions_raw" required placeholder="ej: GGAL:30,MELI:40,BTC-USD:30"
+               class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 font-mono focus:outline-none focus:border-indigo-500">
+      </div>
+      <div>
+        <label class="block text-xs text-gray-500 mb-1">Umbral de revisión (%)</label>
+        <input type="number" name="review_threshold" value="-10" step="0.5" min="-50" max="0"
+               class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-indigo-500">
+      </div>
+    </div>
+    <div id="tmpl-form-error" class="mt-2 text-xs text-red-400 hidden"></div>
+    <div class="mt-4 flex items-center gap-3">
+      <button type="submit"
+              class="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium rounded-lg transition-colors">
+        Crear template
+      </button>
+      <span id="tmpl-saved" class="text-xs text-emerald-400 hidden">✓ Guardado</span>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -661,4 +661,61 @@ async function runAllProactive(uid) {
 
 </div>
 
+<!-- Planes de inversión -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Planes de inversión</h2>
+    <span class="text-xs text-gray-600">{{ finance_plans | length }} plan{{ 'es' if finance_plans | length != 1 }}</span>
+  </div>
+
+  {% if finance_plans %}
+  <div class="overflow-x-auto">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="text-xs text-gray-500 uppercase border-b border-gray-800">
+          <th class="pb-2 text-left">Plan</th>
+          <th class="pb-2 text-left">Posiciones</th>
+          <th class="pb-2 text-center">Desde</th>
+          <th class="pb-2 text-center">P&amp;L</th>
+          <th class="pb-2"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-800">
+        {% for plan in finance_plans %}
+        <tr id="plan-row-{{ plan.id }}" class="hover:bg-gray-800/30">
+          <td class="py-2 pr-4 font-medium text-gray-200">{{ plan.name }}</td>
+          <td class="py-2 pr-4 text-gray-400 text-xs">
+            {% for pos in plan.positions %}
+            <span class="inline-block mr-2">{{ pos.ticker }} {{ pos.pct | int }}%</span>
+            {% endfor %}
+          </td>
+          <td class="py-2 text-center text-gray-500 text-xs">{{ plan.created_at[:10] }}</td>
+          <td class="py-2 text-center text-xs font-mono font-medium
+            {% if plan.weighted_pnl is not none %}
+              {% if plan.weighted_pnl >= 0 %}text-emerald-400{% else %}text-red-400{% endif %}
+            {% else %}text-gray-600{% endif %}">
+            {% if plan.weighted_pnl is not none %}
+              {{ '%+.1f' | format(plan.weighted_pnl) }}%
+            {% else %}—{% endif %}
+          </td>
+          <td class="py-2 text-right">
+            <button
+              hx-delete="/users/{{ uid }}/finance/plans/{{ plan.name }}"
+              hx-target="#plan-row-{{ plan.id }}"
+              hx-swap="outerHTML"
+              hx-confirm="¿Eliminar el plan '{{ plan.name }}'?"
+              class="px-2 py-0.5 text-[10px] text-gray-600 hover:text-red-400 hover:bg-red-900/20 rounded transition-colors">
+              Eliminar
+            </button>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="text-sm text-gray-600">Sin planes de inversión. Se crearán automáticamente en el próximo ciclo proactivo.</p>
+  {% endif %}
+</div>
+
 {% endblock %}


### PR DESCRIPTION
## Summary

- Nueva página `/finance/templates` con tabla CRUD (crear, eliminar templates de planes)
- Link en sidebar bajo "Configuración"
- `user_detail.html` — nueva sección "Planes de inversión": tabla con posiciones, P&L actual por plan, botón eliminar por fila (HTMX)
- Backoffice proxys para todos los endpoints de finance del core

## Test plan

- [ ] `/finance/templates` carga y muestra los templates seeded
- [ ] Crear nuevo template con nombre + posiciones (TICKER:pct) + umbral
- [ ] Eliminar template con confirmación
- [ ] Perfil de usuario muestra sección "Planes de inversión" con P&L

🤖 Generated with [Claude Code](https://claude.com/claude-code)