### PR TITLE
fix: FASE 33 — setup_firebase.sh initializeAuth + Google OAuth client

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -51,16 +51,23 @@ PROJECT=capitan-495518 REGION=southamerica-east1 \
   ALLOWED_EMAILS=matias@blasi.ar bash infra/provision.sh
 ```
 
-Login del dashboard (Firebase Auth + Google sign-in), automatizado:
+Login del dashboard (Firebase Auth + Google sign-in):
+
+**Prerrequisito manual** (Identity Platform exige un OAuth client propio): en la consola
+crear el OAuth consent screen y un **OAuth client ID (Web)** con redirect
+`https://<project>.firebaseapp.com/__/auth/handler`. Copiar client id y secret.
 
 ```bash
-PROJECT=capitan-495518 REGION=southamerica-east1 bash infra/setup_firebase.sh
+PROJECT=capitan-495518 REGION=southamerica-east1 \
+  GOOGLE_CLIENT_ID=...apps.googleusercontent.com \
+  GOOGLE_CLIENT_SECRET=GOCSPX-... \
+  bash infra/setup_firebase.sh
 ```
 
-`setup_firebase.sh` hace: addFirebase → crea la web app → habilita el proveedor Google
-(OAuth Google-managed, sin client manual) → agrega el dominio de Cloud Run a
-*authorized domains* → fija `FIREBASE_API_KEY`/`FIREBASE_AUTH_DOMAIN` en el servicio.
-Idempotente. El acceso queda restringido por `ALLOWED_EMAILS` (validado en el backend).
+`setup_firebase.sh` hace: addFirebase → web app → `initializeAuth` → habilita el proveedor
+Google con el client → agrega el dominio de Cloud Run a *authorized domains* → fija
+`FIREBASE_API_KEY`/`FIREBASE_AUTH_DOMAIN` en el servicio. Idempotente. El acceso queda
+restringido por `ALLOWED_EMAILS` (validado en el backend).
 
 ## Variables de entorno del servicio
 

--- a/cloud/infra/setup_firebase.sh
+++ b/cloud/infra/setup_firebase.sh
@@ -39,12 +39,25 @@ API_KEY="$(echo "$CFG" | python3 -c 'import sys,json; print(json.load(sys.stdin)
 AUTH_DOMAIN="$(echo "$CFG" | python3 -c 'import sys,json; print(json.load(sys.stdin)["authDomain"])')"
 echo "   apiKey: ${API_KEY:0:12}...  authDomain: $AUTH_DOMAIN"
 
-echo "== Habilitar proveedor Google (OAuth Google-managed) =="
-curl -s -X POST "${IT}/projects/${PROJECT}/defaultSupportedIdpConfigs?idpId=google.com" \
-  -H "$(H_AUTH)" -H "$QP" -H "Content-Type: application/json" \
-  -d '{"enabled": true}' >/dev/null 2>&1 || \
-curl -s -X PATCH "${IT}/projects/${PROJECT}/defaultSupportedIdpConfigs/google.com?updateMask=enabled" \
-  -H "$(H_AUTH)" -H "$QP" -H "Content-Type: application/json" -d '{"enabled": true}' >/dev/null
+echo "== Inicializar Identity Platform (idempotente) =="
+curl -s -X POST "https://identitytoolkit.googleapis.com/v2/projects/${PROJECT}/identityPlatform:initializeAuth" \
+  -H "$(H_AUTH)" -H "$QP" -H "Content-Type: application/json" -d '{}' >/dev/null || true
+
+echo "== Habilitar proveedor Google =="
+# Identity Platform exige un OAuth client (Web) creado a mano en la consola:
+#   consent screen + Credentials → OAuth client ID (Web), redirect:
+#   https://${PROJECT}.firebaseapp.com/__/auth/handler
+# Exportar GOOGLE_CLIENT_ID y GOOGLE_CLIENT_SECRET antes de correr.
+if [ -n "${GOOGLE_CLIENT_ID:-}" ] && [ -n "${GOOGLE_CLIENT_SECRET:-}" ]; then
+  BODY="{\"enabled\": true, \"clientId\": \"${GOOGLE_CLIENT_ID}\", \"clientSecret\": \"${GOOGLE_CLIENT_SECRET}\"}"
+  curl -s -X POST "${IT}/projects/${PROJECT}/defaultSupportedIdpConfigs?idpId=google.com" \
+    -H "$(H_AUTH)" -H "$QP" -H "Content-Type: application/json" -d "$BODY" >/dev/null 2>&1 || \
+  curl -s -X PATCH "${IT}/projects/${PROJECT}/defaultSupportedIdpConfigs/google.com?updateMask=enabled,clientId,clientSecret" \
+    -H "$(H_AUTH)" -H "$QP" -H "Content-Type: application/json" -d "$BODY" >/dev/null
+  echo "   proveedor Google habilitado"
+else
+  echo "   SKIP: exportá GOOGLE_CLIENT_ID y GOOGLE_CLIENT_SECRET para habilitar Google"
+fi
 
 echo "== Authorized domains (agregar dominio de Cloud Run) =="
 RUN_HOST="$(gcloud run services describe "$SERVICE" --region "$REGION" \


### PR DESCRIPTION
El proveedor Google en Identity Platform necesita un OAuth client manual; el script ahora hace initializeAuth y habilita Google con GOOGLE_CLIENT_ID/SECRET. Corrige el auth/configuration-not-found del login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)