### PR TITLE
fix: deploy — respetar flag --restart-wa

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,12 +19,11 @@ ssh capitan-lxc "
   echo 'Servicios reiniciados.'
 "
 
-# WA siempre se reinicia después del core — no reintenta conexiones caídas
-echo "Reiniciando WA..."
-ssh capitan-lxc "systemctl --user restart capitan-wa"
-
-if [[ $RESTART_WA -eq 0 ]]; then
-  : # WA ya reiniciado arriba
+# WA solo se reinicia con --restart-wa (reconectar el cliente WhatsApp es caro:
+# puede requerir re-escanear el QR). El core no depende de WA para arrancar.
+if [[ $RESTART_WA -eq 1 ]]; then
+  echo "Reiniciando WA..."
+  ssh capitan-lxc "systemctl --user restart capitan-wa"
 fi
 
 echo "=== Smoke test (esperando 5s) ==="


### PR DESCRIPTION
## Problema

`--restart-wa` no tenía efecto: WA se reiniciaba **siempre**. El flag `RESTART_WA` se calculaba pero nunca se usaba (el bloque que lo chequeaba estaba vacío).

## Fix

WA solo se reinicia cuando se pasa `--restart-wa`. Reconectar el cliente WhatsApp es caro (puede pedir re-escanear el QR) y el core no depende de WA para arrancar — el deploy por defecto no debería tocarlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)