### PR TITLE
fix: 16.32 — provisioning THRESH 0.8 + FRAMES_REQ=2; bump ear

### DIFF
--- a/scripts/nspanel.sh
+++ b/scripts/nspanel.sh
@@ -282,7 +282,8 @@ ROOM=$room
 WAKEWORD_MODEL=/data/data/com.termux/files/home/wakeword/capitan.onnx
 MELSPEC_MODEL=/data/data/com.termux/files/home/wakeword/melspectrogram.onnx
 EMBEDDING_MODEL=/data/data/com.termux/files/home/wakeword/embedding_model.onnx
-WAKEWORD_THRESH=0.7
+WAKEWORD_THRESH=0.8
+WAKEWORD_FRAMES_REQ=2
 COMMAND_SECS=5
 SAMPLE_RATE=16000
 EOF


### PR DESCRIPTION
Alinea el `satellite.env` del provisioning con el tuning anti-falsos-positivos:
- `WAKEWORD_THRESH` 0.7 → 0.8 (estaba por debajo del default del código).
- `WAKEWORD_FRAMES_REQ=2` explícito (antes no se seteaba → caía al default).

Incluye el bump del submodule `ear` (PR ear #37: default de FRAMES_REQ 1→2).

Parte de #528. Falta el retrain con hard-negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)