### PR TITLE
fix: deploy smoke test — aceptar 3xx para backoffice

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,6 +30,7 @@ fi
 echo "=== Smoke test (esperando 5s) ==="
 sleep 5
 ssh capitan-lxc "curl -sf http://localhost:8765/health" && echo "core OK" || echo "core NO responde"
-ssh capitan-lxc "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/" | grep -qE '^(200|307)' && echo "backoffice OK" || echo "backoffice NO responde"
+# / redirige a /login (303) cuando no hay sesión — un 3xx es respuesta sana
+ssh capitan-lxc "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/" | grep -qE '^(2..|3..)' && echo "backoffice OK" || echo "backoffice NO responde"
 
 echo "=== Deploy completo ==="


### PR DESCRIPTION
## Problema

El smoke test del deploy reportaba `backoffice NO responde` aunque el servicio estaba sano. La causa: `/` devuelve **303** (redirect a `/login` cuando no hay sesión) y el test solo aceptaba `200|307`.

## Fix

Acepta cualquier `2xx`/`3xx` como respuesta sana. Un redirect a login es signo de que el backoffice está sirviendo.

Verificado en prod: `/` → 303 → `/login` (200), servicio `active (running)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)