### PR TITLE
plan/docs: FASE 33 Etapa E completa — SSO local + RBAC

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -79,6 +79,17 @@ restringido por `ALLOWED_EMAILS` (validado en el backend).
 | `BRIDGE_SA_EMAIL` | email de la SA del bridge autorizada a ingest/commands |
 | `SERVICE_URL` | audiencia esperada del OIDC del bridge |
 | `FIREBASE_API_KEY` / `FIREBASE_AUTH_DOMAIN` | config web de Firebase Auth |
+| `SSO_SECRET` | secreto HMAC compartido con el backoffice local (firma el token SSO) |
+| `LOCAL_SSO_ORIGINS` | allow-list de orígenes LAN del backoffice local para el redirect SSO |
+
+## SSO con el backoffice local (33.22–33.24)
+
+El backoffice local (LAN, `:8080`) reusa este login en vez de un token compartido. La nube
+actúa de broker: `/sso/start?redirect_uri=<local>/sso/callback` hace el Google sign-in y
+`/sso/mint` emite un token HMAC firmado (exp corto) que redirige al backoffice local, el cual
+lo verifica, resuelve email→usuario→rol contra su DB y abre sesión con RBAC (admin escribe;
+familiar/adolescente read-only). El `redirect_uri` se valida contra `LOCAL_SSO_ORIGINS`. El
+codec del token está espejado en `cloud/app/sso.py` y en el backoffice.
 
 ## Seguridad
 

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -123,6 +123,13 @@ inversión de control.
   comandos tipados y cerrados; reglas Firestore deny-all de cliente.
 - **Failover**: si la nube cae, el core sigue local y el bridge reintenta con backoff; si el
   bridge cae, el backoffice local en LAN (`:8080`, FASE 12) sigue operando.
+- **Login consistente + RBAC** (Etapa E): el login del dashboard se valida contra los usuarios
+  reales (roster email→rol que el bridge materializa desde la DB). RBAC por rol: admin ve todo y
+  emite comandos; familiar read-only; adolescente read-only vista básica (sin PII/auditoría);
+  resto sin acceso. El backoffice **local** reusa este mismo login vía SSO (la nube emite un
+  token HMAC firmado tras el Google sign-in y redirige al `:8080`), con sesión por usuario y
+  RBAC (admin escribe; familiar/adolescente read-only). `BACKOFFICE_TOKEN` queda como
+  bootstrap de emergencia offline. Identidad de login = `User.email` (o `gcal_email`).
 
 Contrato y modelo de amenazas: `masterplan/fase33_cloud_backoffice.md`.
 

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -2866,8 +2866,8 @@ Objetivo: Tener un backoffice accesible desde internet SIN exponer el SER9 ni HA
           La nube nunca inicia conexiones hacia la casa: el SER9 empuja estado para
           dibujar el dashboard y POLEA una cola de comandos para ejecutar acciones de
           administración (patrón command / executor). Plataforma: Google Cloud.
-Estado:   EN CURSO (21/24 — A–D + cloud login/RBAC desplegados; falta SSO del backoffice
-          local (reusar el login de la nube) + RBAC local, 33.22–33.24).
+Estado:   COMPLETA — cloud + bridge + login consistente (roster email→rol) + RBAC, y SSO
+          del backoffice local (reusa el Google sign-in de la nube) + RBAC local. Verificado e2e.
 Deps:     FASE 12 (backoffice local — COMPLETA, fuente de datos y UI a reusar),
           FASE 21 (SER9 estable — COMPLETA), FASE 32 (datos en SQLite — COMPLETA).
 Principio de seguridad: el SER9 sólo hace conexiones SALIENTES (HTTPS) a la nube.
@@ -2949,11 +2949,11 @@ Stack GCP elegido: Cloud Run (web + API, scale-to-zero), Firestore (snapshot de
             familiar: read-only completo; adolescente: read-only vista básica sin PII/auditoría;
             resto: sin acceso). Gate de `/api/commands` y filtrado de datos sensibles por
             capacidad; el frontend oculta acciones sin permiso; tests.
-- [ ] 33.22 SSO broker en la nube: endpoint `/sso/start?redirect_uri=...` que, tras el Google
+- [x] 33.22 SSO broker en la nube: endpoint `/sso/start?redirect_uri=...` que, tras el Google
             sign-in ya existente, emite un token firmado (HMAC, exp corto) y redirige al
             backoffice local. Allow-list de redirect_uri (orígenes LAN permitidos).
-- [ ] 33.23 Backoffice local: aceptar el SSO token (verificar firma+exp), mapear email→usuario→rol
+- [x] 33.23 Backoffice local: aceptar el SSO token (verificar firma+exp), mapear email→usuario→rol
             (DB local), sesión atada al usuario; el header muestra usuario·rol; `BACKOFFICE_TOKEN`
             queda como bootstrap de emergencia offline (→admin). Acceso por IP de la LAN.
-- [ ] 33.24 RBAC en el backoffice local: admin escribe; familiar/adolescente read-only (bloqueo
+- [x] 33.24 RBAC en el backoffice local: admin escribe; familiar/adolescente read-only (bloqueo
             de POST/PATCH/DELETE/PUT por middleware); roles sin acceso rechazados. Tests.


### PR DESCRIPTION
Marca 33.22-33.24 completas y FASE 33 COMPLETA. Docs: cloud README (SSO + vars) + arquitectura_funcional (login consistente + RBAC + SSO local). Verificado e2e en capitan-lxc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)