### PR TITLE
FASE 33 Etapa A — diseño y contrato del backoffice en la nube

### DIFF
--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -2866,7 +2866,7 @@ Objetivo: Tener un backoffice accesible desde internet SIN exponer el SER9 ni HA
           La nube nunca inicia conexiones hacia la casa: el SER9 empuja estado para
           dibujar el dashboard y POLEA una cola de comandos para ejecutar acciones de
           administración (patrón command / executor). Plataforma: Google Cloud.
-Estado:   Pendiente
+Estado:   EN CURSO (4/17 — Etapa A diseño/contrato completa; ver fase33_cloud_backoffice.md)
 Deps:     FASE 12 (backoffice local — COMPLETA, fuente de datos y UI a reusar),
           FASE 21 (SER9 estable — COMPLETA), FASE 32 (datos en SQLite — COMPLETA).
 Principio de seguridad: el SER9 sólo hace conexiones SALIENTES (HTTPS) a la nube.
@@ -2886,16 +2886,17 @@ Stack GCP elegido: Cloud Run (web + API, scale-to-zero), Firestore (snapshot de
 ```
 
 #### Etapa A - Diseño y contrato
-- [ ] 33.1  Documentar el modelo egress-only y el modelo de amenazas: qué datos salen de
+> Diseño completo en `masterplan/fase33_cloud_backoffice.md`.
+- [x] 33.1  Documentar el modelo egress-only y el modelo de amenazas: qué datos salen de
             la red local, qué NO sale nunca (tokens HAOS, .env, PII sensible), y por qué la
             nube no puede iniciar conexiones hacia la casa.
-- [ ] 33.2  Definir el contrato del snapshot de estado (server→nube): servicios up/down,
+- [x] 33.2  Definir el contrato del snapshot de estado (server→nube): servicios up/down,
             latencias STT/LLM/HAOS, agentes activos, últimos comandos, métricas de wake word,
             usuarios (sin datos sensibles). Minimizar el subconjunto que sale de la LAN.
-- [ ] 33.3  Definir el catálogo TIPADO de comandos admin permitidos (allowlist): restart de
+- [x] 33.3  Definir el catálogo TIPADO de comandos admin permitidos (allowlist): restart de
             servicio, redeploy, ver logs, recargar config, reentrenar wake word, re-enrolar voz,
             etc. Cada comando es un tipo cerrado con parámetros validados. NUNCA shell arbitrario.
-- [ ] 33.4  Definir autenticación en ambas direcciones: dashboard vía Identity Platform
+- [x] 33.4  Definir autenticación en ambas direcciones: dashboard vía Identity Platform
             restringido al email del usuario; bridge del SER9 vía token OIDC de Service Account
             (sin API keys embebidas si se puede). Definir rotación de credenciales.
 

--- a/masterplan/fase33_cloud_backoffice.md
+++ b/masterplan/fase33_cloud_backoffice.md
@@ -1,0 +1,249 @@
+# FASE 33 — Backoffice en la nube: diseño y contrato (Etapa A)
+
+Documento de diseño de los ítems 33.1–33.4. Fuente de verdad del contrato entre el
+SER9 y la nube. Cualquier cambio de payload, comando o autenticación se refleja acá
+**antes** de tocar código.
+
+Plataforma: Google Cloud (Cloud Run + Firestore + Identity Platform + Secret Manager).
+
+---
+
+## 33.1 — Modelo egress-only y modelo de amenazas
+
+### Principio rector
+
+El SER9 **sólo** abre conexiones salientes HTTPS hacia la nube. La nube nunca inicia
+una conexión hacia la casa. No hay port-forwarding, no hay inbound, no hay túnel
+persistente reverso administrado por terceros. Si la nube desaparece, la casa sigue
+operando y el backoffice local (FASE 12, LAN) sigue disponible.
+
+```
+                 (1) push estado  ─────────────►
+   [SER9 LXC] ── (2) poll comandos ────────────►  [Cloud Run + Firestore] ◄── HTTPS ── [navegador]
+                 (3) post resultado ───────────►
+                          ▲
+                  todas SALIENTES desde el SER9
+```
+
+Las tres interacciones del bridge (push estado, poll comandos, post resultado) son
+requests HTTPS salientes iniciadas por el SER9. La nube responde dentro de esa misma
+conexión; nunca abre una nueva hacia la LAN.
+
+### Qué sale de la red local (dato que cruza a la nube)
+
+- Estado de salud de servicios (up/down de core, LLM, ear, backoffice, WA).
+- Latencias agregadas (STT / LLM / HAOS), promedios y por comando.
+- Lista de agentes activos y su estado on/off.
+- Últimos N comandos de voz: texto del comando, agente que respondió, latencia,
+  timestamp. **Texto del comando incluido** — asumido de bajo riesgo (domótica),
+  pero ver "datos a minimizar".
+- Métricas de wake word (score, falsos positivos, estado del nodo).
+- Usuarios: sólo `id`, `nombre`, `rol`, conteos. **Sin** documentos, sin PII de
+  contacto, sin tokens de servicios.
+- Resultado de comandos admin ejecutados (stdout acotado / código de salida).
+
+### Qué NO sale NUNCA de la red local
+
+- `HAOS_TOKEN` y cualquier credencial en `core/.env` / `backoffice/.env`.
+- Tokens OAuth de servicios de usuario (Google, MercadoLibre, etc.).
+- Documentos de usuario / PII sensible (DNI, expiraciones, datos de contacto).
+- El `.env` de ningún submodule, claves SSH, ni secretos de despliegue.
+- Direcciones IP internas y topología detallada de la LAN más allá de lo necesario
+  para dibujar el dashboard.
+- Audio crudo, embeddings de voz, ni samples de wake word.
+
+Regla de minimización: el bridge construye el snapshot a partir de un **subconjunto
+explícito allow-list** de campos. Nunca serializa objetos de dominio completos. Si un
+campo no está en el contrato de 33.2, no se envía.
+
+### Por qué la nube no puede iniciar conexiones hacia la casa
+
+- No existe ningún endpoint inbound en el SER9 expuesto a internet. El LXC no tiene
+  puerto publicado ni regla de NAT/port-forward en el router.
+- La nube no conoce ninguna IP pública enrutable hacia la casa (IP dinámica + sin
+  DNS dinámico apuntando al SER9).
+- El control fluye por inversión: la nube **encola** comandos en Firestore; el SER9
+  los **busca** (pull) en su próximo ciclo de polling. La nube nunca "empuja" al SER9.
+- Aunque la cuenta de nube se comprometa, el atacante sólo puede encolar comandos del
+  catálogo tipado (33.3), que se ejecutan con permiso mínimo y quedan auditados. No
+  obtiene shell, ni los secretos, ni acceso a HAOS.
+
+### Modelo de amenazas (resumen)
+
+| Amenaza | Mitigación |
+|---|---|
+| Compromiso de la cuenta/proyecto GCP | Comandos sólo del catálogo tipado; sin shell arbitrario; secretos nunca en la nube; auditoría de cada comando. |
+| Interceptación en tránsito | HTTPS gestionado por Cloud Run; verificación de firma del payload (33.14). |
+| Replay de un comando | `id` único + estado `done` idempotente; TTL en la cola; rechazo de comandos ya ejecutados. |
+| Acceso no autorizado al dashboard | Identity Platform con allow-list por email (33.8); sin registro abierto. |
+| Robo de credencial del bridge | Service Account de permiso mínimo, token OIDC de corta vida, rotación documentada (33.13). |
+| Caída de la nube | Failover: la casa sigue local; bridge reintenta con backoff (33.17). |
+| Exfiltración de PII vía snapshot | Allow-list de campos; PII y tokens excluidos por diseño (este doc). |
+
+---
+
+## 33.2 — Contrato del snapshot de estado (SER9 → nube)
+
+Endpoint destino: `POST /ingest/state`. El bridge envía el snapshot completo en cada
+ciclo (idempotente: la nube reemplaza el snapshot actual y conserva histórico corto).
+
+### Esquema (JSON)
+
+```jsonc
+{
+  "schema_version": 1,
+  "ts": "2026-06-16T12:00:00Z",        // ISO-8601 UTC, momento de captura
+  "host": "capitan-lxc",                // identificador del emisor (no IP)
+  "services": {                          // up/down por servicio
+    "core":       { "up": true,  "detail": "ok" },
+    "llm":        { "up": true,  "detail": "qwen2.5:7b warm" },
+    "ear":        { "up": true,  "detail": "2 nodos" },
+    "backoffice": { "up": true,  "detail": "ok" },
+    "wa":         { "up": false, "detail": "stopped" }
+  },
+  "latency": {                           // milisegundos, promedios móviles
+    "stt_ms":  4600,
+    "llm_ms":  3500,
+    "haos_ms": 120,
+    "by_command": [                      // últimas mediciones por comando (acotado)
+      { "cmd": "prende la luz", "stt_ms": 4500, "llm_ms": 3200, "haos_ms": 110 }
+    ]
+  },
+  "agents": [                            // agentes y su estado
+    { "id": "haos",    "active": true,  "proactive": false },
+    { "id": "clima",   "active": true,  "proactive": true  },
+    { "id": "finance", "active": false, "proactive": false }
+  ],
+  "recent_commands": [                   // últimos N (default 20), sin PII
+    {
+      "ts": "2026-06-16T11:58:30Z",
+      "text": "prende la luz del comedor",
+      "agent": "haos",
+      "ok": true,
+      "latency_ms": 7800
+    }
+  ],
+  "wakeword": {
+    "last_score": 0.83,
+    "false_positives_24h": 1,
+    "nodes": [
+      { "id": "comedor", "ip": "192.168.68.113", "online": true, "rms": 1000 }
+    ]
+  },
+  "users_summary": [                     // sin documentos, sin tokens, sin PII
+    { "id": "matias", "name": "Matías", "role": "admin", "intents_pending": 2 }
+  ]
+}
+```
+
+### Reglas del contrato
+
+- `schema_version` obligatorio. La nube rechaza versiones que no entiende (no degrada
+  en silencio).
+- Tamaño acotado: `recent_commands` y `latency.by_command` con tope (default 20) para
+  mantener el payload chico y dentro del free tier.
+- Listas allow-list: cada objeto incluye **sólo** los campos del esquema. El bridge no
+  reenvía objetos de dominio completos.
+- `ip` de nodos se incluye sólo para mostrar topología en el dashboard; es IP privada
+  (LAN), no enrutable. Evaluar omitirla si no aporta.
+- Sin tokens, sin documentos, sin audio, sin embeddings (ver 33.1).
+- La nube sella el snapshot con su propio `received_at`; no confía en el `ts` del
+  emisor para ordenar histórico.
+
+---
+
+## 33.3 — Catálogo tipado de comandos admin (allow-list)
+
+Principio: **NUNCA shell arbitrario.** Cada comando es un tipo cerrado con `type`
+fijo y parámetros validados contra un esquema. El executor (33.12) mapea cada `type`
+a una función concreta; un `type` desconocido se rechaza sin ejecutar.
+
+### Estructura de un comando (en la cola Firestore)
+
+```jsonc
+{
+  "id": "cmd_01HXYZ...",                // generado por la nube, único
+  "type": "service.restart",            // del catálogo cerrado de abajo
+  "params": { "service": "capitan-core" },
+  "issued_by": "matias@blasi.ar",       // email autenticado que lo emitió
+  "issued_at": "2026-06-16T12:01:00Z",
+  "status": "pending",                  // pending | running | done | error
+  "result": null,                       // se completa al postear resultado
+  "ttl_at": "2026-06-17T12:01:00Z"      // expiración en Firestore
+}
+```
+
+### Catálogo (v1)
+
+| `type` | Parámetros | Validación | Acción en el SER9 |
+|---|---|---|---|
+| `service.restart` | `service` ∈ {`capitan-core`, `capitan-backoffice`, `capitan-wa`, `capitan-ear`} | enum cerrado | `systemctl --user restart <service>` |
+| `service.status` | `service` (mismo enum) o vacío = todos | enum/opcional | `systemctl --user status` parseado |
+| `deploy.run` | `restart_wa`: bool | bool | ejecuta `scripts/deploy.sh` |
+| `logs.tail` | `service` (enum), `lines`: int 1..500 | enum + rango | `journalctl --user -u <service> -n <lines>` |
+| `config.reload` | `target` ∈ {`core`, `backoffice`} | enum | recarga config sin redeploy |
+| `wakeword.retrain` | — | — | dispara `/wakeword/train` (FASE async) |
+| `voice.reenroll` | `node_id`, `user_id` | existen en estado | re-enrola embedding desde el nodo |
+
+Notas:
+- Cada `type` es exhaustivo: parámetros fuera del esquema → rechazo, no ejecución.
+- Los enums se validan contra el estado conocido (servicios/nodos/usuarios reales),
+  no contra texto libre.
+- Comandos de larga duración (`deploy.run`, `wakeword.retrain`) pasan a `running` y
+  reportan resultado al terminar; el dashboard muestra el progreso.
+- El catálogo es versionado junto al executor. Agregar un comando = agregar el tipo
+  acá **y** la función concreta en el executor; nunca uno sin el otro.
+
+---
+
+## 33.4 — Autenticación bidireccional
+
+### Dashboard (navegador → nube)
+
+- **Identity Platform / Firebase Auth.** Login con proveedor (Google) restringido por
+  **allow-list de email** (33.8): sólo `matias@blasi.ar` (y los que se agreguen
+  explícitamente). Sin auto-registro.
+- El frontend obtiene un ID token de Firebase; cada request a la API de Cloud Run lo
+  envía en `Authorization: Bearer`. Cloud Run valida el token y el claim de email
+  contra la allow-list antes de servir datos o aceptar emisión de comandos.
+- Reglas de seguridad de Firestore por colección (33.6) refuerzan el acceso del lado
+  de datos: lectura del dashboard sólo para emails autorizados.
+
+### Bridge (SER9 → nube)
+
+- El bridge se autentica con un **token OIDC de Service Account** (sin API key
+  embebida en el repo). La SA tiene permiso mínimo: invocar el servicio Cloud Run de
+  ingest/commands, nada más.
+- Token de corta vida obtenido del metadata/credenciales de la SA; el bridge lo
+  refresca automáticamente. Cloud Run valida el `aud` y la identidad de la SA.
+- La clave de la SA (si se usa archivo, no Workload Identity) vive **fuera del repo**,
+  en el filesystem del LXC con permisos restrictivos, referenciada por env var. En la
+  nube los secretos van en Secret Manager.
+
+### Integridad de payload
+
+- Además del transporte TLS, el snapshot y los resultados de comando se firman
+  (HMAC con secreto compartido del bridge, o la propia identidad OIDC) y la nube
+  verifica antes de aceptar (33.14). Esto evita que un cliente sin la credencial del
+  bridge inyecte estado falso aunque conozca la URL.
+
+### Rotación de credenciales
+
+- Secreto/clave de la SA del bridge: rotación documentada (33.13). Procedimiento:
+  generar nueva credencial en GCP → cargar en Secret Manager / filesystem del LXC →
+  reiniciar el bridge → revocar la anterior. Sin downtime del sistema local.
+- HMAC compartido (si se usa): rotación con ventana de doble-aceptación (acepta clave
+  vieja y nueva durante la transición) para no perder snapshots.
+- Allow-list de emails del dashboard: gestionada en config de Identity Platform,
+  cambio inmediato sin redeploy.
+
+---
+
+## Decisiones de Etapa A (no reabrir sin justificación)
+
+- Control por **inversión / pull**: la nube encola, el SER9 polea. Cero inbound.
+- Firestore unifica **estado + cola de comandos** (vs Pub/Sub) para tener histórico
+  y auditoría con TTL en un solo lugar.
+- Comandos **tipados y cerrados**, nunca shell. Catálogo versionado junto al executor.
+- Secretos y PII **nunca** cruzan a la nube. Snapshot por allow-list de campos.
+- Auth dashboard por Identity Platform + allow-list de email; bridge por OIDC de SA.


### PR DESCRIPTION
Diseño y contrato de FASE 33 (33.1–33.4), todo en `masterplan/fase33_cloud_backoffice.md`.

- **33.1** Modelo egress-only + modelo de amenazas: qué dato cruza a la nube, qué no sale nunca (tokens HAOS, .env, PII), por qué la nube no puede iniciar conexiones hacia la casa (control por inversión/pull).
- **33.2** Contrato del snapshot `POST /ingest/state` con esquema JSON y allow-list de campos.
- **33.3** Catálogo tipado de comandos admin (allow-list cerrada, sin shell arbitrario).
- **33.4** Autenticación bidireccional (dashboard via Identity Platform + allow-list de email; bridge via OIDC de Service Account) + rotación de credenciales.

Sin código ejecutable; sólo diseño/contrato. Lint de estado.md OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)