### PR TITLE
FASE 33 Etapa C — bridge/executor en el SER9

### DIFF
--- a/cloud/bridge/README.md
+++ b/cloud/bridge/README.md
@@ -1,0 +1,47 @@
+# cloud/bridge/ — Bridge/executor del SER9 (FASE 33 Etapa C)
+
+Daemon que corre en el LXC del SER9 (no en la nube). Hace **sólo conexiones
+salientes** hacia el servicio Cloud Run (`cloud/`):
+
+- `cloud_bridge.py` — loop: push del snapshot (`/ingest/state`) cada `PUSH_INTERVAL`
+  y poll de comandos (`/commands/pending`) cada `POLL_INTERVAL`, con backoff.
+- `snapshot.py` — arma el snapshot reusando core (:8765) + audio_server (:8766) +
+  `/tmp/capitan`. Allow-list de campos; nunca tokens/PII.
+- `executor.py` — ejecuta cada comando del catálogo TIPADO con una función concreta
+  (subprocess con lista de args, sin shell). El catálogo es el mismo de la nube
+  (`cloud/app/commands.py`), re-validado en el bridge.
+
+## Credencial (33.13)
+
+La SA del bridge (`capitan-bridge@<project>.iam.gserviceaccount.com`) **no tiene
+roles de proyecto**: sólo se usa su identidad para mintear ID tokens OIDC con
+audience = URL del servicio. La key vive **fuera del repo**, en el LXC:
+
+```
+~/.config/capitan/bridge-sa-key.json   # chmod 600, gitignored
+```
+
+Rotación: generar nueva key (`gcloud iam service-accounts keys create`), reemplazar
+el archivo, `systemctl --user restart capitan-bridge`, y borrar la key vieja
+(`gcloud iam service-accounts keys delete`).
+
+## Config (`~/.config/capitan/bridge.env`)
+
+```
+CLOUD_URL=https://capitan-cloud-m2x3ep3hfa-rj.a.run.app
+BRIDGE_SA_KEY=%h/.config/capitan/bridge-sa-key.json
+CORE_URL=http://localhost:8765
+AUDIO_SERVER_URL=http://localhost:8766
+PUSH_INTERVAL=30
+POLL_INTERVAL=10
+```
+
+## Instalación en el LXC
+
+```bash
+cp cloud/bridge/capitan-bridge.service ~/.config/systemd/user/
+~/home-agents-env/bin/pip install -r cloud/bridge/requirements.txt
+systemctl --user daemon-reload
+systemctl --user enable --now capitan-bridge
+journalctl --user -u capitan-bridge -f
+```

--- a/cloud/bridge/capitan-bridge.service
+++ b/cloud/bridge/capitan-bridge.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Capitán cloud bridge (push estado + poll comandos hacia la nube)
+After=network-online.target capitan-core.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/workspace/home-agents/cloud/bridge
+EnvironmentFile=%h/.config/capitan/bridge.env
+ExecStart=%h/home-agents-env/bin/python %h/workspace/home-agents/cloud/bridge/cloud_bridge.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/cloud/bridge/cloud_bridge.py
+++ b/cloud/bridge/cloud_bridge.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""cloud_bridge.py — bridge/executor del SER9 hacia el backoffice en la nube.
+
+FASE 33 Etapa C. Conexiones SALIENTES únicamente (control por inversión):
+  - push periódico del snapshot de estado    → POST /ingest/state          (33.10)
+  - poll de la cola de comandos con backoff   → GET  /commands/pending      (33.11)
+  - ejecuta cada comando (executor seguro)    → POST /commands/{id}/result  (33.12)
+
+Auth: ID token OIDC de la Service Account del bridge (audience = URL del servicio),
+sin API keys embebidas. La key de la SA vive FUERA del repo (33.13).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+
+# Catálogo TIPADO compartido con la nube (única fuente de verdad).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app.commands import CommandError, validate_command  # noqa: E402
+
+from google.auth.transport.requests import AuthorizedSession  # noqa: E402
+from google.oauth2 import service_account  # noqa: E402
+
+import executor  # noqa: E402
+import snapshot  # noqa: E402
+
+CLOUD_URL = os.environ["CLOUD_URL"].rstrip("/")
+SA_KEY = os.environ["BRIDGE_SA_KEY"]
+PUSH_INTERVAL = int(os.environ.get("PUSH_INTERVAL", "30"))
+POLL_INTERVAL = int(os.environ.get("POLL_INTERVAL", "10"))
+MAX_BACKOFF = int(os.environ.get("MAX_BACKOFF", "300"))
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("cloud_bridge")
+
+
+def _session() -> AuthorizedSession:
+    creds = service_account.IDTokenCredentials.from_service_account_file(
+        SA_KEY, target_audience=CLOUD_URL,
+    )
+    return AuthorizedSession(creds)
+
+
+def push_state(sess: AuthorizedSession) -> None:
+    snap = snapshot.build_snapshot()
+    r = sess.post(f"{CLOUD_URL}/ingest/state", json=snap, timeout=15)
+    r.raise_for_status()
+    log.info("push estado OK (%d servicios, %d agentes)",
+             len(snap["services"]), len(snap["agents"]))
+
+
+def poll_and_execute(sess: AuthorizedSession) -> None:
+    r = sess.get(f"{CLOUD_URL}/commands/pending", timeout=15)
+    r.raise_for_status()
+    for cmd in r.json().get("commands", []):
+        cid, ctype, params = cmd["id"], cmd["type"], cmd.get("params", {})
+        log.info("comando %s type=%s params=%s issued_by=%s",
+                 cid, ctype, params, cmd.get("issued_by"))
+        try:
+            clean = validate_command(ctype, params)  # re-validación defensiva
+            result = executor.execute(ctype, clean)
+        except CommandError as exc:
+            result = executor.ExecResult(False, "", f"rechazado por catálogo: {exc}")
+        log.info("comando %s → ok=%s %s", cid, result.ok, result.error or "")
+        try:
+            rr = sess.post(f"{CLOUD_URL}/commands/{cid}/result",
+                           json=result.as_dict(), timeout=15)
+            rr.raise_for_status()
+        except Exception as exc:  # noqa: BLE001
+            log.error("no se pudo postear resultado de %s: %s", cid, exc)
+
+
+def main() -> None:
+    log.info("bridge arrancando → %s (push %ds, poll %ds)",
+             CLOUD_URL, PUSH_INTERVAL, POLL_INTERVAL)
+    sess = _session()
+    last_push = 0.0
+    backoff = POLL_INTERVAL
+    while True:
+        try:
+            now = time.monotonic()
+            if now - last_push >= PUSH_INTERVAL:
+                push_state(sess)
+                last_push = now
+            poll_and_execute(sess)
+            backoff = POLL_INTERVAL  # reset tras un ciclo OK
+        except Exception as exc:  # noqa: BLE001 — la nube puede estar caída
+            log.warning("ciclo falló (%s); backoff %ds", exc, backoff)
+            time.sleep(backoff)
+            backoff = min(backoff * 2, MAX_BACKOFF)
+            continue
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/cloud/bridge/executor.py
+++ b/cloud/bridge/executor.py
@@ -1,0 +1,123 @@
+"""Executor seguro de comandos admin. FASE 33 (33.12).
+
+Cada tipo del catálogo TIPADO mapea a una función concreta. NUNCA eval ni shell
+arbitrario: subprocess siempre con lista de argumentos (sin shell=True) y los enums
+ya vienen validados por el catálogo compartido (commands.py). Auditoría: el daemon
+loguea cada comando, parámetros y resultado.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import requests
+
+CORE_URL = os.environ.get("CORE_URL", "http://localhost:8765")
+AUDIO_URL = os.environ.get("AUDIO_SERVER_URL", "http://localhost:8766")
+REPO_DIR = os.environ.get("REPO_DIR", os.path.expanduser("~/workspace/home-agents"))
+PIP = os.environ.get("PIP_BIN", os.path.expanduser("~/home-agents-env/bin/pip"))
+
+
+class ExecResult:
+    def __init__(self, ok: bool, output: str = "", error: str = ""):
+        self.ok, self.output, self.error = ok, output, error
+
+    def as_dict(self) -> dict:
+        return {"ok": self.ok, "output": self.output, "error": self.error}
+
+
+def _run(args: list[str], timeout: int = 60) -> ExecResult:
+    """Ejecuta un comando con lista de args (sin shell). Devuelve ExecResult."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+        out = (p.stdout or "") + (p.stderr or "")
+        return ExecResult(p.returncode == 0, out.strip(), "" if p.returncode == 0 else f"exit {p.returncode}")
+    except subprocess.TimeoutExpired:
+        return ExecResult(False, "", f"timeout tras {timeout}s")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", str(exc))
+
+
+# ── Handlers por tipo ───────────────────────────────────────────────────────────
+
+def _service_restart(p: dict) -> ExecResult:
+    return _run(["systemctl", "--user", "restart", p["service"]], timeout=30)
+
+
+def _service_status(p: dict) -> ExecResult:
+    svc = p.get("service")
+    units = [svc] if svc else ["capitan-core", "capitan-backoffice", "capitan-wa"]
+    return _run(["systemctl", "--user", "is-active", *units], timeout=10)
+
+
+def _logs_tail(p: dict) -> ExecResult:
+    lines = str(p.get("lines", 100))
+    return _run(["journalctl", "--user", "-u", p["service"], "-n", lines, "--no-pager"], timeout=15)
+
+
+def _deploy_run(p: dict) -> ExecResult:
+    out = []
+    for step in (
+        ["git", "-C", REPO_DIR, "pull", "--recurse-submodules"],
+        [PIP, "install", "-q", "-r", os.path.join(REPO_DIR, "core/requirements.txt")],
+        [PIP, "install", "-q", "-r", os.path.join(REPO_DIR, "backoffice/requirements.txt")],
+        ["systemctl", "--user", "restart", "capitan-core", "capitan-backoffice"],
+    ):
+        r = _run(step, timeout=180)
+        out.append(f"$ {' '.join(step)}\n{r.output}")
+        if not r.ok:
+            return ExecResult(False, "\n".join(out), r.error)
+    if p.get("restart_wa"):
+        r = _run(["systemctl", "--user", "restart", "capitan-wa"], timeout=30)
+        out.append(f"restart wa: {r.output}")
+    return ExecResult(True, "\n".join(out))
+
+
+def _config_reload(p: dict) -> ExecResult:
+    if p["target"] == "core":
+        try:
+            r = requests.post(f"{CORE_URL}/users/reload", timeout=10)
+            r.raise_for_status()
+            return ExecResult(True, f"core reload: {r.status_code}")
+        except Exception as exc:  # noqa: BLE001
+            return ExecResult(False, "", str(exc))
+    return _run(["systemctl", "--user", "restart", "capitan-backoffice"], timeout=30)
+
+
+def _wakeword_retrain(_p: dict) -> ExecResult:
+    try:
+        r = requests.post(f"{AUDIO_URL}/wakeword/train", timeout=15)
+        r.raise_for_status()
+        return ExecResult(True, f"retrain disparado: {r.status_code}")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", f"endpoint de retrain no disponible: {exc}")
+
+
+def _voice_reenroll(p: dict) -> ExecResult:
+    try:
+        r = requests.post(
+            f"{AUDIO_URL}/nodes/{p['node_id']}/enroll/voice/{p['user_id']}", timeout=15
+        )
+        r.raise_for_status()
+        return ExecResult(True, f"re-enroll disparado: {r.status_code}")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", f"endpoint de enroll no disponible: {exc}")
+
+
+HANDLERS = {
+    "service.restart": _service_restart,
+    "service.status": _service_status,
+    "logs.tail": _logs_tail,
+    "deploy.run": _deploy_run,
+    "config.reload": _config_reload,
+    "wakeword.retrain": _wakeword_retrain,
+    "voice.reenroll": _voice_reenroll,
+}
+
+
+def execute(cmd_type: str, params: dict) -> ExecResult:
+    """Despacha al handler concreto. El tipo ya fue validado contra el catálogo."""
+    handler = HANDLERS.get(cmd_type)
+    if handler is None:
+        return ExecResult(False, "", f"sin handler para {cmd_type!r}")
+    return handler(params)

--- a/cloud/bridge/requirements.txt
+++ b/cloud/bridge/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+google-auth>=2.37

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -1,0 +1,171 @@
+"""Construcción del snapshot de estado (SER9 → nube). FASE 33 (33.10).
+
+Reusa datos que ya producen core (:8765) y audio_server (:8766) + /tmp/capitan.
+Best-effort y resiliente: cada fuente está envuelta en try/except y nunca propaga
+excepciones — un snapshot parcial es mejor que ninguno. Allow-list de campos: sólo
+se serializa lo definido en el contrato (33.2), nunca objetos de dominio completos.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+CORE_URL = os.environ.get("CORE_URL", "http://localhost:8765")
+AUDIO_URL = os.environ.get("AUDIO_SERVER_URL", "http://localhost:8766")
+LLM_URL = os.environ.get("LLM_BASE_URL", os.environ.get("OLLAMA_URL", "http://localhost:11434"))
+METRICS_DIR = Path(os.environ.get("METRICS_DIR", "/tmp/capitan"))
+HOST = os.environ.get("BRIDGE_HOST", "capitan-lxc")
+RECENT_LIMIT = int(os.environ.get("SNAPSHOT_RECENT_LIMIT", "20"))
+
+SYSTEMD_UNITS = {
+    "core": "capitan-core",
+    "backoffice": "capitan-backoffice",
+    "wa": "capitan-wa",
+}
+
+
+def _get(url: str, timeout: int = 4):
+    try:
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return None
+
+
+def _systemctl_active(unit: str) -> bool:
+    try:
+        out = subprocess.run(
+            ["systemctl", "--user", "is-active", unit],
+            capture_output=True, text=True, timeout=4,
+        )
+        return out.stdout.strip() == "active"
+    except Exception:
+        return False
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _services() -> dict:
+    core_ok = _get(f"{CORE_URL}/health") is not None
+    llm_ok = _get(f"{LLM_URL}/api/tags", timeout=3) is not None
+    audio = _get(f"{AUDIO_URL}/health")
+    ear_ok = bool(audio) and audio.get("status") == "ok"
+    return {
+        "core":       {"up": core_ok, "detail": "ok" if core_ok else "down"},
+        "llm":        {"up": llm_ok,  "detail": "ok" if llm_ok else "down"},
+        "ear":        {"up": ear_ok,  "detail": f"{audio.get('nodes', 0)} nodos" if ear_ok else "down"},
+        "backoffice": {"up": _systemctl_active(SYSTEMD_UNITS["backoffice"]), "detail": ""},
+        "wa":         {"up": _systemctl_active(SYSTEMD_UNITS["wa"]), "detail": ""},
+    }
+
+
+def _agents() -> list[dict]:
+    data = _get(f"{CORE_URL}/agents", timeout=8)
+    if not isinstance(data, dict):
+        return []
+    out = []
+    for aid, meta in data.items():
+        if not isinstance(meta, dict):
+            continue
+        out.append({
+            "id": aid,
+            "active": meta.get("status") == "active",
+            "proactive": bool(meta.get("proactive") or meta.get("proactive_enabled")),
+        })
+    return out
+
+
+def _nodes() -> list[dict]:
+    data = _get(f"{AUDIO_URL}/nodes")
+    return data if isinstance(data, list) else []
+
+
+def _wakeword(nodes: list[dict]) -> dict:
+    fps = [n.get("fp", 0) for n in nodes]
+    return {
+        "last_score": None,  # no expuesto por el audio_server actual
+        "false_positives_24h": sum(fps) if fps else None,
+        "nodes": [
+            {
+                "id": n.get("node_id", n.get("room", "?")),
+                "ip": n.get("ip") or None,
+                "online": n.get("state") == "active",
+                "rms": None,
+            }
+            for n in nodes
+        ],
+    }
+
+
+def _recent_commands(nodes: list[dict]) -> list[dict]:
+    """Sin history.json en el sistema actual: el último comando por nodo es la
+    señal disponible (audio_server /nodes)."""
+    out = []
+    for n in nodes:
+        cmd = n.get("last_command")
+        if not cmd:
+            continue
+        ts = n.get("last_command_ts")
+        out.append({
+            "ts": datetime.fromtimestamp(ts, timezone.utc).isoformat() if ts else _now_iso(),
+            "text": cmd,
+            "agent": n.get("node_id", "?"),
+            "ok": True,
+            "latency_ms": n.get("last_latency_ms"),
+        })
+    out.sort(key=lambda c: c["ts"], reverse=True)
+    return out[:RECENT_LIMIT]
+
+
+def _latency(nodes: list[dict]) -> dict:
+    lats = [n.get("last_latency_ms") for n in nodes if n.get("last_latency_ms")]
+    avg = round(sum(lats) / len(lats)) if lats else None
+    return {"stt_ms": None, "llm_ms": avg, "haos_ms": None, "by_command": []}
+
+
+def _users() -> list[dict]:
+    data = _get(f"{CORE_URL}/users")
+    users = list(data.values()) if isinstance(data, dict) else (data if isinstance(data, list) else [])
+    intents = _get(f"{CORE_URL}/intents") or []
+    pending: dict[str, int] = {}
+    if isinstance(intents, list):
+        for it in intents:
+            uid = it.get("user_id")
+            if uid and it.get("status", "open") not in ("done", "closed", "cancelled"):
+                pending[uid] = pending.get(uid, 0) + 1
+    out = []
+    for u in users:
+        if not isinstance(u, dict):
+            continue
+        uid = u.get("id", "?")
+        out.append({
+            "id": uid,
+            "name": u.get("name", uid),
+            "role": u.get("role", "user"),
+            "intents_pending": pending.get(uid, 0),
+        })
+    return out
+
+
+def build_snapshot() -> dict:
+    """Arma el snapshot completo. Nunca lanza: campos faltantes quedan vacíos."""
+    nodes = _nodes()
+    return {
+        "schema_version": 1,
+        "ts": _now_iso(),
+        "host": HOST,
+        "services": _services(),
+        "latency": _latency(nodes),
+        "agents": _agents(),
+        "recent_commands": _recent_commands(nodes),
+        "wakeword": _wakeword(nodes),
+        "users_summary": _users(),
+    }

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -1,0 +1,84 @@
+"""Tests del bridge: executor (dispatch sin shell) y snapshot (resiliencia)."""
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import executor  # noqa: E402
+import snapshot  # noqa: E402
+
+
+def test_executor_unknown_type():
+    r = executor.execute("nope.bad", {})
+    assert not r.ok and "sin handler" in r.error
+
+
+def test_executor_service_restart_uses_arg_list():
+    captured = {}
+
+    class P:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(args, **kw):
+        captured["args"] = args
+        return P()
+
+    with patch.object(executor.subprocess, "run", fake_run):
+        r = executor.execute("service.restart", {"service": "capitan-core"})
+    assert r.ok
+    # sin shell: lista de args, no string
+    assert captured["args"] == ["systemctl", "--user", "restart", "capitan-core"]
+
+
+def test_executor_logs_tail_builds_command():
+    captured = {}
+
+    class P:
+        returncode = 0
+        stdout = "log"
+        stderr = ""
+
+    with patch.object(executor.subprocess, "run", lambda args, **kw: captured.update(args=args) or P()):
+        executor.execute("logs.tail", {"service": "capitan-wa", "lines": 50})
+    assert captured["args"] == ["journalctl", "--user", "-u", "capitan-wa", "-n", "50", "--no-pager"]
+
+
+def test_snapshot_resilient_when_all_sources_down():
+    # Todas las fuentes caídas: igual devuelve estructura válida (no lanza).
+    with patch.object(snapshot, "_get", lambda *a, **k: None), \
+         patch.object(snapshot, "_systemctl_active", lambda u: False):
+        snap = snapshot.build_snapshot()
+    assert snap["schema_version"] == 1
+    assert set(snap["services"]) == {"core", "llm", "ear", "backoffice", "wa"}
+    assert all(not s["up"] for s in snap["services"].values())
+    assert snap["agents"] == [] and snap["users_summary"] == []
+
+
+def test_snapshot_maps_agents_and_nodes():
+    def fake_get(url, timeout=4):
+        if url.endswith("/agents"):
+            return {"haos": {"status": "active"}, "clima": {"status": "inactive", "proactive": True}}
+        if url.endswith("/nodes"):
+            return [{"node_id": "comedor", "state": "active", "last_command": "prende la luz",
+                     "last_command_ts": 1781581761, "last_latency_ms": 3379, "fp": 2}]
+        if url.endswith("/health"):
+            return {"status": "ok", "nodes": 1}
+        if url.endswith("/users"):
+            return {"matias": {"id": "matias", "name": "Matías", "role": "admin"}}
+        if url.endswith("/intents"):
+            return [{"user_id": "matias", "status": "open"}]
+        if url.endswith("/api/tags"):
+            return {"models": []}
+        return None
+
+    with patch.object(snapshot, "_get", fake_get), \
+         patch.object(snapshot, "_systemctl_active", lambda u: True):
+        snap = snapshot.build_snapshot()
+    assert {a["id"] for a in snap["agents"]} == {"haos", "clima"}
+    assert snap["recent_commands"][0]["text"] == "prende la luz"
+    assert snap["latency"]["llm_ms"] == 3379
+    assert snap["users_summary"][0]["intents_pending"] == 1


### PR DESCRIPTION
Daemon `cloud_bridge.py` en el LXC del SER9. Sólo conexiones SALIENTES hacia el servicio Cloud Run (control por inversión).

- **33.10** Push del snapshot a `/ingest/state` (snapshot.py reusa core/audio_server/`/tmp/capitan`, allow-list de campos, resiliente).
- **33.11** Poll de `/commands/pending` con backoff exponencial + reconexión.
- **33.12** Executor seguro (executor.py): cada tipo del catálogo → función concreta, subprocess con lista de args (sin shell), re-validado contra el catálogo compartido `cloud/app/commands.py`. Auditoría por log.
- **33.13** Auth OIDC de la SA del bridge (audience = URL del servicio, sin API keys). Key fuera del repo (gitignored), rotación documentada.

systemd unit `capitan-bridge.service`. 5 tests passing (dispatch sin shell, snapshot resiliente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)