### PR TITLE
FASE 33 Etapa D — seguridad, costo y operación (33.14–33.17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Every agent inherits `ProactiveMixin`, enabling autonomous intent detection by s
 home-agents/
 ├── ear/          → submodule: home-agents-ear
 ├── core/         → submodule: home-agents-core
-├── backoffice/   → web admin UI at :8080
+├── backoffice/   → web admin UI at :8080 (LAN)
+├── cloud/        → cloud backoffice (Cloud Run + Firestore) + bridge (egress-only)
 ├── masterplan/   → estado.md (task list + decisions + functional docs)
 ├── scripts/      → sync_issues.py, lint_estado.py
 └── interagent/   → product concept (Interagent network)

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -79,3 +79,17 @@ Idempotente. El acceso queda restringido por `ALLOWED_EMAILS` (validado en el ba
 - Comandos **tipados y cerrados**; un tipo fuera del catálogo se rechaza sin ejecutar.
 - Reglas Firestore deny-all de cliente: el dashboard sólo accede vía la API server-side.
 - Bridge SA sin roles de proyecto: sólo su identidad OIDC; permiso mínimo absoluto.
+
+## Seguridad, costo y operación (Etapa D)
+
+- **Rate limiting** (33.14): token bucket in-memory por identidad — ingest/pending 120/min,
+  emisión de comandos 60/min (`app/ratelimit.py`). Middleware `BodySizeLimit` rechaza
+  payloads > 512 KB con 413. La firma/verificación es el propio ID token OIDC (Google-signed);
+  los payloads se validan con Pydantic.
+- **Auditoría** (33.15): el dashboard muestra cada comando con estado, tipo, params, quién lo
+  emitió, cuándo y el resultado (ok/output o error).
+- **Costo / free tier** (33.16): Cloud Run `min-instances=0` (scale-to-zero), Firestore native
+  con TTL para acotar almacenamiento. Budget de USD 5 con alertas a 50/90/100% del billing.
+- **Failover** (33.17): si la nube cae, el `core` ni se entera (el bridge es un proceso
+  aparte); el bridge reintenta con backoff exponencial (10→300s) y se recupera solo. Si el
+  bridge cae, el backoffice local en LAN (`:8080`, FASE 12) sigue operando. Verificado e2e.

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -13,15 +13,32 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from starlette.middleware.base import BaseHTTPMiddleware
+
 from . import firestore_db as fdb
+from . import ratelimit
 from .auth import ALLOWED_EMAILS, FIREBASE_PROJECT_ID, require_bridge, require_dashboard_user
 from .commands import CommandError, catalog_summary, validate_command
 from .models import SCHEMA_VERSION, CommandRequest, CommandResult, StateSnapshot
 
 HERE = os.path.dirname(__file__)
+MAX_BODY = int(os.environ.get("MAX_BODY_BYTES", str(512 * 1024)))  # 512 KB
+
 app = FastAPI(title="home-agents cloud backoffice", docs_url=None, redoc_url=None)
 app.mount("/static", StaticFiles(directory=os.path.join(HERE, "static")), name="static")
 templates = Jinja2Templates(directory=os.path.join(HERE, "templates"))
+
+
+class BodySizeLimit(BaseHTTPMiddleware):
+    """Rechaza payloads grandes antes de parsearlos (33.14)."""
+    async def dispatch(self, request: Request, call_next):
+        cl = request.headers.get("content-length")
+        if cl and cl.isdigit() and int(cl) > MAX_BODY:
+            return JSONResponse({"detail": "payload demasiado grande"}, status_code=413)
+        return await call_next(request)
+
+
+app.add_middleware(BodySizeLimit)
 
 
 @app.get("/_health")
@@ -34,6 +51,7 @@ def health():
 
 @app.post("/ingest/state")
 def ingest_state(snapshot: StateSnapshot, sa: str = Depends(require_bridge)):
+    ratelimit.limit_ingest(sa)
     if snapshot.schema_version != SCHEMA_VERSION:
         raise HTTPException(status_code=422, detail="schema_version no soportada")
     fdb.store_state(snapshot.model_dump())
@@ -42,6 +60,7 @@ def ingest_state(snapshot: StateSnapshot, sa: str = Depends(require_bridge)):
 
 @app.get("/commands/pending")
 def commands_pending(sa: str = Depends(require_bridge)):
+    ratelimit.limit_ingest(sa)
     return {"commands": fdb.claim_pending()}
 
 
@@ -74,6 +93,7 @@ def api_catalog(user: str = Depends(require_dashboard_user)):
 
 @app.post("/api/commands")
 def api_emit_command(req: CommandRequest, user: str = Depends(require_dashboard_user)):
+    ratelimit.limit_command(user)
     try:
         params = validate_command(req.type, req.params)
     except CommandError as exc:

--- a/cloud/app/ratelimit.py
+++ b/cloud/app/ratelimit.py
@@ -1,0 +1,45 @@
+"""Rate limiting in-memory (token bucket) por identidad. FASE 33 (33.14).
+
+Por instancia de Cloud Run (scale-to-zero, máx 2): suficiente para un backoffice de
+un solo usuario + un bridge. No necesita backend distribuido. Protege de loops
+descontrolados del bridge o abuso desde una credencial comprometida.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+from fastapi import HTTPException
+
+
+class TokenBucket:
+    def __init__(self, rate_per_min: int, burst: int | None = None):
+        self.capacity = burst or rate_per_min
+        self.refill_per_sec = rate_per_min / 60.0
+        self._buckets: dict[str, tuple[float, float]] = {}  # key -> (tokens, last_ts)
+        self._lock = threading.Lock()
+
+    def check(self, key: str) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            tokens, last = self._buckets.get(key, (self.capacity, now))
+            tokens = min(self.capacity, tokens + (now - last) * self.refill_per_sec)
+            if tokens < 1:
+                self._buckets[key] = (tokens, now)
+                return False
+            self._buckets[key] = (tokens - 1, now)
+            return True
+
+
+_ingest = TokenBucket(rate_per_min=120)   # bridge: push frecuente
+_command = TokenBucket(rate_per_min=60)   # dashboard: emisión de comandos
+
+
+def limit_ingest(key: str) -> None:
+    if not _ingest.check(key):
+        raise HTTPException(status_code=429, detail="rate limit (ingest)")
+
+
+def limit_command(key: str) -> None:
+    if not _command.check(key):
+        raise HTTPException(status_code=429, detail="rate limit (commands)")

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -112,8 +112,18 @@ async function refresh() {
   } catch (e) { $("updated").textContent = "error: " + e.message; }
   try {
     const { commands } = await api("/api/commands");
+    const st = (s) => s === "done" ? "🟢" : s === "error" ? "🔴" : s === "running" ? "🟡" : "⚪";
     $("audit").querySelector("tbody").innerHTML = commands
-      .map(c => `<tr><td>${c.status}</td><td><b>${c.type}</b></td><td class="muted">${JSON.stringify(c.params)}</td><td class="muted">${c.issued_by}</td><td class="muted">${c.issued_at}</td></tr>`).join("");
+      .map(c => {
+        const r = c.result || {};
+        const res = c.status === "pending" || c.status === "running" ? ""
+          : (r.ok ? (r.output || "ok") : ("error: " + (r.error || ""))).slice(0, 80);
+        return `<tr><td>${st(c.status)} ${c.status}</td><td><b>${c.type}</b></td>`
+          + `<td class="muted">${JSON.stringify(c.params)}</td>`
+          + `<td class="muted">${c.issued_by}</td>`
+          + `<td class="muted">${c.issued_at}</td>`
+          + `<td class="muted">${res}</td></tr>`;
+      }).join("");
   } catch (e) {}
 }
 

--- a/cloud/tests/test_ratelimit.py
+++ b/cloud/tests/test_ratelimit.py
@@ -1,0 +1,35 @@
+"""Tests del token bucket (rate limiting)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app.ratelimit import TokenBucket
+
+
+def test_allows_within_burst():
+    tb = TokenBucket(rate_per_min=60, burst=5)
+    assert all(tb.check("k") for _ in range(5))
+
+
+def test_blocks_over_burst():
+    tb = TokenBucket(rate_per_min=60, burst=3)
+    assert tb.check("k") and tb.check("k") and tb.check("k")
+    assert not tb.check("k")
+
+
+def test_per_key_isolation():
+    tb = TokenBucket(rate_per_min=60, burst=1)
+    assert tb.check("a")
+    assert not tb.check("a")
+    assert tb.check("b")  # otra identidad, su propio bucket
+
+
+def test_refill_over_time(monkeypatch):
+    import app.ratelimit as rl
+    t = {"v": 1000.0}
+    monkeypatch.setattr(rl.time, "monotonic", lambda: t["v"])
+    tb = TokenBucket(rate_per_min=60, burst=1)  # 1 token/seg
+    assert tb.check("k")
+    assert not tb.check("k")
+    t["v"] += 1.1  # pasa >1s → se recarga 1 token
+    assert tb.check("k")

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -105,6 +105,27 @@ archivos `.json` más abajo describen el **modelo lógico**; físicamente son fi
 la DB. Quedan como archivos por diseño: embeddings `.npy`, traces JSONL, sesión de WhatsApp,
 samples de audio, y `panels.yaml` (config del repo leída por backoffice/scripts).
 
+### cloud (backoffice en la nube) — FASE 33
+
+Backoffice accesible desde internet **sin exponer el SER9 ni HAOS**, con principio
+egress-only: la nube nunca inicia conexiones hacia la casa. Patrón command/executor por
+inversión de control.
+
+- **Servicio** (`cloud/`, Cloud Run + Firestore, scale-to-zero): endpoints del bridge
+  (`/ingest/state`, `/commands/pending` con claim atómico, `/commands/{id}/result`) y API
+  del dashboard (`/api/state|commands|catalog`, emisión). Login Firebase Auth (Google) con
+  allow-list por email; rate limiting por identidad + límite de payload.
+- **Bridge** (`cloud/bridge/`, daemon systemd en el LXC): empuja el snapshot de estado y
+  polea la cola de comandos — **sólo conexiones salientes**. Reusa datos de core/audio_server.
+  Executor seguro: cada tipo del catálogo tipado → función concreta (sin shell). Auth por ID
+  token OIDC de una Service Account sin roles de proyecto (permiso mínimo absoluto).
+- **Seguridad**: secretos y PII nunca cruzan a la nube (allow-list de campos en el snapshot);
+  comandos tipados y cerrados; reglas Firestore deny-all de cliente.
+- **Failover**: si la nube cae, el core sigue local y el bridge reintenta con backoff; si el
+  bridge cae, el backoffice local en LAN (`:8080`, FASE 12) sigue operando.
+
+Contrato y modelo de amenazas: `masterplan/fase33_cloud_backoffice.md`.
+
 ---
 
 ## Agentes

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -2866,7 +2866,8 @@ Objetivo: Tener un backoffice accesible desde internet SIN exponer el SER9 ni HA
           La nube nunca inicia conexiones hacia la casa: el SER9 empuja estado para
           dibujar el dashboard y POLEA una cola de comandos para ejecutar acciones de
           administración (patrón command / executor). Plataforma: Google Cloud.
-Estado:   EN CURSO (13/17 — Etapas A, B y C completas; bridge desplegado y empujando estado)
+Estado:   COMPLETA — servicio en la nube desplegado (capitan-495518/southamerica-east1),
+          bridge en capitan-lxc empujando estado y ejecutando comandos, verificado e2e.
 Deps:     FASE 12 (backoffice local — COMPLETA, fuente de datos y UI a reusar),
           FASE 21 (SER9 estable — COMPLETA), FASE 32 (datos en SQLite — COMPLETA).
 Principio de seguridad: el SER9 sólo hace conexiones SALIENTES (HTTPS) a la nube.
@@ -2925,9 +2926,10 @@ Stack GCP elegido: Cloud Run (web + API, scale-to-zero), Firestore (snapshot de
             necesarios), almacenadas fuera del repo. Rotación documentada.
 
 #### Etapa D - Seguridad, costo y operación
-- [ ] 33.14 Rate limiting y validación de payloads en ingest/commands; firma/verificación.
-- [ ] 33.15 Auditoría visible en el dashboard: quién emitió cada comando, cuándo y resultado.
-- [ ] 33.16 Mantener dentro del free tier de GCP (Cloud Run scale-to-zero, cuota de Firestore);
-            alerta de presupuesto.
-- [ ] 33.17 Failover: si la nube cae, el SER9 sigue operando local y el bridge reintenta; si el
-            bridge cae, el backoffice local en LAN (FASE 12) sigue disponible.
+- [x] 33.14 Rate limiting y validación de payloads en ingest/commands; firma/verificación.
+            (token bucket por identidad + middleware de tamaño 512KB; OIDC = firma; Pydantic)
+- [x] 33.15 Auditoría visible en el dashboard: quién emitió cada comando, cuándo y resultado.
+- [x] 33.16 Mantener dentro del free tier de GCP (Cloud Run scale-to-zero, cuota de Firestore);
+            alerta de presupuesto. (budget USD 5, alertas 50/90/100%)
+- [x] 33.17 Failover: si la nube cae, el SER9 sigue operando local y el bridge reintenta; si el
+            bridge cae, el backoffice local en LAN (FASE 12) sigue disponible. (verificado e2e)


### PR DESCRIPTION
Cierra FASE 33.

- **33.14** Rate limiting (token bucket por identidad: ingest 120/min, comandos 60/min) + middleware `BodySizeLimit` (413 > 512KB). Firma/verificación = ID token OIDC; validación Pydantic. Verificado en vivo: 413 en payload grande, 401 sin auth.
- **33.15** Auditoría en el dashboard: estado, tipo, params, quién emitió, cuándo y resultado.
- **33.16** Budget USD 5 con alertas 50/90/100%; Cloud Run scale-to-zero + TTL Firestore (free tier).
- **33.17** Failover verificado e2e: bridge con backoff exponencial (10→300s) que se recupera solo; backoffice local LAN independiente.

Docs: `arquitectura_funcional.md` (sección cloud) + README. 17 tests cloud passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)