### PR TITLE
FASE 33 Etapa E — auth contra roster + RBAC (33.19–33.21)

### DIFF
--- a/cloud/app/auth.py
+++ b/cloud/app/auth.py
@@ -8,9 +8,14 @@ from __future__ import annotations
 
 import os
 
+from dataclasses import dataclass
+
 from fastapi import Header, HTTPException
 from google.auth.transport import requests as ga_requests
 from google.oauth2 import id_token as ga_id_token
+
+from . import firestore_db as fdb
+from . import rbac
 
 PROJECT_ID = os.environ.get("GCP_PROJECT", "")
 FIREBASE_PROJECT_ID = os.environ.get("FIREBASE_PROJECT_ID", PROJECT_ID)
@@ -29,8 +34,18 @@ def _bearer(authorization: str | None) -> str:
     return authorization.split(" ", 1)[1].strip()
 
 
-def require_dashboard_user(authorization: str | None = Header(default=None)) -> str:
-    """Valida el Firebase ID token y la allow-list de email. Devuelve el email."""
+@dataclass
+class Principal:
+    email: str
+    role: str
+    caps: dict
+
+
+def require_dashboard_user(authorization: str | None = Header(default=None)) -> Principal:
+    """Valida el Firebase ID token y autoriza contra el roster de usuarios (email→rol)
+    pusheado por el SER9. `ALLOWED_EMAILS` queda sólo como bootstrap de emergencia
+    (→ admin) para no quedar bloqueado si el roster está vacío. Devuelve el Principal
+    con rol y capacidades RBAC (33.20/33.21)."""
     token = _bearer(authorization)
     try:
         claims = ga_id_token.verify_firebase_token(
@@ -39,9 +54,16 @@ def require_dashboard_user(authorization: str | None = Header(default=None)) -> 
     except Exception as exc:  # noqa: BLE001 — token inválido
         raise HTTPException(status_code=401, detail="ID token inválido") from exc
     email = (claims.get("email") or "").lower()
-    if not claims.get("email_verified") or email not in ALLOWED_EMAILS:
+    if not claims.get("email_verified") or not email:
+        raise HTTPException(status_code=401, detail="email no verificado")
+
+    role = fdb.get_roster().get(email)
+    if role is None and email in ALLOWED_EMAILS:
+        role = "admin"  # bootstrap de emergencia
+    caps = rbac.caps_for(role)
+    if not caps["access"]:
         raise HTTPException(status_code=403, detail="email no autorizado")
-    return email
+    return Principal(email=email, role=role or "", caps=caps)
 
 
 def require_bridge(authorization: str | None = Header(default=None)) -> str:

--- a/cloud/app/firestore_db.py
+++ b/cloud/app/firestore_db.py
@@ -11,17 +11,19 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from google.cloud import firestore
+# google.cloud.firestore se importa de forma lazy (dentro de las funciones) para no
+# forzar esa dependencia pesada en tests de unidad de otros módulos.
 
 HISTORY_TTL_HOURS = int(os.environ.get("STATE_HISTORY_TTL_HOURS", "24"))
 COMMAND_TTL_HOURS = int(os.environ.get("COMMAND_TTL_HOURS", "24"))
 
-_client: firestore.Client | None = None
+_client = None
 
 
-def db() -> firestore.Client:
+def db():
     global _client
     if _client is None:
+        from google.cloud import firestore
         _client = firestore.Client()
     return _client
 
@@ -45,6 +47,28 @@ def get_state() -> dict | None:
     return snap.to_dict() if snap.exists else None
 
 
+# ── Roster de autorización (email→rol), materializado desde el snapshot ─────────
+
+def store_roster(users_summary: list[dict]) -> None:
+    """Materializa el roster email→rol para autorizar el login del dashboard.
+    Se guarda como lista (las field keys de Firestore no admiten '.' del email)."""
+    entries = [
+        {"email": u["email"].strip().lower(), "role": u.get("role", "")}
+        for u in users_summary
+        if u.get("email")
+    ]
+    db().collection("auth").document("roster").set(
+        {"entries": entries, "updated_at": _now()}
+    )
+
+
+def get_roster() -> dict[str, str]:
+    snap = db().collection("auth").document("roster").get()
+    if not snap.exists:
+        return {}
+    return {e["email"]: e.get("role", "") for e in snap.to_dict().get("entries", [])}
+
+
 # ── Comandos ──────────────────────────────────────────────────────────────────
 
 def enqueue_command(cmd_type: str, params: dict, issued_by: str) -> dict:
@@ -66,6 +90,7 @@ def enqueue_command(cmd_type: str, params: dict, issued_by: str) -> dict:
 def claim_pending(limit: int = 20) -> list[dict]:
     """Devuelve comandos pending y los pasa a running atómicamente (evita doble
     ejecución entre ciclos de polling del bridge)."""
+    from google.cloud import firestore
     col = db().collection("commands")
     q = col.where("status", "==", "pending").limit(limit)
     claimed: list[dict] = []
@@ -102,6 +127,7 @@ def set_result(cmd_id: str, ok: bool, output: str, error: str) -> bool:
 
 
 def recent_commands(limit: int = 50) -> list[dict]:
+    from google.cloud import firestore
     col = db().collection("commands")
     q = col.order_by("issued_at", direction=firestore.Query.DESCENDING).limit(limit)
     return [snap.to_dict() for snap in q.stream()]

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -17,7 +17,14 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from . import firestore_db as fdb
 from . import ratelimit
-from .auth import ALLOWED_EMAILS, FIREBASE_PROJECT_ID, require_bridge, require_dashboard_user
+from . import rbac
+from .auth import (
+    ALLOWED_EMAILS,
+    FIREBASE_PROJECT_ID,
+    Principal,
+    require_bridge,
+    require_dashboard_user,
+)
 from .commands import CommandError, catalog_summary, validate_command
 from .models import SCHEMA_VERSION, CommandRequest, CommandResult, StateSnapshot
 
@@ -54,7 +61,10 @@ def ingest_state(snapshot: StateSnapshot, sa: str = Depends(require_bridge)):
     ratelimit.limit_ingest(sa)
     if snapshot.schema_version != SCHEMA_VERSION:
         raise HTTPException(status_code=422, detail="schema_version no soportada")
-    fdb.store_state(snapshot.model_dump())
+    data = snapshot.model_dump()
+    fdb.store_state(data)
+    # Materializa el roster email→rol para autorizar el login del dashboard (33.19).
+    fdb.store_roster(data.get("users_summary", []))
     return {"ok": True}
 
 
@@ -71,34 +81,52 @@ def command_result(cmd_id: str, result: CommandResult, sa: str = Depends(require
     return {"ok": True}
 
 
-# ── Dashboard API (navegador → nube): auth Firebase + allow-list de email ───────
+# ── Dashboard API (navegador → nube): auth Firebase + roster + RBAC ─────────────
+
+def _require_emit(p: Principal) -> None:
+    if not p.caps.get("emit"):
+        raise HTTPException(status_code=403, detail="tu rol no puede emitir comandos")
+
+
+def _require_view_full(p: Principal) -> None:
+    if not p.caps.get("view_full"):
+        raise HTTPException(status_code=403, detail="tu rol no tiene acceso a esta vista")
+
+
+@app.get("/api/me")
+def api_me(p: Principal = Depends(require_dashboard_user)):
+    return {"email": p.email, "role": p.role, "caps": p.caps}
+
 
 @app.get("/api/state")
-def api_state(user: str = Depends(require_dashboard_user)):
+def api_state(p: Principal = Depends(require_dashboard_user)):
     state = fdb.get_state()
     if state is None:
         return JSONResponse({"state": None}, status_code=200)
-    return {"state": state}
+    return {"state": rbac.filter_state(state, p.caps)}
 
 
 @app.get("/api/commands")
-def api_commands(user: str = Depends(require_dashboard_user)):
+def api_commands(p: Principal = Depends(require_dashboard_user)):
+    _require_view_full(p)  # la auditoría sólo para roles con view_full
     return {"commands": fdb.recent_commands()}
 
 
 @app.get("/api/catalog")
-def api_catalog(user: str = Depends(require_dashboard_user)):
+def api_catalog(p: Principal = Depends(require_dashboard_user)):
+    _require_emit(p)
     return {"catalog": catalog_summary()}
 
 
 @app.post("/api/commands")
-def api_emit_command(req: CommandRequest, user: str = Depends(require_dashboard_user)):
-    ratelimit.limit_command(user)
+def api_emit_command(req: CommandRequest, p: Principal = Depends(require_dashboard_user)):
+    _require_emit(p)
+    ratelimit.limit_command(p.email)
     try:
         params = validate_command(req.type, req.params)
     except CommandError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    cmd = fdb.enqueue_command(req.type, params, issued_by=user)
+    cmd = fdb.enqueue_command(req.type, params, issued_by=p.email)
     return {"command": cmd}
 
 

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -59,6 +59,7 @@ class UserSummary(BaseModel):
     name: str
     role: str
     intents_pending: int = 0
+    email: str | None = None   # login_email (identidad de acceso al dashboard), FASE 33.19
 
 
 class StateSnapshot(BaseModel):

--- a/cloud/app/rbac.py
+++ b/cloud/app/rbac.py
@@ -1,0 +1,32 @@
+"""RBAC del backoffice en la nube. FASE 33 (33.21).
+
+Capacidades por rol (consistente con los roles de la gestión de usuarios del core):
+  admin       → acceso total: ver todo + emitir comandos admin
+  familiar    → read-only completo (ve estado y auditoría, no emite)
+  adolescente → read-only vista básica (sin PII de usuarios ni auditoría de comandos)
+  niño/invitado/guest/desconocido → SIN acceso al backoffice en la nube
+"""
+from __future__ import annotations
+
+# access: puede entrar al dashboard | view_full: ve users/auditoría | emit: emite comandos
+ROLE_CAPS: dict[str, dict[str, bool]] = {
+    "admin":       {"access": True,  "view_full": True,  "emit": True},
+    "familiar":    {"access": True,  "view_full": True,  "emit": False},
+    "adolescente": {"access": True,  "view_full": False, "emit": False},
+}
+
+_NO_ACCESS = {"access": False, "view_full": False, "emit": False}
+
+
+def caps_for(role: str | None) -> dict[str, bool]:
+    return ROLE_CAPS.get(role or "", _NO_ACCESS)
+
+
+def filter_state(state: dict, caps: dict[str, bool]) -> dict:
+    """Aplica RBAC al snapshot que ve el dashboard: oculta PII de usuarios a quien
+    no tiene view_full."""
+    if caps.get("view_full"):
+        return state
+    redacted = dict(state)
+    redacted["users_summary"] = []  # adolescente no ve la lista de usuarios
+    return redacted

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -45,7 +45,7 @@
       <table id="recent"><tbody></tbody></table>
     </section>
 
-    <section class="card">
+    <section class="card hidden" id="actions-card">
       <h2>Acciones admin</h2>
       <form id="emit">
         <select id="cmd-type"></select>
@@ -55,7 +55,7 @@
       <p id="emit-msg" class="muted"></p>
     </section>
 
-    <section class="card">
+    <section class="card hidden" id="audit-card">
       <h2>Auditoría de comandos admin</h2>
       <table id="audit"><tbody></tbody></table>
     </section>
@@ -95,6 +95,8 @@ async function api(path, opts = {}) {
 
 function dot(ok) { return ok ? "🟢" : "🔴"; }
 
+let CAPS = {};
+
 async function refresh() {
   try {
     const { state } = await api("/api/state");
@@ -110,6 +112,7 @@ async function refresh() {
     $("recent").querySelector("tbody").innerHTML = (state.recent_commands || [])
       .map(c => `<tr><td>${dot(c.ok)}</td><td>${c.text}</td><td class="muted">${c.agent}</td><td class="muted">${c.latency_ms ?? "—"}ms</td></tr>`).join("");
   } catch (e) { $("updated").textContent = "error: " + e.message; }
+  if (!CAPS.view_full) return;  // adolescente: sin auditoría
   try {
     const { commands } = await api("/api/commands");
     const st = (s) => s === "done" ? "🟢" : s === "error" ? "🔴" : s === "running" ? "🟡" : "⚪";
@@ -158,10 +161,21 @@ auth.onAuthStateChanged(async (user) => {
   }
   idToken = await user.getIdToken();
   $("useremail").textContent = user.email;
-  hide("login"); show("app"); show("userbox");
-  try { await loadCatalog(); } catch (e) {
-    $("login-error").textContent = e.message; show("login"); hide("app"); return;
+  // Autorización + capacidades RBAC (rol resuelto contra el roster del SER9).
+  let me;
+  try { me = await api("/api/me"); }
+  catch (e) {
+    $("login-error").textContent = e.message + " — tu cuenta no tiene acceso";
+    show("login"); hide("app"); hide("userbox"); auth.signOut(); return;
   }
+  CAPS = me.caps || {};
+  $("useremail").textContent = user.email + " · " + me.role;
+  hide("login"); show("app"); show("userbox");
+  if (CAPS.view_full) show("audit-card"); else hide("audit-card");
+  if (CAPS.emit) {
+    show("actions-card");
+    try { await loadCatalog(); } catch (e) { hide("actions-card"); }
+  } else { hide("actions-card"); }
   refresh();
   timer = setInterval(async () => { idToken = await user.getIdToken(); refresh(); }, 10000);
 });

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -146,11 +146,14 @@ def _users() -> list[dict]:
         if not isinstance(u, dict):
             continue
         uid = u.get("id", "?")
+        # login_email: email dedicado o, en su defecto, gcal_email (FASE 33.19).
+        login_email = u.get("email") or u.get("gcal_email")
         out.append({
             "id": uid,
             "name": u.get("name", uid),
             "role": u.get("role", "user"),
             "intents_pending": pending.get(uid, 0),
+            "email": login_email,
         })
     return out
 

--- a/cloud/tests/test_auth_roster.py
+++ b/cloud/tests/test_auth_roster.py
@@ -1,0 +1,72 @@
+"""Tests de require_dashboard_user contra el roster (33.20)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import auth
+from fastapi import HTTPException
+
+
+@pytest.fixture
+def fake_token(monkeypatch):
+    """Hace que verify_firebase_token devuelva claims fijos por email."""
+    def _set(email, verified=True):
+        monkeypatch.setattr(
+            auth.ga_id_token, "verify_firebase_token",
+            lambda *a, **k: {"email": email, "email_verified": verified},
+        )
+    return _set
+
+
+def _roster(monkeypatch, mapping):
+    monkeypatch.setattr(auth.fdb, "get_roster", lambda: mapping)
+
+
+def test_admin_from_roster(fake_token, monkeypatch):
+    fake_token("matias@blasi.ar")
+    _roster(monkeypatch, {"matias@blasi.ar": "admin"})
+    p = auth.require_dashboard_user("Bearer x")
+    assert p.role == "admin" and p.caps["emit"]
+
+
+def test_familiar_readonly_from_roster(fake_token, monkeypatch):
+    fake_token("pareja@gmail.com")
+    _roster(monkeypatch, {"pareja@gmail.com": "familiar"})
+    p = auth.require_dashboard_user("Bearer x")
+    assert p.role == "familiar" and p.caps["view_full"] and not p.caps["emit"]
+
+
+def test_unknown_email_rejected(fake_token, monkeypatch):
+    fake_token("intruso@x.com")
+    _roster(monkeypatch, {"matias@blasi.ar": "admin"})
+    monkeypatch.setattr(auth, "ALLOWED_EMAILS", set())
+    with pytest.raises(HTTPException) as exc:
+        auth.require_dashboard_user("Bearer x")
+    assert exc.value.status_code == 403
+
+
+def test_role_without_access_rejected(fake_token, monkeypatch):
+    fake_token("nino@x.com")
+    _roster(monkeypatch, {"nino@x.com": "niño"})
+    monkeypatch.setattr(auth, "ALLOWED_EMAILS", set())
+    with pytest.raises(HTTPException) as exc:
+        auth.require_dashboard_user("Bearer x")
+    assert exc.value.status_code == 403
+
+
+def test_bootstrap_allowed_emails(fake_token, monkeypatch):
+    fake_token("boss@blasi.ar")
+    _roster(monkeypatch, {})  # roster vacío
+    monkeypatch.setattr(auth, "ALLOWED_EMAILS", {"boss@blasi.ar"})
+    p = auth.require_dashboard_user("Bearer x")
+    assert p.role == "admin"
+
+
+def test_unverified_email_401(fake_token, monkeypatch):
+    fake_token("matias@blasi.ar", verified=False)
+    _roster(monkeypatch, {"matias@blasi.ar": "admin"})
+    with pytest.raises(HTTPException) as exc:
+        auth.require_dashboard_user("Bearer x")
+    assert exc.value.status_code == 401

--- a/cloud/tests/test_rbac.py
+++ b/cloud/tests/test_rbac.py
@@ -1,0 +1,39 @@
+"""Tests del RBAC del backoffice en la nube (33.21)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import rbac
+
+
+def test_admin_full():
+    c = rbac.caps_for("admin")
+    assert c == {"access": True, "view_full": True, "emit": True}
+
+
+def test_familiar_readonly():
+    c = rbac.caps_for("familiar")
+    assert c["access"] and c["view_full"] and not c["emit"]
+
+
+def test_adolescente_basic_readonly():
+    c = rbac.caps_for("adolescente")
+    assert c["access"] and not c["view_full"] and not c["emit"]
+
+
+def test_nino_invitado_guest_no_access():
+    for role in ("niño", "invitado", "guest", "", None, "loquesea"):
+        assert rbac.caps_for(role)["access"] is False
+
+
+def test_filter_state_redacts_users_for_basic():
+    state = {"services": {}, "users_summary": [{"id": "matias", "email": "x@y.z"}]}
+    out = rbac.filter_state(state, rbac.caps_for("adolescente"))
+    assert out["users_summary"] == []
+    assert "services" in out
+
+
+def test_filter_state_keeps_users_for_full():
+    state = {"users_summary": [{"id": "matias"}]}
+    out = rbac.filter_state(state, rbac.caps_for("familiar"))
+    assert out["users_summary"] == [{"id": "matias"}]


### PR DESCRIPTION
Login del cloud consistente con la gestión de usuarios + RBAC.

- **33.19** El snapshot incluye `login_email` (email dedicado o gcal_email); al ingestar, el cloud materializa un roster email→rol en Firestore (`auth/roster`).
- **33.20** `require_dashboard_user` autoriza contra el roster y devuelve `Principal(email, role, caps)`. `ALLOWED_EMAILS` queda sólo como bootstrap de emergencia (→admin). Email no registrado o rol sin acceso → 403.
- **33.21** RBAC por rol: admin full (ver+emitir) · familiar read-only · adolescente read-only vista básica (sin PII de usuarios ni auditoría) · niño/invitado/guest sin acceso. Gate de emisión y de auditoría; `filter_state` oculta `users_summary`; `/api/me`; el frontend oculta acciones/auditoría según capacidades.

`firestore_db` ahora importa firestore de forma lazy (desacopla los tests). 12 tests nuevos (29 cloud passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)