### PR TITLE
feat: templates de inversión per-user en backoffice

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1141,20 +1141,21 @@ def alerts_page(request: Request):
                    alerts=data, alert_state=alert_keys)
 
 
-@app.get("/finance/templates", response_class=HTMLResponse)
-def finance_templates_page(request: Request):
-    core_ok   = _core("/health", timeout=3) is not None
-    templates = _core("/finance/templates") or [] if core_ok else []
-    return _render(request, "finance_templates.html", "finance-templates",
-                   templates=templates, core_ok=core_ok)
+@app.get("/users/{uid}/finance/templates", response_class=HTMLResponse)
+def get_user_finance_templates_fragment(uid: str):
+    templates = _core(f"/finance/plans/{uid}/templates") or []
+    return HTMLResponse(_render_templates_rows(uid, templates))
 
 
-@app.post("/finance/templates", response_class=HTMLResponse)
-async def create_finance_template_proxy(request: Request):
-    form     = await request.form()
-    name     = str(form.get("name", "")).strip()
-    raw_pos  = str(form.get("positions_raw", "")).strip()
-    threshold = float(form.get("review_threshold", -10))
+@app.post("/users/{uid}/finance/templates", response_class=HTMLResponse)
+async def create_user_finance_template(request: Request, uid: str):
+    form      = await request.form()
+    name      = str(form.get("name", "")).strip()
+    raw_pos   = str(form.get("positions_raw", "")).strip()
+    try:
+        threshold = float(form.get("review_threshold") or -10)
+    except ValueError:
+        threshold = -10.0
 
     positions: list[dict] = []
     for part in raw_pos.split(","):
@@ -1167,20 +1168,46 @@ async def create_finance_template_proxy(request: Request):
                 pass
 
     if not name or not positions:
-        return HTMLResponse('<p class="text-red-400 text-xs">Nombre y posiciones requeridos.</p>', status_code=422)
+        return HTMLResponse('<p class="text-red-400 text-xs mt-1">Nombre y posiciones requeridos.</p>')
 
-    _core("/finance/templates", method="POST",
+    _core(f"/finance/plans/{uid}/templates", method="POST",
           json={"name": name, "positions": positions, "review_threshold": threshold})
 
-    templates = _core("/finance/templates") or []
-    return _render(request, "finance_templates.html", "finance-templates",
-                   templates=templates, core_ok=True)
+    templates = _core(f"/finance/plans/{uid}/templates") or []
+    return HTMLResponse(_render_templates_rows(uid, templates))
 
 
-@app.delete("/finance/templates/{name}", response_class=HTMLResponse)
-def delete_finance_template_proxy(name: str):
-    _core(f"/finance/templates/{name}", method="DELETE")
+@app.delete("/users/{uid}/finance/templates/{name}", response_class=HTMLResponse)
+def delete_user_finance_template(uid: str, name: str):
+    _core(f"/finance/plans/{uid}/templates/{name}", method="DELETE")
     return HTMLResponse("")
+
+
+def _render_templates_rows(uid: str, templates: list[dict]) -> str:
+    if not templates:
+        return '<p class="text-xs text-gray-600 italic">Sin templates definidos.</p>'
+    rows = []
+    for t in templates:
+        positions_str = ", ".join(
+            f'{p["ticker"]} {p["pct"]:.0f}%' for p in t.get("positions", [])
+        )
+        threshold = t.get("review_threshold", -10.0)
+        name_safe = t["name"].replace('"', "&quot;")
+        rows.append(
+            f'<div class="flex items-center gap-2 py-1.5 border-b border-gray-800 last:border-0">'
+            f'  <span class="text-sm font-medium text-gray-200 w-28 shrink-0">{t["name"]}</span>'
+            f'  <span class="text-xs text-gray-500 flex-1 font-mono">{positions_str}</span>'
+            f'  <span class="text-xs font-mono shrink-0 '
+            f'{"text-amber-400" if threshold >= -5 else "text-yellow-400" if threshold >= -10 else "text-red-400"}">'
+            f'  {threshold:+.0f}%</span>'
+            f'  <button hx-delete="/users/{uid}/finance/templates/{name_safe}"'
+            f'    hx-target="closest div" hx-swap="outerHTML"'
+            f'    hx-confirm="¿Eliminar template \'{name_safe}\'?"'
+            f'    class="shrink-0 px-1.5 py-0.5 text-[10px] text-gray-600 hover:text-red-400'
+            f'           hover:bg-red-900/20 rounded transition-colors">✕</button>'
+            f'</div>'
+        )
+    return "".join(rows)
 
 
 @app.get("/config", response_class=HTMLResponse)

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -78,7 +78,6 @@
         <p class="sb-section px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-600">Configuración</p>
         <a href="/users"            title="Usuarios"      class="{{ link_active if section == 'users'            else link_base }}"><span>👥</span><span class="sb-text">Usuarios</span></a>
         <a href="/integrations"     title="Integraciones" class="{{ link_active if section == 'integrations'     else link_base }}"><span>🔌</span><span class="sb-text">Integraciones</span></a>
-        <a href="/finance/templates"title="Templates inv." class="{{ link_active if section == 'finance-templates' else link_base }}"><span>📋</span><span class="sb-text">Templates inv.</span></a>
         <a href="/config"           title="Config (.env)" class="{{ link_active if section == 'config'           else link_base }}"><span>⚙️</span><span class="sb-text">Config (.env)</span></a>
       </div>
 

--- a/backoffice/templates/user_detail.html
+++ b/backoffice/templates/user_detail.html
@@ -616,6 +616,58 @@ async function runAllProactive(uid) {
         {% endif %}
       </div>
       {% endfor %}
+
+      {% if agent_id == 'finance' %}
+      <!-- Templates de inversión — configuración del agente, no va al LLM -->
+      <div class="mt-4 pt-3 border-t border-gray-800">
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Templates de inversión</span>
+          <button onclick="this.closest('div').querySelector('#tmpl-form').classList.toggle('hidden')"
+                  class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">+ Nuevo</button>
+        </div>
+
+        <!-- Lista cargada por HTMX -->
+        <div id="finance-templates-list"
+             hx-get="/users/{{ uid }}/finance/templates"
+             hx-trigger="load"
+             hx-swap="innerHTML"
+             class="space-y-0 mb-2">
+          <span class="text-xs text-gray-600 italic">Cargando…</span>
+        </div>
+
+        <!-- Formulario nuevo template (oculto por defecto) -->
+        <div id="tmpl-form" class="hidden mt-2 bg-gray-800/50 rounded-lg p-3 space-y-2">
+          <form hx-post="/users/{{ uid }}/finance/templates"
+                hx-target="#finance-templates-list"
+                hx-swap="innerHTML"
+                hx-on::after-request="this.reset(); document.getElementById('tmpl-form').classList.add('hidden')"
+                class="space-y-2">
+            <div class="flex gap-2">
+              <input name="name" placeholder="Nombre (ej: conservador)"
+                     class="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200
+                            focus:outline-none focus:ring-1 focus:ring-indigo-500" required>
+              <input name="review_threshold" type="number" step="0.5" value="-10"
+                     title="Umbral P&L para revisión (%)"
+                     class="w-20 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200
+                            focus:outline-none focus:ring-1 focus:ring-indigo-500">
+            </div>
+            <input name="positions_raw" placeholder="Posiciones: GGAL:30, MELI:40, GC=F:30"
+                   class="w-full bg-gray-900 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200
+                          focus:outline-none focus:ring-1 focus:ring-indigo-500" required>
+            <div class="flex gap-2 justify-end">
+              <button type="button"
+                      onclick="document.getElementById('tmpl-form').classList.add('hidden')"
+                      class="px-2 py-1 text-xs text-gray-500 hover:text-gray-300 transition-colors">Cancelar</button>
+              <button type="submit"
+                      class="px-3 py-1 text-xs bg-indigo-700 hover:bg-indigo-600 text-white rounded transition-colors">
+                Guardar
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+      {% endif %}
+
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary

- Templates de inversión pasan de globales a per-user
- Sección "Templates de inversión" bajo el agente `finance` en `/users/{uid}`, separada visualmente del contexto que va al LLM
- Lista cargada con HTMX al cargar la página; formulario inline para crear nuevos
- Se eliminan las rutas `/finance/templates` (globales) y el ítem del sidebar
- Requiere core PR #176 (ya mergeado)

## Test plan

- [ ] `/users/matias` → sección finance muestra campos LLM Y templates de inversión separados
- [ ] Templates carga defaults (conservador/moderado/agresivo) si no hay archivo por usuario
- [ ] Botón "+ Nuevo" → formulario inline; guardar crea template y actualiza la lista
- [ ] Botón ✕ → elimina template con confirm
- [ ] Sidebar no tiene más "Templates inv."

🤖 Generated with [Claude Code](https://claude.com/claude-code)