### PR TITLE
feat: backoffice — landing /home post-login

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -154,7 +154,7 @@ async def do_login(response: Response, token: str = Form(...)):
     if BACKOFFICE_TOKEN and secrets.compare_digest(token, BACKOFFICE_TOKEN):
         session = _new_session({"user_id": None, "name": "emergencia",
                                 "role": "admin", "email": None})
-        resp = RedirectResponse("/dashboard", status_code=303)
+        resp = RedirectResponse("/home", status_code=303)
         resp.set_cookie(_SESSION_COOKIE, session, httponly=True, samesite="lax")
         return resp
     return RedirectResponse("/login?error=Token+incorrecto", status_code=303)
@@ -175,7 +175,7 @@ def sso_callback(request: Request, sso: str = ""):
         return RedirectResponse("/login?error=Tu+rol+no+tiene+acceso", status_code=303)
     session = _new_session({"user_id": user_id, "name": name,
                             "role": role, "email": payload.get("email")})
-    resp = RedirectResponse("/dashboard", status_code=303)
+    resp = RedirectResponse("/home", status_code=303)
     resp.set_cookie(_SESSION_COOKIE, session, httponly=True, samesite="lax")
     return resp
 
@@ -341,7 +341,12 @@ def api_status():
 
 @app.get("/", response_class=HTMLResponse)
 def root():
-    return RedirectResponse("/chat")
+    return RedirectResponse("/home")
+
+
+@app.get("/home", response_class=HTMLResponse)
+def home(request: Request):
+    return _render(request, "home.html", "home")
 
 
 # ── Chat (17.2–17.4) ───────────────────────────────────────────────────────────

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -76,6 +76,7 @@
       <!-- Monitoreo -->
       <div class="flex flex-col gap-0.5">
         <p class="sb-section px-3 pb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-600">Monitoreo</p>
+        <a href="/home"         title="Inicio"       class="{{ link_active if section == 'home'         else link_base }}"><span>🏠</span><span class="sb-text">Inicio</span></a>
         <a href="/dashboard"    title="Dashboard"    class="{{ link_active if section == 'dashboard'    else link_base }}"><span>📊</span><span class="sb-text">Dashboard</span></a>
         <a href="/stats"        title="Estadísticas" class="{{ link_active if section == 'stats'        else link_base }}"><span>📈</span><span class="sb-text">Estadísticas</span></a>
         <a href="/alerts"       title="Alertas"      class="{{ link_active if section == 'alerts'       else link_base }}"><span>🔔</span><span class="sb-text">Alertas</span></a>

--- a/backoffice/templates/home.html
+++ b/backoffice/templates/home.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block title %}Inicio{% endblock %}
+
+{% block content %}
+{% set _p = request.state.principal if request and request.state else None %}
+
+<div class="mb-8">
+  <h1 class="text-2xl font-bold">
+    Hola{% if _p and _p.name %}, {{ _p.name }}{% endif %} 👋
+  </h1>
+  <p class="text-gray-500 text-sm mt-1">
+    Backoffice de Capitán
+    {% if _p %}
+      · <span class="text-gray-400">{{ _p.role }}</span>
+      {% if _p.role not in ["admin"] %}<span class="text-amber-500"> · solo lectura</span>{% endif %}
+    {% endif %}
+  </p>
+</div>
+
+<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+  {% set cards = [
+    ("/dashboard", "📊", "Dashboard", "Estado, latencias y actividad"),
+    ("/agents", "🤖", "Agentes", "Agentes activos y configuración"),
+    ("/conversations", "💬", "Conversaciones", "Historial de conversaciones"),
+    ("/intents", "🎯", "Intenciones", "Intents pendientes y capturas"),
+    ("/goals", "🏆", "Goals", "Objetivos en curso"),
+    ("/routines", "🔄", "Rutinas", "Rutinas detectadas"),
+    ("/users", "👥", "Usuarios", "Gestión de usuarios y roles"),
+    ("/panels", "🖥️", "Paneles", "NSPanel y nodos de voz"),
+    ("/wakeword", "🎙️", "Wake word", "Métricas y reentrenamiento"),
+    ("/integrations", "🔌", "Integraciones", "Servicios conectados"),
+    ("/plan", "🗺️", "Plan", "Estado del masterplan"),
+    ("/config", "⚙️", "Config", "Variables de entorno"),
+  ] %}
+  {% for href, icon, title, desc in cards %}
+  <a href="{{ href }}"
+     class="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-blue-600 hover:bg-gray-800/60 transition-colors">
+    <div class="text-2xl mb-2">{{ icon }}</div>
+    <div class="font-medium text-sm">{{ title }}</div>
+    <div class="text-xs text-gray-500 mt-1">{{ desc }}</div>
+  </a>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Landing de bienvenida tras el login OAuth: saludo con usuario·rol + cards a las secciones. root y post-login redirigen a /home. Ítem Inicio en la nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)