### PR TITLE
fix: FASE 33 — /ingest/state 500 (schema check)

### DIFF
--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -16,7 +16,7 @@ from fastapi.templating import Jinja2Templates
 from . import firestore_db as fdb
 from .auth import ALLOWED_EMAILS, FIREBASE_PROJECT_ID, require_bridge, require_dashboard_user
 from .commands import CommandError, catalog_summary, validate_command
-from .models import CommandRequest, CommandResult, StateSnapshot
+from .models import SCHEMA_VERSION, CommandRequest, CommandResult, StateSnapshot
 
 HERE = os.path.dirname(__file__)
 app = FastAPI(title="home-agents cloud backoffice", docs_url=None, redoc_url=None)
@@ -34,7 +34,7 @@ def health():
 
 @app.post("/ingest/state")
 def ingest_state(snapshot: StateSnapshot, sa: str = Depends(require_bridge)):
-    if snapshot.schema_version != StateSnapshot().schema_version:
+    if snapshot.schema_version != SCHEMA_VERSION:
         raise HTTPException(status_code=422, detail="schema_version no soportada")
     fdb.store_state(snapshot.model_dump())
     return {"ok": True}

--- a/cloud/tests/test_models.py
+++ b/cloud/tests/test_models.py
@@ -1,0 +1,27 @@
+"""Tests del contrato del snapshot (regresión del bug de schema_version)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app.models import SCHEMA_VERSION, StateSnapshot
+
+
+def test_schema_version_constant_matches_default():
+    # ingest_state compara contra SCHEMA_VERSION, no instancia StateSnapshot() vacío
+    # (que falla porque ts/host son requeridos). Regresión del 500 en /ingest/state.
+    snap = StateSnapshot(ts="2026-06-16T00:00:00Z", host="x")
+    assert snap.schema_version == SCHEMA_VERSION
+
+
+def test_minimal_snapshot_validates():
+    snap = StateSnapshot(ts="2026-06-16T00:00:00Z", host="capitan-lxc")
+    d = snap.model_dump()
+    assert d["schema_version"] == 1
+    assert d["services"] == {} and d["agents"] == []
+
+
+def test_ts_and_host_required():
+    with pytest.raises(Exception):
+        StateSnapshot()


### PR DESCRIPTION
`ingest_state` instanciaba `StateSnapshot()` sin args para leer el default de `schema_version`, pero `ts`/`host` son requeridos → ValidationError → 500. Ahora compara contra la constante `SCHEMA_VERSION`. Test de regresión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)