### PR TITLE
feat: 16.7 — frontend backoffice de ambientes (áreas HA)

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1855,7 +1855,35 @@ def panels_page(request: Request):
     """Administración de paneles (16.26): lista del registro (DB) + estado en vivo del audio_server."""
     panels = _panels()
     nodes = {n["node_id"]: n for n in (_audio("/nodes") or [])}
-    return _render(request, "panels.html", "panels", panels=panels, nodes=nodes)
+    areas = _core("/areas") or []   # áreas de HAOS para bindear el panel (16.7)
+    return _render(request, "panels.html", "panels", panels=panels, nodes=nodes, areas=areas)
+
+
+@app.post("/panels/{name}/area", response_class=HTMLResponse)
+async def panels_set_area(name: str, request: Request):
+    """Bindea un panel a un área de HAOS (16.7)."""
+    form = await request.form()
+    area_id = str(form.get("area_id", "")).strip()
+    _core("/panels", method="POST", json={"name": name, "area_id": area_id})
+    return HTMLResponse('<span class="text-xs text-emerald-400">✓ guardado</span>')
+
+
+# ── Ambientes / Rooms (FASE 16.7) — fuente de verdad = áreas de HAOS ──────────
+
+@app.get("/rooms", response_class=HTMLResponse)
+def rooms_page(request: Request):
+    """Ambientes: áreas de HAOS (fuente de verdad) + augmentación local (Echo) + paneles."""
+    rooms = _core("/rooms") or []
+    return _render(request, "rooms.html", "rooms", rooms=rooms)
+
+
+@app.post("/rooms/{area_id}/echo", response_class=HTMLResponse)
+async def rooms_save_echo(area_id: str, request: Request):
+    """Guarda el media_player (Echo) asignado a un área (augmentación local)."""
+    form = await request.form()
+    echo = str(form.get("echo_entity_id", "")).strip()
+    _core("/rooms", method="POST", json={"area_id": area_id, "echo_entity_id": echo})
+    return HTMLResponse('<span class="text-xs text-emerald-400">✓ guardado</span>')
 
 
 @app.delete("/panels/{name}", response_class=HTMLResponse)
@@ -1888,7 +1916,8 @@ def _provision_log_fragment(name: str) -> str:
 async def panels_provision(request: Request):
     form = await request.form()
     name = str(form.get("name", "")).strip().lower()
-    room = str(form.get("room", "")).strip().lower() or name
+    area_id = str(form.get("area_id", "")).strip()       # área de HAOS (16.7)
+    room = area_id or str(form.get("room", "")).strip().lower() or name
     ip   = str(form.get("ip", "")).strip()
     if not name or not ip:
         return HTMLResponse('<p class="text-red-400 text-xs">Faltan nombre o IP.</p>')
@@ -1901,6 +1930,8 @@ async def panels_provision(request: Request):
                          stdout=f, stderr=subprocess.STDOUT, cwd=str(_REPO_DIR))
     except Exception as e:
         return HTMLResponse(f'<p class="text-red-400 text-xs">No se pudo lanzar: {e}</p>')
+    if area_id:   # bindear el panel al área elegida (16.7)
+        _core("/panels", method="POST", json={"name": name, "area_id": area_id})
     return HTMLResponse(_provision_log_fragment(name))
 
 

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -102,6 +102,7 @@
         <a href="/users"            title="Usuarios"      class="{{ link_active if section == 'users'            else link_base }}"><span>👥</span><span class="sb-text">Usuarios</span></a>
         <a href="/wakeword"         title="Wake word"     class="{{ link_active if section == 'wakeword'         else link_base }}"><span>🎙️</span><span class="sb-text">Wake word</span></a>
         <a href="/panels"           title="Paneles"       class="{{ link_active if section == 'panels'           else link_base }}"><span>🖥️</span><span class="sb-text">Paneles</span></a>
+        <a href="/rooms"            title="Ambientes"     class="{{ link_active if section == 'rooms'            else link_base }}"><span>🏘️</span><span class="sb-text">Ambientes</span></a>
         <a href="/integrations"     title="Integraciones" class="{{ link_active if section == 'integrations'     else link_base }}"><span>🔌</span><span class="sb-text">Integraciones</span></a>
         <a href="/config"           title="Config (.env)" class="{{ link_active if section == 'config'           else link_base }}"><span>⚙️</span><span class="sb-text">Config (.env)</span></a>
       </div>

--- a/backoffice/templates/panels.html
+++ b/backoffice/templates/panels.html
@@ -18,7 +18,7 @@
     <thead class="bg-gray-800/50 text-gray-400 text-xs uppercase tracking-wider">
       <tr>
         <th class="text-left px-4 py-2">Panel</th>
-        <th class="text-left px-4 py-2">Ambiente</th>
+        <th class="text-left px-4 py-2">Área HA</th>
         <th class="text-left px-4 py-2">IP</th>
         <th class="text-left px-4 py-2">Estado</th>
         <th class="text-left px-4 py-2">Usuarios</th>
@@ -30,7 +30,17 @@
       {% set node = nodes.get(p.node_id) %}
       <tr id="panel-{{ p.name }}" class="border-t border-gray-800">
         <td class="px-4 py-2 font-medium text-gray-200">{{ p.name }}</td>
-        <td class="px-4 py-2 text-gray-400">{{ p.room }}</td>
+        <td class="px-4 py-2">
+          <select name="area_id" hx-post="/panels/{{ p.name }}/area" hx-trigger="change"
+                  hx-target="#area-st-{{ p.name }}" hx-swap="innerHTML"
+                  class="px-2 py-1 bg-gray-800 border border-gray-700 rounded-lg text-xs text-gray-200">
+            <option value="" {% if not p.area_id %}selected{% endif %}>— sin área —</option>
+            {% for a in areas %}
+            <option value="{{ a.area_id }}" {% if a.area_id == p.area_id %}selected{% endif %}>{{ a.name }}</option>
+            {% endfor %}
+          </select>
+          <span id="area-st-{{ p.name }}" class="ml-1"></span>
+        </td>
         <td class="px-4 py-2 font-mono text-gray-500">{{ p.ip }}</td>
         <td class="px-4 py-2">
           {% if node and node.state == 'active' %}
@@ -75,9 +85,14 @@
              class="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
     </div>
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Ambiente</label>
-      <input name="room" placeholder="dormitorio"
-             class="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
+      <label class="block text-xs text-gray-500 mb-1">Área (Home Assistant)</label>
+      <select name="area_id"
+              class="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
+        <option value="">— elegir área —</option>
+        {% for a in areas %}
+        <option value="{{ a.area_id }}">{{ a.name }}</option>
+        {% endfor %}
+      </select>
     </div>
     <div>
       <label class="block text-xs text-gray-500 mb-1">IP</label>

--- a/backoffice/templates/rooms.html
+++ b/backoffice/templates/rooms.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block title %}Ambientes{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Ambientes</h1>
+  <a href="/panels" class="text-sm text-gray-400 hover:text-gray-200">Paneles →</a>
+</div>
+
+<p class="text-sm text-gray-400 mb-4">
+  Los ambientes son las <strong>áreas definidas en Home Assistant</strong> (fuente de verdad).
+  Acá se aumentan con config local: el <em>media_player</em> (Echo) al que se enruta la respuesta
+  de voz, y qué paneles están bindeados a cada área.
+</p>
+
+<div class="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+  <table class="w-full text-sm">
+    <thead class="bg-gray-800/50 text-gray-400 text-xs uppercase tracking-wider">
+      <tr>
+        <th class="text-left px-4 py-2">Área (HA)</th>
+        <th class="text-left px-4 py-2">Media player / Echo</th>
+        <th class="text-left px-4 py-2">Paneles</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for r in rooms %}
+      <tr class="border-t border-gray-800 align-top">
+        <td class="px-4 py-3">
+          <div class="font-medium text-gray-200">{{ r.name }}</div>
+          <div class="text-xs font-mono text-gray-600">{{ r.area_id }}</div>
+        </td>
+        <td class="px-4 py-3">
+          <form hx-post="/rooms/{{ r.area_id }}/echo" hx-target="#echo-st-{{ r.area_id }}"
+                hx-swap="innerHTML" class="flex items-center gap-2">
+            <input name="echo_entity_id" value="{{ r.echo_entity_id or '' }}"
+                   placeholder="media_player.echo_..."
+                   class="px-2 py-1 bg-gray-800 border border-gray-700 rounded-lg text-xs text-gray-200 font-mono w-64">
+            <button type="submit"
+                    class="text-xs px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded-lg text-gray-200">guardar</button>
+            <span id="echo-st-{{ r.area_id }}"></span>
+          </form>
+        </td>
+        <td class="px-4 py-3 text-xs text-gray-400">
+          {% for p in r.panels %}
+          <span class="inline-block bg-gray-800 rounded px-2 py-0.5 mr-1 mb-1">
+            🖥️ {{ p.name }}{% if p.node_id %} <span class="text-gray-600 font-mono">({{ p.node_id }})</span>{% endif %}
+          </span>
+          {% else %}
+          <span class="text-gray-600 italic">—</span>
+          {% endfor %}
+        </td>
+      </tr>
+      {% else %}
+      <tr><td colspan="3" class="px-4 py-6 text-center text-gray-600">
+        No se pudieron leer las áreas de Home Assistant.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<p class="text-xs text-gray-600 mt-3">
+  El binding panel→área se hace desde <a href="/panels" class="text-gray-400 hover:text-gray-200 underline">Paneles</a>.
+</p>
+{% endblock %}


### PR DESCRIPTION
Frontend de FASE 16.7 sobre el backend del core (PR core #200).

- **Página `/rooms`** (nav "Ambientes"): lista las áreas de HAOS (fuente de verdad), permite editar el `media_player`/Echo por área (augmentación local, para el routing de 16.6) y muestra los paneles bindeados a cada área.
- **Paneles**: columna "Área HA" con dropdown poblado de `GET /areas` que bindea el panel (`POST /panels/{name}/area`). El alta de panel elige el área de HA en vez de texto libre — "agregar un panel se nutre de las áreas de HA".

Cierra 16.7 (#88). Desbloquea 16.33 (#529).

🤖 Generated with [Claude Code](https://claude.com/claude-code)