### PR TITLE
FASE 33 Etapa E — SSO backoffice local + RBAC local (33.22–33.24)

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -39,6 +39,13 @@ OAUTH_APP_URL = os.environ.get("OAUTH_APP_URL", "").rstrip("/")
 METRICS_DIR   = Path("/tmp/capitan")
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
+# ── SSO con la nube (FASE 33.23): login por usuario reusando el Google sign-in ──
+SSO_SECRET   = os.environ.get("SSO_SECRET", "").encode()
+CLOUD_SSO_URL = os.environ.get("CLOUD_SSO_URL", "").rstrip("/")  # …/sso/start
+LOCAL_ACCESS_ROLES = {"admin", "familiar", "adolescente"}
+WRITE_ROLES = {"admin"}
+_MUTATING = {"POST", "PUT", "PATCH", "DELETE"}
+
 app = FastAPI(title="capitan-backoffice", version="1.0")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
@@ -65,20 +72,24 @@ templates.env.filters["tojson"]      = _tojson_filter
 # ── Auth ───────────────────────────────────────────────────────────────────────
 
 _SESSION_COOKIE = "capitan_session"
-_SESSIONS: set[str] = set()
+# session_id → principal {user_id, name, role, email}
+_SESSIONS: dict[str, dict] = {}
 
 
-def _new_session() -> str:
+def _new_session(principal: dict) -> str:
     tok = secrets.token_urlsafe(32)
-    _SESSIONS.add(tok)
+    _SESSIONS[tok] = principal
     return tok
 
 
+def _principal(request: Request) -> dict | None:
+    return _SESSIONS.get(request.cookies.get(_SESSION_COOKIE, ""))
+
+
 def _check_auth(request: Request) -> bool:
-    if not BACKOFFICE_TOKEN:
-        return True  # sin token configurado, acceso libre (solo LAN)
-    session = request.cookies.get(_SESSION_COOKIE, "")
-    return session in _SESSIONS
+    if not BACKOFFICE_TOKEN and not SSO_SECRET:
+        return True  # sin auth configurada, acceso libre (solo LAN)
+    return _principal(request) is not None
 
 
 def _require_auth(request: Request):
@@ -86,25 +97,93 @@ def _require_auth(request: Request):
         raise HTTPException(status_code=303, headers={"Location": "/login"})
 
 
+# ── SSO token (codec espejo de cloud/app/sso.py) ────────────────────────────────
+import base64 as _b64mod
+import hashlib as _hashlib
+import hmac as _hmac
+import time as _time
+
+
+def _sso_verify(token: str) -> dict | None:
+    if not SSO_SECRET or not token:
+        return None
+    try:
+        body, sig = token.split(".", 1)
+        expected = _b64mod.urlsafe_b64encode(
+            _hmac.new(SSO_SECRET, body.encode(), _hashlib.sha256).digest()
+        ).decode().rstrip("=")
+        if not _hmac.compare_digest(sig, expected):
+            return None
+        pad = _b64mod.urlsafe_b64decode(body + "=" * (-len(body) % 4))
+        payload = json.loads(pad)
+        if payload.get("exp", 0) < _time.time():
+            return None
+        return payload
+    except Exception:
+        return None
+
+
+def _user_role_by_email(email: str) -> tuple[str, str, str] | None:
+    """(user_id, name, role) del usuario cuyo login_email == email, o None."""
+    if not email:
+        return None
+    e = email.strip().lower()
+    data = _core("/users") or {}
+    users = data.values() if isinstance(data, dict) else (data if isinstance(data, list) else [])
+    for u in users:
+        login_email = (u.get("email") or u.get("gcal_email") or "").strip().lower()
+        if login_email and login_email == e:
+            return u.get("id"), u.get("name", u.get("id")), u.get("role", "")
+    return None
+
+
 @app.get("/login", response_class=HTMLResponse)
 def login_page(request: Request, error: str = ""):
-    return templates.TemplateResponse(request, "login.html", {"error": error})
+    sso_link = ""
+    if CLOUD_SSO_URL and SSO_SECRET:
+        from urllib.parse import quote
+        redirect_uri = str(request.base_url).rstrip("/") + "/sso/callback"
+        sso_link = f"{CLOUD_SSO_URL}?redirect_uri={quote(redirect_uri, safe='')}"
+    return templates.TemplateResponse(request, "login.html",
+                                      {"error": error, "sso_link": sso_link})
 
 
 @app.post("/login")
 async def do_login(response: Response, token: str = Form(...)):
-    if not BACKOFFICE_TOKEN or secrets.compare_digest(token, BACKOFFICE_TOKEN):
-        session = _new_session()
+    # BACKOFFICE_TOKEN: bootstrap de emergencia offline → sesión admin sin usuario.
+    if BACKOFFICE_TOKEN and secrets.compare_digest(token, BACKOFFICE_TOKEN):
+        session = _new_session({"user_id": None, "name": "emergencia",
+                                "role": "admin", "email": None})
         resp = RedirectResponse("/dashboard", status_code=303)
         resp.set_cookie(_SESSION_COOKIE, session, httponly=True, samesite="lax")
         return resp
     return RedirectResponse("/login?error=Token+incorrecto", status_code=303)
 
 
+@app.get("/sso/callback")
+def sso_callback(request: Request, sso: str = ""):
+    """Recibe el token firmado emitido por la nube tras el Google sign-in (33.23).
+    Verifica firma+exp, resuelve email→usuario→rol (DB local) y abre sesión."""
+    payload = _sso_verify(sso)
+    if not payload:
+        return RedirectResponse("/login?error=SSO+inválido+o+expirado", status_code=303)
+    info = _user_role_by_email(payload.get("email", ""))
+    if not info:
+        return RedirectResponse("/login?error=Email+sin+usuario+registrado", status_code=303)
+    user_id, name, role = info
+    if role not in LOCAL_ACCESS_ROLES:
+        return RedirectResponse("/login?error=Tu+rol+no+tiene+acceso", status_code=303)
+    session = _new_session({"user_id": user_id, "name": name,
+                            "role": role, "email": payload.get("email")})
+    resp = RedirectResponse("/dashboard", status_code=303)
+    resp.set_cookie(_SESSION_COOKIE, session, httponly=True, samesite="lax")
+    return resp
+
+
 @app.get("/logout")
 def logout(request: Request, response: Response):
     session = request.cookies.get(_SESSION_COOKIE, "")
-    _SESSIONS.discard(session)
+    _SESSIONS.pop(session, None)
     resp = RedirectResponse("/login", status_code=303)
     resp.delete_cookie(_SESSION_COOKIE)
     return resp
@@ -115,10 +194,19 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        public = {"/login", "/api/status"}
-        if request.url.path not in public and not request.url.path.startswith("/login"):
+        path = request.url.path
+        request.state.principal = _principal(request)
+        public = {"/login", "/api/status", "/sso/callback"}
+        if path not in public and not path.startswith("/login"):
             if not _check_auth(request):
                 return RedirectResponse("/login", status_code=303)
+            # RBAC (33.24): solo admin puede mutar; el resto es read-only.
+            if request.method in _MUTATING:
+                p = _principal(request)
+                role = (p or {}).get("role")
+                if role is not None and role not in WRITE_ROLES:
+                    return JSONResponse(
+                        {"detail": "tu rol es de solo lectura"}, status_code=403)
         return await call_next(request)
 
 app.add_middleware(AuthMiddleware)

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -108,6 +108,13 @@
     </nav>
 
     <div class="px-3 py-3 border-t border-gray-800">
+      {% set _p = request.state.principal if request and request.state else None %}
+      {% if _p %}
+      <div class="sb-text flex items-center gap-2 text-xs text-gray-300 mb-2 px-2">
+        <span>👤</span>
+        <span>{{ _p.name }} · <span class="text-gray-500">{{ _p.role }}{{ " · solo lectura" if _p.role not in ["admin"] else "" }}</span></span>
+      </div>
+      {% endif %}
       <a href="/logout" title="Cerrar sesión"
          class="sb-logout flex items-center gap-2 text-xs text-gray-500 hover:text-gray-300 transition-colors py-1 rounded px-2 hover:bg-gray-800">
         <span>🚪</span><span class="sb-text">Cerrar sesión</span>

--- a/backoffice/templates/login.html
+++ b/backoffice/templates/login.html
@@ -13,13 +13,22 @@
       <p class="text-gray-500 text-sm mt-1">Backoffice</p>
     </div>
 
-    <form method="post" action="/login" class="bg-gray-900 border border-gray-800 rounded-xl p-6 space-y-4">
-      {% if error %}
-      <div class="text-red-400 text-sm bg-red-900/20 border border-red-800 rounded-lg px-3 py-2">
-        {{ error }}
-      </div>
-      {% endif %}
+    {% if error %}
+    <div class="text-red-400 text-sm bg-red-900/20 border border-red-800 rounded-lg px-3 py-2 mb-4">
+      {{ error }}
+    </div>
+    {% endif %}
 
+    {% if sso_link %}
+    <a href="{{ sso_link }}"
+       class="block text-center w-full bg-white text-gray-900 font-medium py-2 rounded-lg
+              text-sm hover:bg-gray-200 transition-colors mb-4">
+      Ingresar con Google (vía nube)
+    </a>
+    <p class="text-center text-xs text-gray-600 mb-4">— o token de emergencia —</p>
+    {% endif %}
+
+    <form method="post" action="/login" class="bg-gray-900 border border-gray-800 rounded-xl p-6 space-y-4">
       <div>
         <label class="block text-xs text-gray-400 mb-1">Token de acceso</label>
         <input type="password" name="token" autofocus required

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -18,6 +18,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from . import firestore_db as fdb
 from . import ratelimit
 from . import rbac
+from . import sso
 from .auth import (
     ALLOWED_EMAILS,
     FIREBASE_PROJECT_ID,
@@ -128,6 +129,46 @@ def api_emit_command(req: CommandRequest, p: Principal = Depends(require_dashboa
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     cmd = fdb.enqueue_command(req.type, params, issued_by=p.email)
     return {"command": cmd}
+
+
+# ── SSO broker para el backoffice local (33.22) ─────────────────────────────────
+
+LOCAL_SSO_ORIGINS = {
+    o.strip().rstrip("/")
+    for o in os.environ.get("LOCAL_SSO_ORIGINS", "").split(",") if o.strip()
+}
+
+
+def _valid_redirect(redirect_uri: str) -> bool:
+    """El redirect_uri debe ser /sso/callback de un origen LAN permitido."""
+    try:
+        from urllib.parse import urlparse
+        u = urlparse(redirect_uri)
+        origin = f"{u.scheme}://{u.netloc}"
+        return origin in LOCAL_SSO_ORIGINS and u.path == "/sso/callback"
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@app.get("/sso/start", response_class=HTMLResponse)
+def sso_start(request: Request, redirect_uri: str = ""):
+    if not _valid_redirect(redirect_uri):
+        raise HTTPException(status_code=400, detail="redirect_uri no permitido")
+    return templates.TemplateResponse(request, "sso.html", {
+        "firebase_api_key": os.environ.get("FIREBASE_API_KEY", ""),
+        "firebase_auth_domain": os.environ.get("FIREBASE_AUTH_DOMAIN", ""),
+        "firebase_project_id": FIREBASE_PROJECT_ID,
+        "redirect_uri": redirect_uri,
+    })
+
+
+@app.post("/sso/mint")
+def sso_mint(body: dict, p: Principal = Depends(require_dashboard_user)):
+    redirect_uri = (body or {}).get("redirect_uri", "")
+    if not _valid_redirect(redirect_uri):
+        raise HTTPException(status_code=400, detail="redirect_uri no permitido")
+    token = sso.mint(p.email, p.role)
+    return {"redirect": f"{redirect_uri}?sso={token}"}
 
 
 # ── Frontend ────────────────────────────────────────────────────────────────────

--- a/cloud/app/sso.py
+++ b/cloud/app/sso.py
@@ -1,0 +1,48 @@
+"""Token SSO firmado (HMAC) para autenticar en el backoffice local. FASE 33.22.
+
+La nube actúa de broker: tras el Google sign-in, emite un token corto firmado con
+un secreto compartido (`SSO_SECRET`) que el backoffice local verifica. El mismo
+codec está duplicado en el backoffice (son deployables separados).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+
+SSO_SECRET = os.environ.get("SSO_SECRET", "").encode()
+DEFAULT_TTL = int(os.environ.get("SSO_TTL", "120"))  # segundos
+
+
+def _b64(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).decode().rstrip("=")
+
+
+def _unb64(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def mint(email: str, role: str, ttl: int = DEFAULT_TTL) -> str:
+    payload = {"email": email, "role": role, "exp": int(time.time()) + ttl}
+    body = _b64(json.dumps(payload, separators=(",", ":")).encode())
+    sig = _b64(hmac.new(SSO_SECRET, body.encode(), hashlib.sha256).digest())
+    return f"{body}.{sig}"
+
+
+def verify(token: str) -> dict | None:
+    if not SSO_SECRET:
+        return None
+    try:
+        body, sig = token.split(".", 1)
+        expected = _b64(hmac.new(SSO_SECRET, body.encode(), hashlib.sha256).digest())
+        if not hmac.compare_digest(sig, expected):
+            return None
+        payload = json.loads(_unb64(body))
+        if payload.get("exp", 0) < time.time():
+            return None
+        return payload
+    except Exception:  # noqa: BLE001
+        return None

--- a/cloud/app/templates/sso.html
+++ b/cloud/app/templates/sso.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Capitán · acceso al backoffice local</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<main>
+  <section class="card" style="max-width:480px;margin:60px auto;">
+    <h1>Capitán <span class="muted">· acceso local</span></h1>
+    <p class="muted">Ingresá con Google para autenticarte en el backoffice local.</p>
+    <p id="status" class="muted">Esperando login…</p>
+    <button id="signin">Ingresar con Google</button>
+    <p id="err" class="error hidden"></p>
+  </section>
+</main>
+
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script>
+const CFG = {
+  apiKey: "{{ firebase_api_key }}",
+  authDomain: "{{ firebase_auth_domain }}",
+  projectId: "{{ firebase_project_id }}",
+};
+const REDIRECT_URI = {{ redirect_uri | tojson }};
+firebase.initializeApp(CFG);
+const auth = firebase.auth();
+const provider = new firebase.auth.GoogleAuthProvider();
+const $ = (id) => document.getElementById(id);
+
+$("signin").onclick = () => auth.signInWithPopup(provider).catch(e => {
+  $("err").textContent = e.message; $("err").classList.remove("hidden");
+});
+
+async function handoff(user) {
+  $("status").textContent = "Generando acceso…";
+  const idToken = await user.getIdToken();
+  try {
+    const r = await fetch("/sso/mint", {
+      method: "POST",
+      headers: { "Authorization": "Bearer " + idToken, "Content-Type": "application/json" },
+      body: JSON.stringify({ redirect_uri: REDIRECT_URI }),
+    });
+    if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || r.status);
+    const { redirect } = await r.json();
+    $("status").textContent = "Redirigiendo al backoffice local…";
+    window.location = redirect;
+  } catch (e) {
+    $("err").textContent = "No autorizado: " + e.message;
+    $("err").classList.remove("hidden");
+    $("status").textContent = "";
+    auth.signOut();
+  }
+}
+
+auth.onAuthStateChanged((user) => { if (user) handoff(user); });
+</script>
+</body>
+</html>

--- a/cloud/tests/test_sso.py
+++ b/cloud/tests/test_sso.py
@@ -1,0 +1,57 @@
+"""Tests del token SSO firmado (33.22)."""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import sso
+
+
+def _secret(monkeypatch, val=b"supersecreto-de-prueba"):
+    monkeypatch.setattr(sso, "SSO_SECRET", val)
+
+
+def test_mint_verify_roundtrip(monkeypatch):
+    _secret(monkeypatch)
+    tok = sso.mint("matias@blasi.ar", "admin")
+    p = sso.verify(tok)
+    assert p["email"] == "matias@blasi.ar" and p["role"] == "admin"
+
+
+def test_tampered_token_rejected(monkeypatch):
+    _secret(monkeypatch)
+    tok = sso.mint("matias@blasi.ar", "admin")
+    body, sig = tok.split(".", 1)
+    forged = body + "." + ("A" * len(sig))
+    assert sso.verify(forged) is None
+
+
+def test_expired_rejected(monkeypatch):
+    _secret(monkeypatch)
+    tok = sso.mint("x@y.z", "familiar", ttl=-1)
+    assert sso.verify(tok) is None
+
+
+def test_wrong_secret_rejected(monkeypatch):
+    _secret(monkeypatch, b"secreto-A")
+    tok = sso.mint("x@y.z", "admin")
+    _secret(monkeypatch, b"secreto-B")
+    assert sso.verify(tok) is None
+
+
+def test_no_secret_returns_none(monkeypatch):
+    _secret(monkeypatch, b"")
+    assert sso.verify("a.b") is None
+
+
+def test_role_escalation_via_tamper_blocked(monkeypatch):
+    # Cambiar el rol en el payload invalida la firma.
+    _secret(monkeypatch)
+    tok = sso.mint("x@y.z", "adolescente")
+    import base64, json
+    body, sig = tok.split(".", 1)
+    payload = json.loads(base64.urlsafe_b64decode(body + "=" * (-len(body) % 4)))
+    payload["role"] = "admin"
+    forged_body = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":")).encode()).decode().rstrip("=")
+    assert sso.verify(f"{forged_body}.{sig}") is None


### PR DESCRIPTION
El backoffice local reusa el login de la nube (Google sign-in) en vez del token compartido.

- **33.22** Cloud broker: `/sso/start` (Google sign-in) + `/sso/mint` emiten un token HMAC firmado (exp 120s) y redirigen al backoffice local. Allow-list de `redirect_uri` (`LOCAL_SSO_ORIGINS`).
- **33.23** Backoffice local: `/sso/callback` verifica firma+exp, resuelve email→usuario→rol (DB local), sesión por usuario, header con usuario·rol. `BACKOFFICE_TOKEN` queda como bootstrap de emergencia offline (→admin). Funciona por IP de la LAN sin Firebase del lado local.
- **33.24** RBAC local: middleware bloquea POST/PUT/PATCH/DELETE salvo admin (read-only para familiar/adolescente); roles sin acceso rechazados.

Codec SSO espejado cloud↔backoffice; 6 tests + cross-compat verificada en runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)