### PR TITLE
feat: histograma P&L de planes en backoffice (Chart.js)

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -26,7 +26,7 @@ import secrets
 
 import requests
 from fastapi import Cookie, FastAPI, Form, HTTPException, Request, Response
-from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 
 # ── Configuración ──────────────────────────────────────────────────────────────
@@ -1381,6 +1381,14 @@ async def set_user_context_field(uid: str, agent_id: str, field: str, request: R
         f'<script>setTimeout(()=>document.getElementById("ctx-saved-{agent_id}-{field}")?.remove(),2000)</script>'
         f'</span>'
     )
+
+
+@app.get("/users/{uid}/finance/plans/history")
+def get_user_plans_history(request: Request, uid: str):
+    plan_names = request.query_params.getlist("plan")
+    params = [("plan", n) for n in plan_names] if plan_names else None
+    data = _core(f"/finance/plans/{uid}/history", timeout=30, params=params) or {}
+    return JSONResponse(data)
 
 
 @app.delete("/users/{uid}/finance/plans/{plan_name}", response_class=HTMLResponse)

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -718,4 +718,181 @@ async function runAllProactive(uid) {
   {% endif %}
 </div>
 
+{% if finance_plans %}
+<!-- Histograma P&L planes -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Evolución P&amp;L</h2>
+    <div class="flex gap-3 flex-wrap items-center" id="pnl-toggles">
+      {% for plan in finance_plans %}
+      <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
+        <input type="checkbox" class="pnl-toggle accent-emerald-500" value="{{ plan.name }}" checked>
+        {{ plan.name }}
+      </label>
+      {% endfor %}
+      <label class="flex items-center gap-1.5 text-xs text-gray-500 cursor-pointer select-none">
+        <input type="checkbox" id="pnl-show-trend" checked>
+        tendencia
+      </label>
+    </div>
+  </div>
+  <div class="relative" style="height:280px">
+    <canvas id="pnlChart"></canvas>
+    <div id="pnl-loading" class="absolute inset-0 flex items-center justify-center text-gray-600 text-sm">
+      Cargando historial…
+    </div>
+  </div>
+  <p id="pnl-error" class="hidden text-xs text-red-500 mt-2">No se pudo cargar el historial.</p>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
+<script>
+(function() {
+  const UID     = {{ uid | tojson }};
+  const COLORS  = ['#34d399','#60a5fa','#f59e0b','#e879f9','#fb923c','#a78bfa'];
+  let   chart   = null;
+
+  async function fetchHistory(planNames) {
+    const qs  = planNames.map(n => 'plan=' + encodeURIComponent(n)).join('&');
+    const url = '/users/' + UID + '/finance/plans/history' + (qs ? '?' + qs : '');
+    const r   = await fetch(url);
+    if (!r.ok) throw new Error(r.status);
+    return r.json();
+  }
+
+  function buildDatasets(data, planNames, showTrend) {
+    const datasets = [];
+    planNames.forEach((name, i) => {
+      const d     = data[name] || {};
+      const color = COLORS[i % COLORS.length];
+      datasets.push({
+        label:           name,
+        data:            (d.series || []).map(p => ({ x: p.date, y: p.pnl_pct })),
+        borderColor:     color,
+        backgroundColor: color + '18',
+        fill:            false,
+        tension:         0.35,
+        pointRadius:     0,
+        borderWidth:     2,
+        spanGaps:        false,
+        order:           1,
+      });
+      if (showTrend && d.trend && (d.trend.points || []).length) {
+        datasets.push({
+          label:       name + ' (tendencia)',
+          data:        d.trend.points.map(p => ({ x: p.date, y: p.pnl_pct })),
+          borderColor: color + '70',
+          borderDash:  [6, 4],
+          borderWidth: 1.5,
+          pointRadius: 0,
+          fill:        false,
+          spanGaps:    true,
+          order:       2,
+        });
+      }
+    });
+    return datasets;
+  }
+
+  function getActivePlans() {
+    return [...document.querySelectorAll('.pnl-toggle:checked')].map(c => c.value);
+  }
+
+  async function render() {
+    const plans     = getActivePlans();
+    const showTrend = document.getElementById('pnl-show-trend').checked;
+    const loading   = document.getElementById('pnl-loading');
+    const errEl     = document.getElementById('pnl-error');
+    loading.style.display = 'flex';
+    errEl.classList.add('hidden');
+
+    let data;
+    try {
+      data = await fetchHistory(plans);
+    } catch (e) {
+      loading.style.display = 'none';
+      errEl.classList.remove('hidden');
+      return;
+    }
+    loading.style.display = 'none';
+
+    // unión de todas las fechas
+    const dateSet = new Set();
+    plans.forEach(name => {
+      const d = data[name] || {};
+      (d.series || []).forEach(p => dateSet.add(p.date));
+      if (showTrend) (d.trend?.points || []).forEach(p => dateSet.add(p.date));
+    });
+    const labels = [...dateSet].sort();
+
+    // índice del último día de serie real (para separar proyección)
+    const lastSeriesDate = plans
+      .map(name => (data[name]?.series || []).at(-1)?.date)
+      .filter(Boolean).sort().at(-1) || '';
+
+    const datasets = buildDatasets(data, plans, showTrend);
+    const ctx      = document.getElementById('pnlChart').getContext('2d');
+
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+      type: 'line',
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
+        scales: {
+          x: {
+            ticks: {
+              color: '#6b7280',
+              maxTicksLimit: 10,
+              callback: (_, idx) => {
+                const d = labels[idx] || '';
+                return d.slice(5);   // MM-DD
+              },
+            },
+            grid: { color: '#1f2937' },
+          },
+          y: {
+            ticks: {
+              color: '#6b7280',
+              callback: v => (v >= 0 ? '+' : '') + v + '%',
+            },
+            grid: { color: '#1f2937' },
+          },
+        },
+        plugins: {
+          legend: {
+            labels: {
+              color: '#9ca3af',
+              filter: item => !item.text.includes('tendencia'),
+              boxWidth: 12,
+              font: { size: 11 },
+            },
+          },
+          tooltip: {
+            callbacks: {
+              label: ctx => {
+                if (ctx.raw === null) return null;
+                const v = ctx.raw.y;
+                return ctx.dataset.label + ': ' + (v >= 0 ? '+' : '') + v + '%';
+              },
+            },
+            filter: item => item.raw !== null,
+          },
+        },
+      },
+    });
+  }
+
+  document.querySelectorAll('.pnl-toggle').forEach(cb =>
+    cb.addEventListener('change', render)
+  );
+  document.getElementById('pnl-show-trend').addEventListener('change', render);
+
+  render();
+})();
+</script>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- Sección "Evolución P&L" en `/users/{uid}` bajo la tabla de planes
- Una línea por plan, toggle individual, línea punteada de tendencia + proyección 30d
- Proxy `GET /users/{uid}/finance/plans/history` → core `:8765`
- Chart.js 4 desde CDN (sin build), colores Tailwind, dark mode nativo
- Update core submodule (get_plan_pnl_history + endpoint)

## Test plan
- [ ] Abrir `/users/matias` en backoffice → sección "Evolución P&L" carga
- [ ] Toggle de plan oculta/muestra la línea
- [ ] Toggle "tendencia" oculta/muestra línea punteada + proyección

🤖 Generated with [Claude Code](https://claude.com/claude-code)