### PR TITLE
feat: fase 6.16 — página dedicada evolución P&L

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1391,6 +1391,13 @@ def get_user_plans_history(request: Request, uid: str):
     return JSONResponse(data)
 
 
+@app.get("/users/{uid}/finance/plans/evolution", response_class=HTMLResponse)
+def user_plans_evolution(request: Request, uid: str):
+    finance_plans = _core(f"/finance/plans/{uid}") or []
+    return _render(request, "finance_pnl_history.html", "users",
+                   uid=uid, finance_plans=finance_plans)
+
+
 @app.delete("/users/{uid}/finance/plans/{plan_name}", response_class=HTMLResponse)
 def delete_user_finance_plan(uid: str, plan_name: str):
     _core(f"/finance/plans/{uid}/{plan_name}", method="DELETE")

--- a/backoffice/templates/finance_pnl_history.html
+++ b/backoffice/templates/finance_pnl_history.html
@@ -1,0 +1,297 @@
+{% extends "base.html" %}
+{% block title %}Evolución P&L — {{ uid }}{% endblock %}
+
+{% block content %}
+<div class="flex items-center gap-3 mb-6">
+  <a href="/users/{{ uid }}" class="text-gray-500 hover:text-white text-sm">← {{ uid }}</a>
+  <span class="text-gray-700">/</span>
+  <h1 class="text-2xl font-bold">Evolución P&L</h1>
+</div>
+
+{% if not finance_plans %}
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-8 text-center text-gray-500 text-sm">
+  No hay planes de inversión para este usuario.
+</div>
+
+{% else %}
+
+<!-- Controles -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-4">
+  <div class="flex items-center gap-4 flex-wrap">
+    <span class="text-xs text-gray-400 uppercase tracking-wider font-semibold">Planes</span>
+    {% for plan in finance_plans %}
+    <label class="flex items-center gap-2 cursor-pointer select-none">
+      <input type="checkbox" class="plan-toggle accent-emerald-500 w-4 h-4"
+             value="{{ plan.name }}" checked>
+      <span class="text-sm text-gray-300">{{ plan.name }}</span>
+    </label>
+    {% endfor %}
+    <button id="btn-refresh"
+            class="ml-auto px-3 py-1.5 bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs rounded-lg transition-colors">
+      Actualizar
+    </button>
+  </div>
+</div>
+
+<!-- Chart -->
+<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
+  <div id="pnl-loading" class="text-center text-gray-500 text-sm py-8">Cargando historial…</div>
+  <div id="pnl-no-data" class="hidden text-center text-gray-500 text-sm py-8">
+    Sin datos suficientes para mostrar evolución (se necesitan al menos 2 registros por plan).
+  </div>
+  <div id="pnl-chart-wrap" class="hidden">
+    <canvas id="pnl-chart" height="320"></canvas>
+  </div>
+</div>
+
+<!-- Métricas por plan -->
+<div id="pnl-metrics" class="grid grid-cols-1 gap-3 hidden">
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script>
+(function () {
+  const UID = {{ uid | tojson }};
+  const PLAN_NAMES = {{ finance_plans | map(attribute='name') | list | tojson }};
+
+  let chart = null;
+
+  const COLORS = [
+    { border: '#10b981', bg: 'rgba(16,185,129,0.08)', trend: '#059669' },
+    { border: '#3b82f6', bg: 'rgba(59,130,246,0.08)', trend: '#2563eb' },
+    { border: '#f59e0b', bg: 'rgba(245,158,11,0.08)',  trend: '#d97706' },
+    { border: '#a78bfa', bg: 'rgba(167,139,250,0.08)', trend: '#7c3aed' },
+    { border: '#f472b6', bg: 'rgba(244,114,182,0.08)', trend: '#db2777' },
+  ];
+
+  function selectedPlans() {
+    return [...document.querySelectorAll('.plan-toggle:checked')].map(el => el.value);
+  }
+
+  function buildUrl(plans) {
+    const base = `/users/${UID}/finance/plans/history`;
+    if (!plans.length) return base;
+    return base + '?' + plans.map(p => `plan=${encodeURIComponent(p)}`).join('&');
+  }
+
+  function buildDatasets(data, labels) {
+    const datasets = [];
+    let colorIdx = 0;
+    for (const [planName, planData] of Object.entries(data)) {
+      const { series, trend } = planData;
+      if (!series || series.length < 2) continue;
+      const col = COLORS[colorIdx % COLORS.length];
+      colorIdx++;
+
+      // Historical series — plain array aligned to labels
+      const seriesMap = Object.fromEntries(series.map(p => [p.date, p.pnl_pct]));
+      const histValues = labels.map(date => {
+        const v = seriesMap[date];
+        return (v !== undefined) ? v : null;
+      });
+
+      datasets.push({
+        label: planName,
+        data: histValues,
+        borderColor: col.border,
+        backgroundColor: col.bg,
+        fill: true,
+        tension: 0.3,
+        pointRadius: 2,
+        pointHoverRadius: 4,
+        spanGaps: false,
+      });
+
+      // Trend line (only if available)
+      if (trend && trend.points && trend.points.length >= 2) {
+        const trendMap = Object.fromEntries(trend.points.map(p => [p.date, p.pnl_pct]));
+        const trendLabels = trend.points.map(p => p.date);
+        // extend labels with future trend dates
+        for (const d of trendLabels) {
+          if (!labels.includes(d)) labels.push(d);
+        }
+        // rebuild trend values after labels may have grown
+        const trendValues = labels.map(date => {
+          const v = trendMap[date];
+          return (v !== undefined) ? v : null;
+        });
+        datasets.push({
+          label: `${planName} (tendencia)`,
+          data: trendValues,
+          borderColor: col.trend,
+          borderDash: [5, 3],
+          borderWidth: 1.5,
+          pointRadius: 0,
+          fill: false,
+          spanGaps: true,
+          tension: 0,
+        });
+      }
+    }
+    return datasets;
+  }
+
+  function renderMetrics(data) {
+    const container = document.getElementById('pnl-metrics');
+    container.innerHTML = '';
+    let hasAny = false;
+    let colorIdx = 0;
+    for (const [planName, planData] of Object.entries(data)) {
+      const { series, trend } = planData;
+      if (!series || series.length < 2) continue;
+      hasAny = true;
+      const col = COLORS[colorIdx % COLORS.length];
+      colorIdx++;
+
+      const last = series[series.length - 1];
+      const first = series[0];
+      const slopeStr = trend && trend.slope_per_day !== undefined
+        ? (trend.slope_per_day >= 0 ? '+' : '') + trend.slope_per_day.toFixed(3) + '%/día'
+        : '—';
+      const proj30Str = trend && trend.projection_30d !== undefined
+        ? (trend.projection_30d >= 0 ? '+' : '') + trend.projection_30d.toFixed(2) + '%'
+        : '—';
+      const r2Str = trend && trend.r2 !== undefined
+        ? (trend.r2 * 100).toFixed(0) + '%'
+        : '—';
+
+      const card = document.createElement('div');
+      card.className = 'bg-gray-900 border border-gray-800 rounded-xl p-4 flex items-start gap-4';
+      card.innerHTML = `
+        <div class="w-2.5 h-2.5 rounded-full mt-1 shrink-0" style="background:${col.border}"></div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-semibold text-gray-200 mb-2">${planName}</div>
+          <div class="grid grid-cols-2 gap-x-6 gap-y-1 text-xs">
+            <div>
+              <span class="text-gray-500">Desde</span>
+              <span class="ml-2 font-mono text-gray-300">${first.date}</span>
+            </div>
+            <div>
+              <span class="text-gray-500">Hasta</span>
+              <span class="ml-2 font-mono text-gray-300">${last.date}</span>
+            </div>
+            <div>
+              <span class="text-gray-500">P&L actual</span>
+              <span class="ml-2 font-mono ${last.pnl_pct >= 0 ? 'text-emerald-400' : 'text-red-400'}">
+                ${last.pnl_pct >= 0 ? '+' : ''}${last.pnl_pct.toFixed(2)}%
+              </span>
+            </div>
+            <div>
+              <span class="text-gray-500">Tendencia</span>
+              <span class="ml-2 font-mono text-gray-400">${slopeStr}</span>
+            </div>
+            <div>
+              <span class="text-gray-500">Proyección 30d</span>
+              <span class="ml-2 font-mono ${(!trend || trend.projection_30d === undefined) ? 'text-gray-500' : trend.projection_30d >= 0 ? 'text-emerald-400' : 'text-red-400'}">
+                ${proj30Str}
+              </span>
+            </div>
+            <div>
+              <span class="text-gray-500">Ajuste (R²)</span>
+              <span class="ml-2 font-mono text-gray-400">${r2Str}</span>
+            </div>
+          </div>
+        </div>
+      `;
+      container.appendChild(card);
+    }
+    container.classList.toggle('hidden', !hasAny);
+  }
+
+  async function load() {
+    const plans = selectedPlans();
+    document.getElementById('pnl-loading').classList.remove('hidden');
+    document.getElementById('pnl-chart-wrap').classList.add('hidden');
+    document.getElementById('pnl-no-data').classList.add('hidden');
+    document.getElementById('pnl-metrics').classList.add('hidden');
+
+    let data;
+    try {
+      const resp = await fetch(buildUrl(plans));
+      data = await resp.json();
+    } catch (e) {
+      document.getElementById('pnl-loading').textContent = 'Error al cargar datos.';
+      return;
+    }
+
+    document.getElementById('pnl-loading').classList.add('hidden');
+
+    // Collect all historical dates (sorted) as the label axis
+    const dateSet = new Set();
+    for (const planData of Object.values(data)) {
+      (planData.series || []).forEach(p => dateSet.add(p.date));
+    }
+    const labels = [...dateSet].sort();
+
+    const datasets = buildDatasets(data, labels);
+
+    const totalPoints = datasets
+      .filter(ds => !ds.label.includes('(tendencia)'))
+      .reduce((s, ds) => s + ds.data.filter(v => v !== null).length, 0);
+
+    if (totalPoints === 0) {
+      document.getElementById('pnl-no-data').classList.remove('hidden');
+      renderMetrics({});
+      return;
+    }
+
+    document.getElementById('pnl-chart-wrap').classList.remove('hidden');
+
+    if (chart) {
+      chart.data.labels = labels;
+      chart.data.datasets = datasets;
+      chart.update();
+    } else {
+      chart = new Chart(document.getElementById('pnl-chart'), {
+        type: 'line',
+        data: { labels, datasets },
+        options: {
+          responsive: true,
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            legend: {
+              labels: { color: '#9ca3af', font: { size: 11 }, boxWidth: 14 }
+            },
+            tooltip: {
+              callbacks: {
+                label: ctx => {
+                  if (ctx.raw === null) return null;
+                  const sign = ctx.raw >= 0 ? '+' : '';
+                  return `${ctx.dataset.label}: ${sign}${ctx.raw.toFixed(2)}%`;
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              type: 'category',
+              ticks: { color: '#6b7280', maxTicksLimit: 10, font: { size: 11 } },
+              grid:  { color: 'rgba(75,85,99,0.2)' }
+            },
+            y: {
+              ticks: {
+                color: '#6b7280',
+                font:  { size: 11 },
+                callback: v => (v >= 0 ? '+' : '') + v.toFixed(1) + '%'
+              },
+              grid: { color: 'rgba(75,85,99,0.2)' }
+            }
+          }
+        }
+      });
+    }
+
+    renderMetrics(data);
+  }
+
+  document.querySelectorAll('.plan-toggle').forEach(el =>
+    el.addEventListener('change', load)
+  );
+  document.getElementById('btn-refresh').addEventListener('click', load);
+
+  load();
+})();
+</script>
+
+{% endif %}
+{% endblock %}

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -665,7 +665,15 @@ async function runAllProactive(uid) {
 <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
   <div class="flex items-center justify-between mb-3">
     <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Planes de inversión</h2>
-    <span class="text-xs text-gray-600">{{ finance_plans | length }} plan{{ 'es' if finance_plans | length != 1 }}</span>
+    <div class="flex items-center gap-3">
+      {% if finance_plans %}
+      <a href="/users/{{ uid }}/finance/plans/evolution"
+         class="text-xs text-emerald-500 hover:text-emerald-400 transition-colors">
+        Ver evolución P&amp;L →
+      </a>
+      {% endif %}
+      <span class="text-xs text-gray-600">{{ finance_plans | length }} plan{{ 'es' if finance_plans | length != 1 }}</span>
+    </div>
   </div>
 
   {% if finance_plans %}
@@ -717,192 +725,5 @@ async function runAllProactive(uid) {
   <p class="text-sm text-gray-600">Sin planes de inversión. Se crearán automáticamente en el próximo ciclo proactivo.</p>
   {% endif %}
 </div>
-
-{% if finance_plans %}
-<!-- Histograma P&L planes -->
-<div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-4">
-  <div class="flex items-center justify-between mb-3">
-    <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Evolución P&amp;L</h2>
-    <div class="flex gap-3 flex-wrap items-center" id="pnl-toggles">
-      {% for plan in finance_plans %}
-      <label class="flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
-        <input type="checkbox" class="pnl-toggle accent-emerald-500" value="{{ plan.name }}" checked>
-        {{ plan.name }}
-      </label>
-      {% endfor %}
-      <label class="flex items-center gap-1.5 text-xs text-gray-500 cursor-pointer select-none">
-        <input type="checkbox" id="pnl-show-trend" checked>
-        tendencia
-      </label>
-    </div>
-  </div>
-  <div class="relative" style="height:280px">
-    <canvas id="pnlChart"></canvas>
-    <div id="pnl-loading" class="absolute inset-0 flex items-center justify-center text-gray-600 text-sm">
-      Cargando historial…
-    </div>
-    <div id="pnl-no-data" class="hidden absolute inset-0 flex items-center justify-center text-gray-600 text-sm">
-      Historial disponible a partir del segundo día de mercado.
-    </div>
-  </div>
-  <p id="pnl-error" class="hidden text-xs text-red-500 mt-2">No se pudo cargar el historial.</p>
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
-<script>
-(function() {
-  const UID     = {{ uid | tojson }};
-  const COLORS  = ['#34d399','#60a5fa','#f59e0b','#e879f9','#fb923c','#a78bfa'];
-  let   chart   = null;
-
-  async function fetchHistory(planNames) {
-    const qs  = planNames.map(n => 'plan=' + encodeURIComponent(n)).join('&');
-    const url = '/users/' + UID + '/finance/plans/history' + (qs ? '?' + qs : '');
-    const r   = await fetch(url);
-    if (!r.ok) throw new Error(r.status);
-    return r.json();
-  }
-
-  function buildDatasets(data, planNames, labels, showTrend) {
-    const datasets = [];
-    planNames.forEach((name, i) => {
-      const d        = data[name] || {};
-      const color    = COLORS[i % COLORS.length];
-      const seriesMap = Object.fromEntries((d.series || []).map(p => [p.date, p.pnl_pct]));
-      const trendMap  = Object.fromEntries((d.trend?.points || []).map(p => [p.date, p.pnl_pct]));
-
-      datasets.push({
-        label:           name,
-        data:            labels.map(date => seriesMap[date] ?? null),
-        borderColor:     color,
-        backgroundColor: color + '18',
-        fill:            false,
-        tension:         0.35,
-        pointRadius:     labels.length < 10 ? 3 : 0,
-        borderWidth:     2,
-        spanGaps:        false,
-        order:           1,
-      });
-      if (showTrend && (d.trend?.points || []).length) {
-        datasets.push({
-          label:       name + ' (tendencia)',
-          data:        labels.map(date => trendMap[date] ?? null),
-          borderColor: color + '70',
-          borderDash:  [6, 4],
-          borderWidth: 1.5,
-          pointRadius: 0,
-          fill:        false,
-          spanGaps:    true,
-          order:       2,
-        });
-      }
-    });
-    return datasets;
-  }
-
-  function getActivePlans() {
-    return [...document.querySelectorAll('.pnl-toggle:checked')].map(c => c.value);
-  }
-
-  async function render() {
-    const plans     = getActivePlans();
-    const showTrend = document.getElementById('pnl-show-trend').checked;
-    const loading   = document.getElementById('pnl-loading');
-    const errEl     = document.getElementById('pnl-error');
-    loading.style.display = 'flex';
-    errEl.classList.add('hidden');
-
-    let data;
-    try {
-      data = await fetchHistory(plans);
-    } catch (e) {
-      loading.style.display = 'none';
-      errEl.classList.remove('hidden');
-      return;
-    }
-    loading.style.display = 'none';
-
-    // unión de todas las fechas (serie real + puntos de tendencia)
-    const dateSet = new Set();
-    plans.forEach(name => {
-      const d = data[name] || {};
-      (d.series || []).forEach(p => dateSet.add(p.date));
-      if (showTrend) (d.trend?.points || []).forEach(p => dateSet.add(p.date));
-    });
-    const labels = [...dateSet].sort();
-
-    // sin datos suficientes: mostrar mensaje
-    const totalPoints = plans.reduce((acc, n) => acc + (data[n]?.series?.length || 0), 0);
-    const msgEl = document.getElementById('pnl-no-data');
-    if (totalPoints === 0) {
-      if (msgEl) msgEl.classList.remove('hidden');
-      return;
-    }
-    if (msgEl) msgEl.classList.add('hidden');
-
-    const datasets = buildDatasets(data, plans, labels, showTrend);
-    const ctx      = document.getElementById('pnlChart').getContext('2d');
-
-    if (chart) chart.destroy();
-    chart = new Chart(ctx, {
-      type: 'line',
-      data: { labels, datasets },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: { mode: 'index', intersect: false },
-        scales: {
-          x: {
-            ticks: {
-              color: '#6b7280',
-              maxTicksLimit: 10,
-              callback: (_, idx) => {
-                const d = labels[idx] || '';
-                return d.slice(5);   // MM-DD
-              },
-            },
-            grid: { color: '#1f2937' },
-          },
-          y: {
-            ticks: {
-              color: '#6b7280',
-              callback: v => (v >= 0 ? '+' : '') + v + '%',
-            },
-            grid: { color: '#1f2937' },
-          },
-        },
-        plugins: {
-          legend: {
-            labels: {
-              color: '#9ca3af',
-              filter: item => !item.text.includes('tendencia'),
-              boxWidth: 12,
-              font: { size: 11 },
-            },
-          },
-          tooltip: {
-            callbacks: {
-              label: ctx => {
-                if (ctx.raw === null || ctx.raw === undefined) return null;
-                const v = ctx.raw;
-                return ctx.dataset.label + ': ' + (v >= 0 ? '+' : '') + v + '%';
-              },
-            },
-            filter: item => item.raw !== null && item.raw !== undefined,
-          },
-        },
-      },
-    });
-  }
-
-  document.querySelectorAll('.pnl-toggle').forEach(cb =>
-    cb.addEventListener('change', render)
-  );
-  document.getElementById('pnl-show-trend').addEventListener('change', render);
-
-  render();
-})();
-</script>
-{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- Extrae el histograma P&L de `user_detail.html` a una página separada: `/users/{uid}/finance/plans/evolution`
- Nueva template `finance_pnl_history.html`: chart con toggles por plan, métricas de tendencia (slope/día, proyección 30d, R²), línea de tendencia punteada
- Ruta `GET /users/{uid}/finance/plans/evolution` en `backoffice/server.py`
- Link "Ver evolución P&L →" en la sección de planes del detalle de usuario

## Test plan

- [ ] Ir a `/users/matias` → verificar link "Ver evolución P&L →" visible si hay planes
- [ ] Click al link → carga `/users/matias/finance/plans/evolution`
- [ ] Verificar que aparece chart con series históricas y líneas de tendencia
- [ ] Toggle checkboxes de planes → chart se actualiza
- [ ] Botón "Actualizar" → recarga datos frescos
- [ ] Métricas por plan: slope, proyección 30d, R²

🤖 Generated with [Claude Code](https://claude.com/claude-code)