### PR TITLE
feat: 6.21 — milestones en histograma P&L

### DIFF
--- a/backoffice/templates/finance_pnl_history.html
+++ b/backoffice/templates/finance_pnl_history.html
@@ -59,14 +59,14 @@
     <span class="text-xs text-gray-400 uppercase tracking-wider font-semibold">Ventana</span>
     <div class="flex items-center gap-1.5">
       <span class="text-xs text-gray-500">Desde</span>
-      <input type="date" id="date-start" value="{{ min_date[:10] }}"
-             min="{{ min_date[:10] }}"
+      <input type="datetime-local" id="date-start" value="{{ min_date[:16] if min_date|length >= 16 else min_date[:10] + 'T00:00' }}"
+             min="{{ min_date[:10] }}T00:00"
              class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200
                     focus:outline-none focus:ring-1 focus:ring-indigo-500">
     </div>
     <div class="flex items-center gap-1.5">
       <span class="text-xs text-gray-500">Hasta</span>
-      <input type="date" id="date-end"
+      <input type="datetime-local" id="date-end"
              class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-200
                     focus:outline-none focus:ring-1 focus:ring-indigo-500">
     </div>
@@ -101,11 +101,14 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8/hammer.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
 <script>
 (function () {
   const UID        = {{ uid | tojson | safe }};
-  const MIN_DATE   = {{ min_date[:10] | tojson | safe }};
-  const TODAY      = new Date().toISOString().slice(0, 10);
+  const MIN_DATE   = {{ (min_date[:16] if min_date|length >= 16 else min_date[:10] + 'T00:00') | tojson | safe }};
+  const _now       = new Date();
+  const _pad       = n => String(n).padStart(2, '0');
+  const TODAY      = `${_now.getFullYear()}-${_pad(_now.getMonth()+1)}-${_pad(_now.getDate())}T23:59`;
 
   let chart      = null;
   let lastData   = null;  // raw API response, for re-renders without fetch
@@ -361,8 +364,11 @@
                   const labs   = c.data.labels;
                   const iMin   = Math.max(0, Math.round(xScale.min));
                   const iMax   = Math.min(labs.length - 1, Math.round(xScale.max));
-                  if (labs[iMin]) document.getElementById('date-start').value = labs[iMin].substring(0, 10);
-                  if (labs[iMax]) document.getElementById('date-end').value   = labs[iMax].substring(0, 10);
+                  const toLocal = lab => lab.length >= 16
+                    ? lab.substring(0, 10) + 'T' + lab.substring(11, 16)
+                    : lab.substring(0, 10) + 'T00:00';
+                  if (labs[iMin]) document.getElementById('date-start').value = toLocal(labs[iMin]);
+                  if (labs[iMax]) document.getElementById('date-end').value   = toLocal(labs[iMax]);
                 }
               }
             }
@@ -387,6 +393,86 @@
     renderMetrics(data);
   }
 
+  /* ── milestones ─────────────────────────────────────────────────────────── */
+
+  const MILESTONE_COLORS = {
+    suggestion: '#f59e0b',
+    applied:    '#10b981',
+    rejected:   '#ef4444',
+  };
+
+  function labelToTs(label) {
+    // labels son "YYYY-MM-DD HH:MM" (intraday) o "YYYY-MM-DD" (daily)
+    const iso = label.length >= 16
+      ? label.replace(' ', 'T') + ':00-03:00'
+      : label + 'T00:00:00-03:00';
+    return new Date(iso).getTime() / 1000;
+  }
+
+  async function loadMilestones(labels) {
+    if (!chart || !labels || labels.length === 0) return;
+
+    const since = labelToTs(labels[0]);
+    let events;
+    try {
+      const resp = await fetch(`/finance/plan-events/${UID}?since=${since}`);
+      const json = await resp.json();
+      events = json.events || [];
+    } catch {
+      return;
+    }
+
+    // Limpiar anotaciones previas
+    if (!chart.options.plugins.annotation) {
+      chart.options.plugins.annotation = {};
+    }
+    if (events.length === 0) {
+      chart.options.plugins.annotation.annotations = {};
+      chart.update('none');
+      return;
+    }
+
+    // Precalcular timestamps de cada label para nearestLabel
+    const labelTsArr = labels.map(l => ({ label: l, ts: labelToTs(l) }));
+    function nearestLabel(eventTs) {
+      let best = labelTsArr[0];
+      let bestDiff = Math.abs(eventTs - best.ts);
+      for (const lt of labelTsArr) {
+        const diff = Math.abs(eventTs - lt.ts);
+        if (diff < bestDiff) { bestDiff = diff; best = lt; }
+      }
+      return best.label;
+    }
+
+    const annotations = {};
+    events.forEach((ev, idx) => {
+      const xLabel = nearestLabel(ev.ts);
+      const color  = MILESTONE_COLORS[ev.event_type] || '#6b7280';
+      const detail = (ev.detail || ev.event_type).substring(0, 45)
+                     + ((ev.detail || '').length > 45 ? '…' : '');
+      annotations[`milestone_${idx}`] = {
+        type:        'line',
+        xMin:        xLabel,
+        xMax:        xLabel,
+        borderColor: color,
+        borderWidth: 1.5,
+        borderDash:  [4, 2],
+        label: {
+          content:         detail,
+          display:         true,
+          position:        'start',
+          color:           color,
+          font:            { size: 10 },
+          backgroundColor: 'rgba(17,24,39,0.88)',
+          padding:         { x: 4, y: 2 },
+        },
+      };
+    });
+
+    chart.options.plugins.annotation.annotations = annotations;
+    chart.update('none');
+  }
+
   /* ── load ───────────────────────────────────────────────────────────────── */
 
   async function load() {
@@ -405,6 +491,9 @@
     }
     document.getElementById('pnl-loading').classList.add('hidden');
     renderChart(lastData);
+
+    const labels = chart ? chart.data.labels : [];
+    await loadMilestones(labels);
   }
 
   // Re-render from cache (no fetch) when toggling breakdown/trend

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -561,6 +561,23 @@ Nota:     Modo dummy (recomendaciones + P&L hipotética). Portfolio por usuario 
            con contribución ponderada, sin fetch (re-render desde cache). Métricas incluyen tabla
            de P&L propio + contribución por ticker. Timezone fix (forward-fill) para planes con
            mezcla de equity/cripto/commodity.
+- [ ] 6.20 Ciclo proactivo de mejora de planes:
+           `_proactive_json_extra_schema` + `_on_proactive_llm_data` + `handle_captured_reply`
+           en FinanceAgent. El LLM proactivo recibe contexto de planes+P&L+perfil+noticias y
+           puede sugerir modificaciones via campo "plan_proposals" en el JSON de respuesta.
+           El usuario acepta/rechaza via request intent (WA o web). Se registra en plan_events.py.
+           HOOKS en ProactiveMixin: _proactive_json_extra_schema (extiende JSON schema al LLM),
+           _on_proactive_llm_data (procesa campos extra de la respuesta). _is_affirmative() parsea
+           respuestas del usuario (sí/dale/ok/...). Auto-dedup contra intents activos por título.
+
+- [ ] 6.21 Milestones en histograma P&L:
+           plan_events.py — log de eventos de plan (suggestion/applied/rejected/manual_edit),
+           almacenado en ~/.local/share/capitan/plan_events/{user_id}.json.
+           Endpoint GET /finance/plan-events/{user_id} con filtros plan_name y since (ts Unix).
+           Backoffice finance_pnl_history.html: chartjs-plugin-annotation@3, función loadMilestones()
+           carga eventos y renderiza líneas verticales: amarillo=sugerencia, verde=aplicado,
+           rojo=rechazado. Nearest-label matching para eje category.
+
 - [x] 6.16 Histograma de P&L de planes a lo largo del tiempo (backoffice):
            Vista en backoffice que muestra evolución histórica del P&L de cada plan.
            FUENTE DE DATOS: precios históricos vía fc.get_price_at_date() / yfinance.history()
@@ -2066,3 +2083,118 @@ de la colaboración entre dominios sin hardcodear lógica inter-agente.
 - [x] 27.8  **Tests** — `tests/test_agent_affinities.py`: 13 tests cubren get/set de affinities
             y shared_state_prefix, SharedState.get_by_prefix (incluye expiración y aislamiento
             de prefijos), y _build_affinity_context (sin affinities, con datos, sin prefix, sin datos).
+
+---
+
+### FASE 28 - Gestión de Modos por Canal (UX Multi-Canal)
+
+```
+Objetivo: Formalizar las capacidades de input/output de cada canal de interacción
+          (wa, mic/ear, web) y hacer que el agente respete esas restricciones al
+          elegir el modo de respuesta. Revisar el campo `notification_mode` del usuario
+          para que tenga sentido en un contexto multi-canal.
+Estado:   Pendiente
+Deps:     FASE 3.5 (WA), FASE 18 (UX audio), FASE 12 (backoffice).
+```
+
+- [ ] 28.1  **Mapa de capacidades por canal** — definir en `core/` un diccionario o clase
+            `CHANNEL_CAPS` que declare para cada canal (`"wa"`, `"ear"`, `"web"`) qué modos
+            de input y output soporta:
+            ```
+            wa:  input=[text, audio], output=[text, audio]
+            ear: input=[audio],       output=[audio]
+            web: input=[text],        output=[text]
+            ```
+            El campo `source` que ya llega en `/process` se usa para lookupear las caps.
+            Estas capacidades deben ser consultables desde el agente y desde el coordinador.
+
+- [ ] 28.2  **Restricción de modo en el coordinador** — al construir el contexto de respuesta,
+            el coordinador (o el dispatch en `agent_registry.py`) debe filtrar el modo elegido
+            por el agente contra `CHANNEL_CAPS[source].output`. Si el agente pidió `audio` pero
+            el canal es `web` (solo texto), degradar a `text` automáticamente y loguear el
+            downgrade. Si el canal tiene múltiples opciones de output (ej. WA), respetar la
+            elección del agente o la preferencia del usuario.
+
+- [ ] 28.3  **Campo `response_mode` en la respuesta del agente** — el agente puede incluir en
+            su respuesta un campo opcional `response_mode: "text" | "audio" | "auto"` para
+            señalizar preferencia. `"auto"` (default) delega la decisión al canal/preferencia
+            del usuario. El adaptador de cada canal (WA, ear, web) aplica la lógica:
+            modo solicitado ∩ caps del canal, con fallback a text.
+
+- [ ] 28.4  **Revisión de `notification_mode` del usuario** — el campo actual
+            (`notification_mode: text | audio`) fue diseñado para WA pero su semántica es
+            ambigua en multi-canal. Decidir e implementar una de estas opciones:
+            a) Reemplazarlo por preferencias por canal: `channel_prefs.wa.output_mode`,
+               `channel_prefs.ear.output_mode`, etc.
+            b) Renombrarlo a `default_output_mode` y usarlo como fallback cuando el canal
+               soporta múltiples modos y el agente devuelve `"auto"`.
+            La opción (b) es más conservadora y suficiente hasta tener más canales activos.
+            Actualizar backoffice (`user_edit.html`) para reflejar el campo renombrado/reestructurado.
+
+---
+
+### FASE 29 - Ejecución Real de Planes de Inversión
+
+```
+Objetivo: Pasar el agente de inversiones de modo "dummy" (P&L hipotética) a modo real:
+          mapear un monto de capital a un plan, ejecutar las órdenes en un broker,
+          y ofrecer palancas de entrada/salida manuales y automáticas.
+Estado:   Pendiente
+Deps:     FASE 6 (planes, portfolio.py, COMPLETA), FASE 9 (coordinador, COMPLETA),
+          FASE 26 (rutinas, para triggers automáticos).
+Nota:     Alcance inicial acotado a instrumentos con API pública disponible (crypto vía
+          exchange API, CEDEARs/acciones vía broker con API REST). El modo dummy coexiste:
+          los planes sin capital asignado siguen siendo hipotéticos.
+```
+
+- [ ] 29.1  **Abstracción de broker (`broker_client.py`)** — interfaz común para ejecutar
+            órdenes de compra/venta independientemente del proveedor. Métodos:
+            `place_order(ticker, side, amount_usd)`, `get_positions()`, `get_balance()`,
+            `cancel_order(order_id)`. Primera implementación concreta: broker simulado
+            (`SimulatedBroker`) que registra órdenes localmente sin tocar APIs externas,
+            para poder desarrollar y testear el flujo completo antes de conectar un broker real.
+            Diseño abierto para agregar `LemonBroker`, `IOLBroker`, `BitsoClient`, etc.
+
+- [ ] 29.2  **Activación de plan con capital real (`portfolio.py`)** — `activate_plan(user_id,
+            plan_name, capital_usd)`: marca el plan como "activo" con el capital asignado,
+            calcula la cantidad de cada instrumento según los pesos del plan y el precio actual,
+            y registra las órdenes de compra en `broker_client`. El plan activo tiene
+            `mode: "real" | "simulated"` y `capital_usd`, `activated_at` en su metadata.
+            Los planes sin activar conservan `mode: "dummy"` y su P&L hipotética.
+
+- [ ] 29.3  **Seguimiento de posiciones reales** — `portfolio.py` distingue posiciones dummy
+            (precio snapshot al crear el plan) de posiciones reales (cantidad efectiva comprada,
+            precio promedio de entrada). `calculate_plan_pnl()` usa precios de broker para
+            planes reales y yfinance para dummy. El backoffice muestra badge "REAL" / "DUMMY"
+            por plan, y para planes reales muestra capital invertido, valor actual y P&L en $.
+
+- [ ] 29.4  **Comandos de entrada/salida por voz y WA** — el agente de inversiones reconoce:
+            - "activá el plan X con $Y" → `activate_plan()` + confirmación explícita antes de ejecutar
+            - "salí del plan X" → liquida todas las posiciones del plan (`close_plan()`)
+            - "salí de TICKER en el plan X" → cierra solo esa posición
+            - "¿cómo están mis posiciones reales?" → resumen de planes activos con P&L en $
+            Toda orden que mueve dinero real requiere confirmación del usuario antes de ejecutar
+            (intent con `needs_reply: true` y texto "¿Confirmás la compra de X por $Y?").
+
+- [ ] 29.5  **Palancas automáticas de entrada** — sistema de triggers configurables por plan:
+            - `entry_trigger`: condición para auto-activar un plan (ej: "cuando BTC baje 5% en
+              el día", "el primer lunes de cada mes"). Implementado como regla evaluada en
+              `finance_alerts.check()` o como rutina de FASE 26.
+            - `entry_capital_usd`: capital a invertir al dispararse el trigger.
+            - Flujo: trigger evalúa → notifica al usuario con opción de confirmar o cancelar
+              dentro de una ventana de tiempo (ej: 30min). Si no hay respuesta, no ejecuta.
+            - Los triggers se configuran desde el backoffice (campo en el formulario del plan).
+
+- [ ] 29.6  **Palancas automáticas de salida** — por posición o por plan completo:
+            - `stop_loss_pct`: cierra automáticamente si P&L cae por debajo del umbral.
+            - `take_profit_pct`: cierra si P&L supera el umbral.
+            - `trailing_stop_pct`: stop dinámico que sigue el máximo alcanzado.
+            - Evaluados en cada ciclo de `finance_alerts.check()`. Al dispararse, notifica
+              por WA/TTS antes de ejecutar y da una ventana de cancelación configurable
+              (`exit_confirm_window_sec`, default 0 = inmediato para stop_loss).
+            - Configurables por plan desde el backoffice.
+
+- [ ] 29.7  **Historial de órdenes reales** — `broker_client` persiste cada orden ejecutada
+            en `finance_orders_{uid}.json`: timestamp, ticker, side, cantidad, precio, status,
+            broker. Endpoint `GET /finance/plans/{uid}/orders` en core. Sección en backoffice
+            bajo el plan activo: tabla de órdenes con filtro por plan y estado.


### PR DESCRIPTION
## Summary

- `chartjs-plugin-annotation@3` CDN en `finance_pnl_history.html`
- `loadMilestones(labels)`: fetch `GET /finance/plan-events/{UID}?since=...`, nearest-label matching para eje `type: category`, anotaciones verticales coloreadas
  - amarillo `#f59e0b` → sugerencia del LLM
  - verde `#10b981` → cambio aplicado por el usuario
  - rojo `#ef4444` → cambio rechazado
- `masterplan/estado.md`: tareas 6.20 y 6.21 documentadas
- Submodule `core` apunta al merge de PR #181

## Test plan

- [ ] Abrir `/users/{uid}/finance/pnl-history` con eventos registrados en `plan_events`
- [ ] Verificar líneas verticales con label al inicio
- [ ] Verificar que no explota cuando no hay eventos (`events=[]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)