### PR TITLE
feat: fase 35 Etapa B — dashboards de métricas (backoffice + cloud)

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -1279,6 +1279,27 @@ def stats_page(request: Request):
     return _render(request, "stats.html", "stats", history=history)
 
 
+@app.get("/metrics", response_class=HTMLResponse)
+def metrics_page(request: Request):
+    """Dashboard de observabilidad (FASE 35.4): métricas de voz y LLM desde el core."""
+    _require_auth(request)
+    nodes  = [n.get("node_id") for n in (_audio("/nodes") or []) if n.get("node_id")]
+    agents = sorted((_core("/agents-meta", timeout=5) or {}).keys())
+    return _render(request, "metrics.html", "metrics", nodes=nodes, agents=agents)
+
+
+# Proxy de solo-lectura a la API de métricas del core (FASE 35.3). El browser pega
+# acá (mismo origen, autenticado) y el backoffice reenvía al core en la LAN.
+@app.get("/api/metrics/{path:path}")
+def api_metrics_proxy(path: str, request: Request):
+    _require_auth(request)
+    qs = request.url.query
+    data = _core(f"/metrics/{path}" + (f"?{qs}" if qs else ""), timeout=8)
+    if data is None:
+        return JSONResponse({"detail": "core no disponible"}, status_code=502)
+    return JSONResponse(data)
+
+
 @app.get("/alerts", response_class=HTMLResponse)
 def alerts_page(request: Request):
     data = _core("/alerts") or []

--- a/backoffice/templates/base.html
+++ b/backoffice/templates/base.html
@@ -79,6 +79,7 @@
         <a href="/home"         title="Inicio"       class="{{ link_active if section == 'home'         else link_base }}"><span>🏠</span><span class="sb-text">Inicio</span></a>
         <a href="/dashboard"    title="Dashboard"    class="{{ link_active if section == 'dashboard'    else link_base }}"><span>📊</span><span class="sb-text">Dashboard</span></a>
         <a href="/stats"        title="Estadísticas" class="{{ link_active if section == 'stats'        else link_base }}"><span>📈</span><span class="sb-text">Estadísticas</span></a>
+        <a href="/metrics"      title="Métricas"     class="{{ link_active if section == 'metrics'      else link_base }}"><span>📡</span><span class="sb-text">Métricas</span></a>
         <a href="/alerts"       title="Alertas"      class="{{ link_active if section == 'alerts'       else link_base }}"><span>🔔</span><span class="sb-text">Alertas</span></a>
         <a href="/logs"         title="Logs"         class="{{ link_active if section == 'logs'         else link_base }}"><span>📋</span><span class="sb-text">Logs</span></a>
         <a href="/traces" title="Traces proactivos" class="{{ link_active if section == 'traces' else link_base }}"><span>🔍</span><span class="sb-text">Traces</span></a>

--- a/backoffice/templates/metrics.html
+++ b/backoffice/templates/metrics.html
@@ -1,0 +1,263 @@
+{% extends "base.html" %}
+{% block title %}Métricas{% endblock %}
+
+{% block content %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+
+<div class="flex flex-wrap items-center justify-between gap-3 mb-6">
+  <h1 class="text-2xl font-bold">Métricas <span class="text-sm font-normal text-gray-500">observabilidad</span></h1>
+  <div class="flex flex-wrap items-center gap-2 text-sm">
+    <select id="f-range" class="bg-gray-800 border border-gray-700 rounded px-2 py-1">
+      <option value="1">última hora</option>
+      <option value="6">últimas 6h</option>
+      <option value="24" selected>últimas 24h</option>
+      <option value="168">últimos 7d</option>
+      <option value="720">últimos 30d</option>
+    </select>
+    <label class="flex items-center gap-1 text-gray-400">
+      <input type="checkbox" id="f-auto" class="accent-emerald-500"> auto
+    </label>
+    <button id="f-refresh" class="bg-gray-800 border border-gray-700 rounded px-3 py-1 hover:bg-gray-700">↻</button>
+  </div>
+</div>
+
+<!-- Tabs -->
+<div class="flex gap-2 mb-5 border-b border-gray-800">
+  <button data-tab="voz" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-emerald-500 text-white">🎙️ Voz</button>
+  <button data-tab="llm" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-400 hover:text-white">🤖 LLM / Agentes</button>
+</div>
+
+<!-- ── Sección VOZ ──────────────────────────────────────────────────────────── -->
+<section data-panel="voz">
+  <div class="flex items-center gap-2 mb-4 text-sm">
+    <span class="text-gray-500">nodo:</span>
+    <select id="f-node" class="bg-gray-800 border border-gray-700 rounded px-2 py-1">
+      <option value="">todos</option>
+      {% for n in nodes %}<option value="{{ n }}">{{ n }}</option>{% endfor %}
+    </select>
+  </div>
+
+  <div id="voz-cards" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6"></div>
+
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-6">
+    <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Wake word — comandos (TP) vs falsos positivos (FP)</div>
+    <canvas id="voz-chart" height="90"></canvas>
+  </div>
+
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+    <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Reentrenamientos</div>
+    <table class="w-full text-sm">
+      <thead class="text-gray-500 text-xs uppercase">
+        <tr><th class="text-left py-1">Fecha</th><th class="text-right">Pos</th><th class="text-right">Neg</th>
+            <th class="text-right">Val acc</th><th class="text-right">FP rate</th><th class="text-right">Dur</th><th class="text-right">Estado</th></tr>
+      </thead>
+      <tbody id="voz-retrains" class="font-mono text-gray-300"></tbody>
+    </table>
+  </div>
+</section>
+
+<!-- ── Sección LLM ──────────────────────────────────────────────────────────── -->
+<section data-panel="llm" class="hidden">
+  <div class="flex items-center gap-2 mb-4 text-sm">
+    <span class="text-gray-500">agente:</span>
+    <select id="f-agent" class="bg-gray-800 border border-gray-700 rounded px-2 py-1">
+      <option value="">todos</option>
+      {% for a in agents %}<option value="{{ a }}">{{ a }}</option>{% endfor %}
+    </select>
+  </div>
+
+  <div id="llm-cards" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6"></div>
+
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4 mb-6">
+    <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Requests y latencia total promedio</div>
+    <canvas id="llm-chart" height="90"></canvas>
+  </div>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Por modelo</div>
+      <table class="w-full text-sm">
+        <thead class="text-gray-500 text-xs uppercase">
+          <tr><th class="text-left py-1">Modelo</th><th class="text-right">Llamadas</th><th class="text-right">Lat ms</th><th class="text-right">Tokens p/c</th></tr>
+        </thead>
+        <tbody id="llm-models" class="font-mono text-gray-300"></tbody>
+      </table>
+    </div>
+    <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Por agente</div>
+      <table class="w-full text-sm">
+        <thead class="text-gray-500 text-xs uppercase">
+          <tr><th class="text-left py-1">Agente</th><th class="text-right">Steps</th><th class="text-right">Aciertos</th><th class="text-right">Lat ms</th><th class="text-right">Tools</th></tr>
+        </thead>
+        <tbody id="llm-agents" class="font-mono text-gray-300"></tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const fmtNum = (v) => v == null ? "—" : (typeof v === "number" ? v.toLocaleString("es") : v);
+const fmtPct = (v) => v == null ? "—" : (v * 100).toFixed(1) + "%";
+
+// Etiqueta de tiempo según el rango (horas → HH:MM, días → DD/MM)
+function fmtLabel(ts) {
+  const d = new Date(ts * 1000);
+  const hours = parseInt($("f-range").value, 10);
+  return hours <= 24
+    ? d.toLocaleTimeString("es", {hour: "2-digit", minute: "2-digit"})
+    : d.toLocaleDateString("es", {day: "2-digit", month: "2-digit"});
+}
+
+function card(label, value, sub) {
+  return `<div class="bg-gray-900 border border-gray-800 rounded-xl p-3">
+    <div class="text-[10px] text-gray-500 uppercase tracking-wider">${label}</div>
+    <div class="text-xl font-bold text-gray-100 mt-1">${value}</div>
+    ${sub ? `<div class="text-[11px] text-gray-500 mt-0.5">${sub}</div>` : ""}</div>`;
+}
+
+async function getJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(url + " → " + r.status);
+  return r.json();
+}
+
+function qs(extra) {
+  const p = new URLSearchParams({hours: $("f-range").value});
+  for (const [k, v] of Object.entries(extra || {})) if (v) p.set(k, v);
+  return p.toString();
+}
+
+// ── Charts (creados una vez, actualizados en cada carga) ──────────────────────
+Chart.defaults.color = "#9ca3af";
+Chart.defaults.borderColor = "#1f2937";
+const palette = ["#34d399", "#f87171", "#60a5fa", "#fbbf24"];
+
+function mkChart(canvasId, type) {
+  return new Chart($(canvasId), {
+    type: type || "line",
+    data: {labels: [], datasets: []},
+    options: {
+      responsive: true, maintainAspectRatio: true,
+      interaction: {mode: "index", intersect: false},
+      plugins: {legend: {labels: {boxWidth: 12, font: {size: 11}}}},
+      scales: {x: {grid: {display: false}}, y: {beginAtZero: true}},
+    },
+  });
+}
+const vozChart = mkChart("voz-chart", "bar");
+const llmChart = mkChart("llm-chart", "line");
+
+function applySeries(chart, payload, colorOffset) {
+  chart.data.labels = (payload.labels || []).map(fmtLabel);
+  chart.data.datasets = (payload.series || []).map((s, i) => ({
+    label: s.name,
+    data: s.data,
+    backgroundColor: palette[(i + (colorOffset || 0)) % palette.length],
+    borderColor: palette[(i + (colorOffset || 0)) % palette.length],
+    tension: 0.3, borderWidth: 2, pointRadius: 2,
+  }));
+  chart.update();
+}
+
+// ── Voz ───────────────────────────────────────────────────────────────────────
+async function loadVoz() {
+  const extra = {node_id: $("f-node").value};
+  const [sum, series, retr] = await Promise.all([
+    getJSON("/api/metrics/voice/summary?" + qs(extra)),
+    getJSON("/api/metrics/voice/series?" + qs({...extra, bucket: bucketFor()})),
+    getJSON("/api/metrics/voice/retrains?limit=10"),
+  ]);
+  $("voz-cards").innerHTML =
+    card("Eventos", fmtNum(sum.total)) +
+    card("Comandos (TP)", fmtNum(sum.tp)) +
+    card("Falsos pos. (FP)", fmtNum(sum.fp), "rate " + fmtPct(sum.fp_rate)) +
+    card("Conocidos", fmtNum(sum.known), "guest " + fmtNum(sum.guest)) +
+    card("Lat. total", sum.avg_total_ms != null ? sum.avg_total_ms + " ms" : "—",
+         "stt " + fmtNum(sum.avg_stt_ms) + " / tts " + fmtNum(sum.avg_tts_ms)) +
+    card("Voice-id conf", sum.avg_conf != null ? sum.avg_conf : "—");
+  // sólo tp/fp en el gráfico (total/fp_rate fuera para no saturar)
+  applySeries(vozChart, {labels: series.labels,
+                         series: (series.series || []).filter(s => ["tp", "fp"].includes(s.name))});
+  $("voz-retrains").innerHTML = (retr.retrains || []).map(r => `<tr class="border-t border-gray-800">
+    <td class="py-1">${r.ts ? new Date(r.ts*1000).toLocaleString("es") : "—"}</td>
+    <td class="text-right">${fmtNum(r.n_positive)}</td><td class="text-right">${fmtNum(r.n_negative)}</td>
+    <td class="text-right">${r.val_accuracy != null ? r.val_accuracy : "—"}</td>
+    <td class="text-right">${r.fp_rate != null ? r.fp_rate : "—"}</td>
+    <td class="text-right">${r.duration_s != null ? r.duration_s + "s" : "—"}</td>
+    <td class="text-right">${r.status || "—"}</td></tr>`).join("") ||
+    `<tr><td colspan="7" class="py-2 text-gray-600">sin reentrenamientos</td></tr>`;
+}
+
+// ── LLM ─────────────────────────────────────────────────────────────────────
+async function loadLLM() {
+  const extra = {agent_id: $("f-agent").value};
+  const [sum, series, models, agents] = await Promise.all([
+    getJSON("/api/metrics/llm/summary?" + qs(extra)),
+    getJSON("/api/metrics/llm/series?" + qs({bucket: bucketFor()})),
+    getJSON("/api/metrics/llm/by-model?" + qs()),
+    getJSON("/api/metrics/llm/by-agent?" + qs(extra)),
+  ]);
+  const rq = sum.requests || {}, lc = sum.llm_calls || {};
+  $("llm-cards").innerHTML =
+    card("Requests", fmtNum(rq.requests)) +
+    card("Lat. total", rq.avg_total_latency_ms != null ? rq.avg_total_latency_ms + " ms" : "—") +
+    card("Lat. coord", rq.avg_coordinator_ms != null ? rq.avg_coordinator_ms + " ms" : "—") +
+    card("Fast-path", fmtPct(rq.fast_classifier_rate), "unknown " + fmtPct(rq.unknown_rate)) +
+    card("LLM calls", fmtNum(lc.calls), "lat " + fmtNum(lc.avg_latency_ms) + " ms") +
+    card("Tokens", fmtNum((lc.prompt_tokens||0)+(lc.completion_tokens||0)),
+         "p " + fmtNum(lc.prompt_tokens) + " / c " + fmtNum(lc.completion_tokens));
+  applySeries(llmChart, series, 2);
+  $("llm-models").innerHTML = (models.models || []).map(m => `<tr class="border-t border-gray-800">
+    <td class="py-1">${m.model || "—"}</td><td class="text-right">${fmtNum(m.calls)}</td>
+    <td class="text-right">${fmtNum(m.avg_latency_ms)}</td>
+    <td class="text-right">${fmtNum(m.prompt_tokens)}/${fmtNum(m.completion_tokens)}</td></tr>`).join("") ||
+    `<tr><td colspan="4" class="py-2 text-gray-600">sin datos</td></tr>`;
+  $("llm-agents").innerHTML = (agents.agents || []).map(a => `<tr class="border-t border-gray-800">
+    <td class="py-1">${a.agent_id || "—"}</td><td class="text-right">${fmtNum(a.steps)}</td>
+    <td class="text-right">${fmtPct(a.success_rate)}</td><td class="text-right">${fmtNum(a.avg_latency_ms)}</td>
+    <td class="text-right">${fmtNum(a.tool_calls)}</td></tr>`).join("") ||
+    `<tr><td colspan="5" class="py-2 text-gray-600">sin datos</td></tr>`;
+}
+
+// bucket adaptativo: ~30-40 puntos según el rango
+function bucketFor() {
+  const hours = parseInt($("f-range").value, 10);
+  if (hours <= 6) return 600;        // 10 min
+  if (hours <= 24) return 3600;      // 1 h
+  if (hours <= 168) return 21600;    // 6 h
+  return 86400;                      // 1 d
+}
+
+let activeTab = "voz";
+async function reload() {
+  try { activeTab === "voz" ? await loadVoz() : await loadLLM(); }
+  catch (e) { console.error(e); }
+}
+
+// Tabs
+document.querySelectorAll(".tab-btn").forEach(btn => btn.addEventListener("click", () => {
+  activeTab = btn.dataset.tab;
+  document.querySelectorAll(".tab-btn").forEach(b => {
+    const on = b.dataset.tab === activeTab;
+    b.classList.toggle("border-emerald-500", on); b.classList.toggle("text-white", on);
+    b.classList.toggle("border-transparent", !on); b.classList.toggle("text-gray-400", !on);
+  });
+  document.querySelectorAll("[data-panel]").forEach(p =>
+    p.classList.toggle("hidden", p.dataset.panel !== activeTab));
+  reload();
+}));
+
+// Filtros
+["f-range", "f-node", "f-agent"].forEach(id => $(id).addEventListener("change", reload));
+$("f-refresh").addEventListener("click", reload);
+
+let timer = null;
+$("f-auto").addEventListener("change", (e) => {
+  if (timer) { clearInterval(timer); timer = null; }
+  if (e.target.checked) timer = setInterval(reload, 30000);
+});
+
+reload();
+</script>
+{% endblock %}

--- a/cloud/app/firestore_db.py
+++ b/cloud/app/firestore_db.py
@@ -47,6 +47,21 @@ def get_state() -> dict | None:
     return snap.to_dict() if snap.exists else None
 
 
+# ── Métricas (FASE 35.5) ────────────────────────────────────────────────────────
+
+def store_metrics(snapshot: dict) -> None:
+    received = _now()
+    doc = {**snapshot, "received_at": received}
+    db().collection("metrics").document("current").set(doc)
+    hist = {**doc, "expires_at": received + timedelta(hours=HISTORY_TTL_HOURS)}
+    db().collection("metrics_history").document(received.strftime("%Y%m%dT%H%M%S%f")).set(hist)
+
+
+def get_metrics() -> dict | None:
+    snap = db().collection("metrics").document("current").get()
+    return snap.to_dict() if snap.exists else None
+
+
 # ── Roster de autorización (email→rol), materializado desde el snapshot ─────────
 
 def store_roster(users_summary: list[dict]) -> None:

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -27,7 +27,14 @@ from .auth import (
     require_dashboard_user,
 )
 from .commands import CommandError, catalog_summary, validate_command
-from .models import SCHEMA_VERSION, CommandRequest, CommandResult, StateSnapshot
+from .models import (
+    METRICS_SCHEMA_VERSION,
+    SCHEMA_VERSION,
+    CommandRequest,
+    CommandResult,
+    MetricsSnapshot,
+    StateSnapshot,
+)
 
 HERE = os.path.dirname(__file__)
 MAX_BODY = int(os.environ.get("MAX_BODY_BYTES", str(512 * 1024)))  # 512 KB
@@ -69,6 +76,17 @@ def ingest_state(snapshot: StateSnapshot, sa: str = Depends(require_bridge)):
     return {"ok": True}
 
 
+@app.post("/ingest/metrics")
+def ingest_metrics(snapshot: MetricsSnapshot, sa: str = Depends(require_bridge)):
+    """Recibe agregados de métricas del bridge (FASE 35.5). Egress-only: el SER9
+    empuja, la nube almacena."""
+    ratelimit.limit_ingest(sa)
+    if snapshot.schema_version != METRICS_SCHEMA_VERSION:
+        raise HTTPException(status_code=422, detail="schema_version no soportada")
+    fdb.store_metrics(snapshot.model_dump())
+    return {"ok": True}
+
+
 @app.get("/commands/pending")
 def commands_pending(sa: str = Depends(require_bridge)):
     ratelimit.limit_ingest(sa)
@@ -105,6 +123,15 @@ def api_state(p: Principal = Depends(require_dashboard_user)):
     if state is None:
         return JSONResponse({"state": None}, status_code=200)
     return {"state": rbac.filter_state(state, p.caps)}
+
+
+@app.get("/api/metrics")
+def api_metrics(p: Principal = Depends(require_dashboard_user)):
+    """Métricas para el dashboard cloud (FASE 35.6), filtradas por RBAC."""
+    metrics = fdb.get_metrics()
+    if metrics is None:
+        return JSONResponse({"metrics": None}, status_code=200)
+    return {"metrics": rbac.filter_metrics(metrics, p.caps)}
 
 
 @app.get("/api/commands")

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 SCHEMA_VERSION = 1
+METRICS_SCHEMA_VERSION = 1
 
 
 class ServiceHealth(BaseModel):
@@ -73,6 +74,23 @@ class StateSnapshot(BaseModel):
     recent_commands: list[RecentCommand] = Field(default_factory=list)
     wakeword: Wakeword = Field(default_factory=Wakeword)
     users_summary: list[UserSummary] = Field(default_factory=list)
+
+
+class MetricsSnapshot(BaseModel):
+    """Agregados de métricas que el bridge envía a POST /ingest/metrics (FASE 35.5).
+
+    Los agregados se calculan en el SER9 (core, FASE 35.2/35.3); la nube sólo almacena
+    y muestra. Campos flexibles (dict/list) con el shape que devuelve la API del core."""
+    schema_version: int = METRICS_SCHEMA_VERSION
+    ts: str
+    window_hours: int = 24
+    voice_summary: dict[str, Any] = Field(default_factory=dict)
+    voice_series: dict[str, Any] = Field(default_factory=dict)
+    retrains: list[dict[str, Any]] = Field(default_factory=list)
+    llm_summary: dict[str, Any] = Field(default_factory=dict)
+    llm_by_model: list[dict[str, Any]] = Field(default_factory=list)
+    llm_by_agent: list[dict[str, Any]] = Field(default_factory=list)
+    llm_series: dict[str, Any] = Field(default_factory=dict)
 
 
 class CommandRequest(BaseModel):

--- a/cloud/app/rbac.py
+++ b/cloud/app/rbac.py
@@ -30,3 +30,14 @@ def filter_state(state: dict, caps: dict[str, bool]) -> dict:
     redacted = dict(state)
     redacted["users_summary"] = []  # adolescente no ve la lista de usuarios
     return redacted
+
+
+def filter_metrics(metrics: dict, caps: dict[str, bool]) -> dict:
+    """RBAC sobre las métricas (35.6): los roles sin view_full ven sólo los resúmenes
+    y las series agregadas, no el detalle operativo (por modelo/agente, reentrenamientos)."""
+    if caps.get("view_full"):
+        return metrics
+    basic = dict(metrics)
+    for k in ("llm_by_model", "llm_by_agent", "retrains"):
+        basic[k] = []
+    return basic

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -45,6 +45,23 @@
       <table id="recent"><tbody></tbody></table>
     </section>
 
+    <section class="card" id="metrics-card">
+      <h2>Métricas <span class="muted" id="metrics-window"></span></h2>
+      <div id="metrics-empty" class="muted hidden">sin métricas todavía</div>
+      <div id="metrics-body" class="hidden">
+        <h3>Voz</h3>
+        <div id="m-voice-summary" class="grid"></div>
+        <canvas id="m-voice-chart" height="80"></canvas>
+        <h3>LLM / Agentes</h3>
+        <div id="m-llm-summary" class="grid"></div>
+        <canvas id="m-llm-chart" height="80"></canvas>
+        <div id="m-tables">
+          <table id="m-models"><thead><tr><th>modelo</th><th>llamadas</th><th>lat ms</th><th>tokens</th></tr></thead><tbody></tbody></table>
+          <table id="m-agents"><thead><tr><th>agente</th><th>steps</th><th>aciertos</th><th>lat ms</th></tr></thead><tbody></tbody></table>
+        </div>
+      </div>
+    </section>
+
     <section class="card hidden" id="actions-card">
       <h2>Acciones admin</h2>
       <form id="emit">
@@ -64,6 +81,7 @@
 
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <script>
 const CFG = {
   apiKey: "{{ firebase_api_key }}",
@@ -112,6 +130,7 @@ async function refresh() {
     $("recent").querySelector("tbody").innerHTML = (state.recent_commands || [])
       .map(c => `<tr><td>${dot(c.ok)}</td><td>${c.text}</td><td class="muted">${c.agent}</td><td class="muted">${c.latency_ms ?? "—"}ms</td></tr>`).join("");
   } catch (e) { $("updated").textContent = "error: " + e.message; }
+  loadMetrics();
   if (!CAPS.view_full) return;  // adolescente: sin auditoría
   try {
     const { commands } = await api("/api/commands");
@@ -128,6 +147,65 @@ async function refresh() {
           + `<td class="muted">${res}</td></tr>`;
       }).join("");
   } catch (e) {}
+}
+
+// ── Métricas (FASE 35.6) ──────────────────────────────────────────────────────
+let mVoiceChart = null, mLlmChart = null;
+const mLabel = (ts) => new Date(ts * 1000).toLocaleString("es", {day:"2-digit",month:"2-digit",hour:"2-digit",minute:"2-digit"});
+
+function mkMetricChart(canvasId, type) {
+  return new Chart($(canvasId), {
+    type, data: {labels: [], datasets: []},
+    options: {responsive: true, plugins: {legend: {labels: {boxWidth: 12}}}, scales: {y: {beginAtZero: true}}},
+  });
+}
+
+function setSeries(chart, payload, colors) {
+  chart.data.labels = (payload.labels || []).map(mLabel);
+  chart.data.datasets = (payload.series || []).map((s, i) => ({
+    label: s.name, data: s.data, backgroundColor: colors[i % colors.length],
+    borderColor: colors[i % colors.length], tension: 0.3, borderWidth: 2, pointRadius: 2,
+  }));
+  chart.update();
+}
+
+const mFmt = (v) => v == null ? "—" : v.toLocaleString("es");
+const mPct = (v) => v == null ? "—" : (v * 100).toFixed(1) + "%";
+
+async function loadMetrics() {
+  let metrics;
+  try { ({ metrics } = await api("/api/metrics")); } catch (e) { return; }
+  if (!metrics) { show("metrics-empty"); hide("metrics-body"); return; }
+  hide("metrics-empty"); show("metrics-body");
+  $("metrics-window").textContent = "· últimas " + (metrics.window_hours || 24) + "h";
+
+  const vs = metrics.voice_summary || {};
+  $("m-voice-summary").innerHTML =
+    `<div><b>${mFmt(vs.total)}</b> eventos</div><div><b>${mFmt(vs.tp)}</b> TP</div>` +
+    `<div><b>${mFmt(vs.fp)}</b> FP <span class="muted">${mPct(vs.fp_rate)}</span></div>` +
+    `<div><b>${vs.avg_total_ms ?? "—"}</b> ms lat</div>`;
+  if (!mVoiceChart) mVoiceChart = mkMetricChart("m-voice-chart", "bar");
+  setSeries(mVoiceChart, {labels: (metrics.voice_series||{}).labels,
+    series: ((metrics.voice_series||{}).series || []).filter(s => ["tp","fp"].includes(s.name))},
+    ["#34d399", "#f87171"]);
+
+  const ls = metrics.llm_summary || {}, rq = ls.requests || {}, lc = ls.llm_calls || {};
+  $("m-llm-summary").innerHTML =
+    `<div><b>${mFmt(rq.requests)}</b> requests</div><div><b>${rq.avg_total_latency_ms ?? "—"}</b> ms lat</div>` +
+    `<div><b>${mPct(rq.fast_classifier_rate)}</b> fast-path</div>` +
+    `<div><b>${mFmt((lc.prompt_tokens||0)+(lc.completion_tokens||0))}</b> tokens</div>`;
+  if (!mLlmChart) mLlmChart = mkMetricChart("m-llm-chart", "line");
+  setSeries(mLlmChart, metrics.llm_series || {}, ["#60a5fa", "#fbbf24"]);
+
+  // Tablas de detalle (sólo presentes para roles con view_full)
+  const models = metrics.llm_by_model || [], agents = metrics.llm_by_agent || [];
+  $("m-tables").style.display = (models.length || agents.length) ? "" : "none";
+  $("m-models").querySelector("tbody").innerHTML = models.map(m =>
+    `<tr><td>${m.model || "—"}</td><td>${mFmt(m.calls)}</td><td>${mFmt(m.avg_latency_ms)}</td>` +
+    `<td class="muted">${mFmt(m.prompt_tokens)}/${mFmt(m.completion_tokens)}</td></tr>`).join("");
+  $("m-agents").querySelector("tbody").innerHTML = agents.map(a =>
+    `<tr><td>${a.agent_id || "—"}</td><td>${mFmt(a.steps)}</td><td>${mPct(a.success_rate)}</td>` +
+    `<td>${mFmt(a.avg_latency_ms)}</td></tr>`).join("");
 }
 
 async function loadCatalog() {

--- a/cloud/bridge/cloud_bridge.py
+++ b/cloud/bridge/cloud_bridge.py
@@ -24,11 +24,13 @@ from google.auth.transport.requests import AuthorizedSession  # noqa: E402
 from google.oauth2 import service_account  # noqa: E402
 
 import executor  # noqa: E402
+import metrics_snapshot  # noqa: E402
 import snapshot  # noqa: E402
 
 CLOUD_URL = os.environ["CLOUD_URL"].rstrip("/")
 SA_KEY = os.environ["BRIDGE_SA_KEY"]
 PUSH_INTERVAL = int(os.environ.get("PUSH_INTERVAL", "30"))
+METRICS_PUSH_INTERVAL = int(os.environ.get("METRICS_PUSH_INTERVAL", "300"))
 POLL_INTERVAL = int(os.environ.get("POLL_INTERVAL", "10"))
 MAX_BACKOFF = int(os.environ.get("MAX_BACKOFF", "300"))
 
@@ -51,6 +53,13 @@ def push_state(sess: AuthorizedSession) -> None:
     r.raise_for_status()
     log.info("push estado OK (%d servicios, %d agentes)",
              len(snap["services"]), len(snap["agents"]))
+
+
+def push_metrics(sess: AuthorizedSession) -> None:
+    snap = metrics_snapshot.build_metrics_snapshot()
+    r = sess.post(f"{CLOUD_URL}/ingest/metrics", json=snap, timeout=20)
+    r.raise_for_status()
+    log.info("push métricas OK (ventana %dh)", snap.get("window_hours"))
 
 
 def poll_and_execute(sess: AuthorizedSession) -> None:
@@ -79,6 +88,7 @@ def main() -> None:
              CLOUD_URL, PUSH_INTERVAL, POLL_INTERVAL)
     sess = _session()
     last_push = 0.0
+    last_metrics_push = 0.0
     backoff = POLL_INTERVAL
     while True:
         try:
@@ -86,6 +96,9 @@ def main() -> None:
             if now - last_push >= PUSH_INTERVAL:
                 push_state(sess)
                 last_push = now
+            if now - last_metrics_push >= METRICS_PUSH_INTERVAL:
+                push_metrics(sess)
+                last_metrics_push = now
             poll_and_execute(sess)
             backoff = POLL_INTERVAL  # reset tras un ciclo OK
         except Exception as exc:  # noqa: BLE001 — la nube puede estar caída

--- a/cloud/bridge/metrics_snapshot.py
+++ b/cloud/bridge/metrics_snapshot.py
@@ -1,0 +1,49 @@
+"""Construcción del snapshot de métricas (SER9 → nube). FASE 35.5.
+
+Lee los agregados ya calculados por el core (API de métricas de FASE 35.3) y los empaqueta
+para el push al backoffice cloud. Best-effort y resiliente: cada fuente va envuelta en
+try/except y nunca propaga — un snapshot parcial es mejor que ninguno. El cálculo pesado
+vive en el SER9; la nube sólo almacena y muestra.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import requests
+
+CORE_URL = os.environ.get("CORE_URL", "http://localhost:8765")
+WINDOW_HOURS = int(os.environ.get("METRICS_WINDOW_HOURS", "24"))
+SERIES_BUCKET = int(os.environ.get("METRICS_SERIES_BUCKET", "3600"))
+
+
+def _get(url: str, timeout: int = 6):
+    try:
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_metrics_snapshot(hours: int = WINDOW_HOURS) -> dict:
+    """Arma el snapshot de métricas. Nunca lanza: campos faltantes quedan vacíos."""
+    base = f"{CORE_URL}/metrics"
+    q = f"hours={hours}"
+    qs = f"{q}&bucket={SERIES_BUCKET}"
+    return {
+        "schema_version": 1,
+        "ts": _now_iso(),
+        "window_hours": hours,
+        "voice_summary": _get(f"{base}/voice/summary?{q}") or {},
+        "voice_series":  _get(f"{base}/voice/series?{qs}") or {},
+        "retrains":      (_get(f"{base}/voice/retrains?limit=10") or {}).get("retrains", []),
+        "llm_summary":   _get(f"{base}/llm/summary?{q}") or {},
+        "llm_by_model":  (_get(f"{base}/llm/by-model?{q}") or {}).get("models", []),
+        "llm_by_agent":  (_get(f"{base}/llm/by-agent?{q}") or {}).get("agents", []),
+        "llm_series":    _get(f"{base}/llm/series?{qs}") or {},
+    }

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -82,3 +82,35 @@ def test_snapshot_maps_agents_and_nodes():
     assert snap["recent_commands"][0]["text"] == "prende la luz"
     assert snap["latency"]["llm_ms"] == 3379
     assert snap["users_summary"][0]["intents_pending"] == 1
+
+
+# ── metrics_snapshot (FASE 35.5) ────────────────────────────────────────────────
+
+import metrics_snapshot  # noqa: E402
+
+
+def test_metrics_snapshot_resilient_when_core_down():
+    # Core caído: estructura válida, campos vacíos, nunca lanza.
+    with patch.object(metrics_snapshot, "_get", lambda *a, **k: None):
+        snap = metrics_snapshot.build_metrics_snapshot()
+    assert snap["schema_version"] == 1
+    assert snap["window_hours"] == 24
+    assert snap["voice_summary"] == {} and snap["llm_summary"] == {}
+    assert snap["retrains"] == [] and snap["llm_by_model"] == [] and snap["llm_by_agent"] == []
+
+
+def test_metrics_snapshot_unwraps_list_envelopes():
+    # by-model/by-agent/retrains vienen envueltos por la API; el snapshot los desenvuelve.
+    def fake_get(url, **k):
+        if "by-model" in url: return {"models": [{"model": "qwen2.5:7b", "calls": 3}]}
+        if "by-agent" in url: return {"agents": [{"agent_id": "haos", "steps": 2}]}
+        if "retrains" in url: return {"retrains": [{"version": "v1"}]}
+        if "summary" in url:  return {"total": 5}
+        return {"labels": [1, 2], "series": []}
+    with patch.object(metrics_snapshot, "_get", fake_get):
+        snap = metrics_snapshot.build_metrics_snapshot(hours=6)
+    assert snap["window_hours"] == 6
+    assert snap["llm_by_model"][0]["model"] == "qwen2.5:7b"
+    assert snap["llm_by_agent"][0]["agent_id"] == "haos"
+    assert snap["retrains"][0]["version"] == "v1"
+    assert snap["voice_series"]["labels"] == [1, 2]

--- a/cloud/tests/test_metrics_contract.py
+++ b/cloud/tests/test_metrics_contract.py
@@ -1,0 +1,41 @@
+"""Tests del contrato de métricas (FASE 35.5) y su RBAC (35.6)."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import rbac
+from app.models import METRICS_SCHEMA_VERSION, MetricsSnapshot
+
+
+def test_minimal_metrics_snapshot_validates():
+    snap = MetricsSnapshot(ts="2026-06-18T00:00:00Z")
+    d = snap.model_dump()
+    assert d["schema_version"] == METRICS_SCHEMA_VERSION
+    assert d["window_hours"] == 24
+    assert d["voice_summary"] == {} and d["llm_by_model"] == []
+
+
+def test_ts_required():
+    with pytest.raises(Exception):
+        MetricsSnapshot()
+
+
+def test_filter_metrics_full_keeps_detail():
+    m = {"voice_summary": {"total": 1}, "llm_by_model": [{"model": "x"}],
+         "llm_by_agent": [{"agent_id": "haos"}], "retrains": [{"version": "v1"}]}
+    out = rbac.filter_metrics(m, rbac.caps_for("admin"))
+    assert out["llm_by_model"] and out["llm_by_agent"] and out["retrains"]
+
+
+def test_filter_metrics_basic_strips_detail():
+    m = {"voice_summary": {"total": 1}, "voice_series": {"labels": [1]},
+         "llm_summary": {"requests": {"requests": 2}},
+         "llm_by_model": [{"model": "x"}], "llm_by_agent": [{"agent_id": "haos"}],
+         "retrains": [{"version": "v1"}]}
+    out = rbac.filter_metrics(m, rbac.caps_for("adolescente"))
+    assert out["llm_by_model"] == [] and out["llm_by_agent"] == [] and out["retrains"] == []
+    # los resúmenes y series sí se conservan
+    assert out["voice_summary"] == {"total": 1} and out["voice_series"] == {"labels": [1]}
+    assert out["llm_summary"] == {"requests": {"requests": 2}}

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -662,8 +662,19 @@ daemon que persiste el trace.
 
 Rango temporal por `since`/`until`/`hours`; filtros por `model`/`agent_id`/`node_id`. Las
 series devuelven shape graficable `{labels, series:[{name, data}]}`. Retención configurable
-con `METRICS_RETENTION_DAYS` (default 90, poda oportunista que cubre las 5 tablas). Pendiente:
-dashboards en backoffice (35.4) y cloud (35.6, vía bridge egress-only 35.5).
+con `METRICS_RETENTION_DAYS` (default 90, poda oportunista que cubre las 5 tablas).
+
+**Dashboards (FASE 35.4/35.6).** El backoffice local sirve `/metrics` (Chart.js, tabs
+Voz/LLM, filtros de rango/nodo/agente, auto-refresh); un proxy `/api/metrics/{path}` reenvía
+a la API del core (mismo origen, autenticado). El backoffice cloud muestra una sección de
+métricas equivalente en su dashboard, leyendo `GET /api/metrics` con RBAC (`filter_metrics`:
+sin `view_full` → sólo resúmenes y series, sin detalle por modelo/agente ni reentrenamientos).
+
+**Push al cloud (FASE 35.5, egress-only).** El bridge del SER9 (FASE 33) arma agregados con
+`metrics_snapshot.build_metrics_snapshot` (desde la API del core) y los empuja a
+`POST /ingest/metrics` cada `METRICS_PUSH_INTERVAL` (300s), con la misma auth OIDC de la SA
+y rate limiting que el resto del bridge. La nube los guarda en Firestore (`metrics/current`
++ `metrics_history` con TTL). Cero inbound a la casa.
 
 ---
 

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3107,8 +3107,9 @@ Objetivo: Centralizar TODAS las métricas relevantes del análisis de voz (wake 
           (latencias, tokens, tool calls, coordinador, aciertos/errores), exponerlas en
           un dashboard amigable e interactivo en el backoffice local, y pushearlas al
           backoffice cloud (vía el bridge egress-only de FASE 33) con su propio dashboard.
-Estado:   EN CURSO (3/8 — Etapa A completa: 35.1 voz/retrain + 35.2 LLM + 35.3 API GET).
-          Falta Etapa B (dashboards 35.4/35.6 + push cloud 35.5) y Etapa C (tests/docs 35.7/35.8).
+Estado:   EN CURSO (6/8 — Etapas A+B completas: 35.1-35.3 instrumentación+API,
+          35.4 dashboard backoffice, 35.5 push cloud, 35.6 dashboard cloud).
+          Falta Etapa C (tests adicionales 35.7 + docs 35.8).
 Deps:     FASE 24 (tracing de interacciones — fuente de métricas LLM), FASE 16 (métricas
           de nodos/voz: _bump_metric, estado del retrain), FASE 33 (bridge egress-only +
           cloud backoffice + RBAC), FASE 12 (backoffice local).
@@ -3146,13 +3147,23 @@ Deps:     FASE 24 (tracing de interacciones — fuente de métricas LLM), FASE 1
             test_metrics_api (9). Quedan listos para los dashboards 35.4 (backoffice) y 35.6 (cloud).
 
 #### Etapa B - Dashboards
-- [ ] 35.4  Dashboard de métricas en el backoffice local: páginas amigables e interactivas
+- [x] 35.4  Dashboard de métricas en el backoffice local: páginas amigables e interactivas
             (gráficos de línea/barras, filtros por rango/nodo/agente, auto-refresh).
             Secciones separadas: Voz/Wake/Voice-id/Retrain y LLM/Agentes/Latencias.
-- [ ] 35.5  Push de métricas al cloud: extender el bridge (FASE 33, egress-only) para enviar
+            Hecho: página `/metrics` (Chart.js) con tabs Voz/LLM, filtros (rango/nodo/agente),
+            auto-refresh y tarjetas+gráficos+tablas. Proxy `/api/metrics/{path}` en el
+            backoffice reenvía a la API del core (mismo origen, autenticado). Nav "Métricas".
+- [x] 35.5  Push de métricas al cloud: extender el bridge (FASE 33, egress-only) para enviar
             agregados de métricas al backoffice cloud; contrato + rate limiting + auth.
-- [ ] 35.6  Dashboard de métricas en el cloud backoffice: mismas vistas amigables e
+            Hecho: `cloud/bridge/metrics_snapshot.py` arma los agregados desde la API del core
+            (resiliente); `cloud_bridge.push_metrics` los empuja a `POST /ingest/metrics` cada
+            METRICS_PUSH_INTERVAL (300s). Cloud: modelo `MetricsSnapshot`, `store_metrics`/
+            `get_metrics` en Firestore (TTL), endpoint con auth de bridge (OIDC) + rate limit.
+- [x] 35.6  Dashboard de métricas en el cloud backoffice: mismas vistas amigables e
             interactivas, con el RBAC de FASE 33 (admin ve todo; roles limitados, vista básica).
+            Hecho: sección Métricas en `cloud/app/templates/dashboard.html` (Chart.js),
+            `GET /api/metrics` con `rbac.filter_metrics` (sin view_full → sólo resúmenes y
+            series, sin detalle por modelo/agente ni reentrenamientos).
 
 #### Etapa C - Tests y documentación
 - [ ] 35.7  Tests: agregadores de métricas (voz y LLM) con datos sintéticos; endpoints de


### PR DESCRIPTION
## FASE 35 Etapa B — Dashboards de métricas

Consume la API de métricas de Etapa A (35.3) y la expone en los dos backoffices.

### 35.4 — Dashboard backoffice local
- Página `/metrics` con **Chart.js**: tabs Voz / LLM-Agentes, filtros (rango, nodo, agente), auto-refresh, tarjetas + gráficos de línea/barra + tablas (por modelo, por agente, reentrenamientos).
- Proxy de solo-lectura `/api/metrics/{path}` → reenvía a la API del core (mismo origen, autenticado). Nav "Métricas".

### 35.5 — Push de métricas al cloud (egress-only)
- `cloud/bridge/metrics_snapshot.py`: arma los agregados desde la API del core (resiliente — core caído ⇒ snapshot vacío, nunca lanza).
- `cloud_bridge.push_metrics` → `POST /ingest/metrics` cada `METRICS_PUSH_INTERVAL` (300s), con la **misma auth OIDC de la SA + rate limiting** del bridge. Cero inbound.
- Cloud: modelo `MetricsSnapshot` (contrato versionado), `store_metrics`/`get_metrics` en Firestore (`metrics/current` + `metrics_history` con TTL).

### 35.6 — Dashboard cloud
- Sección Métricas en `dashboard.html` (Chart.js), `GET /api/metrics` con **RBAC** (`filter_metrics`): sin `view_full` ⇒ sólo resúmenes y series, sin detalle por modelo/agente ni reentrenamientos.

### Tests
`cloud/tests/test_metrics_contract.py` (modelo + RBAC, 4), bridge `metrics_snapshot` resiliente (2). Cloud unit: 13 passed; bridge: 7 passed. Templates Jinja validados; rutas backoffice verificadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)