### PR TITLE
fix: mostrar tool_calls en trace_detail del backoffice

### DIFF
--- a/backoffice/templates/trace_detail.html
+++ b/backoffice/templates/trace_detail.html
@@ -295,6 +295,31 @@
           {% endfor %}
           {% endif %}
 
+          <!-- Tool calls -->
+          {% if step.tool_calls %}
+          {% for tc in step.tool_calls %}
+          <div class="relative pl-5">
+            <div class="absolute left-[-1px] top-2 w-3 h-px bg-gray-700"></div>
+            <div class="absolute left-[-4px] top-1.5 w-2 h-2 rounded-full bg-violet-900 border border-violet-700"></div>
+            <div class="bg-gray-950 rounded-lg px-4 py-3 border border-violet-900/30">
+              <div class="flex items-center gap-2 text-xs mb-2">
+                <span class="text-violet-400 font-mono">{{ tc.tool_name }}</span>
+                <span class="text-gray-600">iter {{ tc.iteration }}</span>
+                <span class="text-gray-600">{{ tc.latency_ms }}ms</span>
+              </div>
+              <details class="group">
+                <summary class="text-xs text-gray-600 cursor-pointer hover:text-gray-400 select-none">Argumentos ▸</summary>
+                <pre class="mt-2 text-xs text-gray-400 bg-gray-900 rounded p-3 overflow-x-auto">{{ tc.arguments | tojson(indent=2) }}</pre>
+              </details>
+              <details class="group mt-1">
+                <summary class="text-xs text-gray-600 cursor-pointer hover:text-gray-400 select-none">Resultado ▸</summary>
+                <pre class="mt-2 text-xs text-gray-300 bg-gray-900 rounded p-3 overflow-x-auto">{{ tc.result | tojson(indent=2) }}</pre>
+              </details>
+            </div>
+          </div>
+          {% endfor %}
+          {% endif %}
+
           <!-- Respuesta del agente -->
           <div class="relative pl-5">
             <div class="absolute left-[-1px] top-2 w-3 h-px bg-gray-700"></div>


### PR DESCRIPTION
## Summary
- `trace_detail.html` tenía secciones para `api_calls` y `agent_llm_calls` pero no para `tool_calls`
- Los datos ya existen en el trace desde FASE 30; solo faltaba renderizarlos
- Cada tool call muestra: nombre, iteración, latencia, argumentos y resultado (collapsibles)

## Test plan
- [ ] Abrir trace `d4ad743f03c6` en el backoffice y verificar que aparece la tool call `list_proactive_runs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)