### PR TITLE
test+docs: fase 35 Etapa C — tests cloud + docs (FASE 35 COMPLETA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,21 @@ Los paneles leen métricas de `/tmp/capitan/*.json` escritos por `listen.py`.
 Si la feature genera datos nuevos, agregar la escritura a `listen.py` y
 actualizar el panel correspondiente (o crear uno nuevo si no aplica a ninguno).
 
+### Métricas persistidas y dashboards web (FASE 35)
+
+Además del dashboard zellij (vista live efímera), hay observabilidad **persistida**:
+- `core/metrics_store.py` — SQLite con métricas de voz (`voice_metrics`, `retrain_events`)
+  y de LLM/agentes (`llm_calls`, `agent_steps`, `request_metrics`). Las de LLM se derivan
+  de `trace_store` al cerrar cada request; las de voz las empuja el `audio_server` a
+  `POST /metrics/voice/event`. API de consulta: `GET /metrics/{voice,llm}/*`.
+- Dashboard web de métricas: `/metrics` en el **backoffice local** (`backoffice/templates/metrics.html`,
+  Chart.js) y la sección equivalente en el **backoffice cloud** (`cloud/app/templates/dashboard.html`),
+  alimentada por el push egress-only del bridge (`POST /ingest/metrics`).
+
+Política: si una feature introduce una **métrica nueva** (latencia, tasa, contador, evento),
+evaluar persistirla en `metrics_store` (no sólo en `/tmp/capitan/*.json`) y reflejarla en el
+dashboard web `/metrics`, además del panel zellij que corresponda.
+
 ---
 
 ## Flujo de trabajo por tarea

--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ Every agent inherits `ProactiveMixin`, enabling autonomous intent detection by s
 
 ---
 
+## Observability (Phase 35)
+
+Voice and LLM metrics are centralized in SQLite by `core/metrics_store.py`, separate from
+the per-request traces:
+
+- **Voice** — every wake-word event (TP/FP with reason, voice-id, latencies) is pushed by the
+  audio server to `POST /metrics/voice/event`; retrains are recorded from `/wakeword/train`.
+- **LLM** — derived from each `RequestTrace` at close time into `llm_calls` / `agent_steps` /
+  `request_metrics` (latencies by model/agent, tokens, tool calls, coordinator latency,
+  success/fallback rates) without duplicating the trace.
+
+The core exposes a read-only metrics API (`GET /metrics/{voice,llm}/*`: summaries, time
+series as `{labels, series}`, by-model, by-agent, retrains) with range/model/agent/node
+filters. The **local backoffice** renders it at `/metrics` (Chart.js, filters, auto-refresh);
+the **cloud backoffice** shows an equivalent view, fed by the egress-only bridge that pushes
+aggregates to `POST /ingest/metrics` and gated by the FASE 33 RBAC.
+
+---
+
 ## Repositories
 
 | Repo | Purpose |

--- a/cloud/tests/test_metrics_api.py
+++ b/cloud/tests/test_metrics_api.py
@@ -1,0 +1,93 @@
+"""Tests de los endpoints de métricas del backoffice cloud (FASE 35.7).
+
+Levanta la app con TestClient, sobreescribe las dependencias de auth (bridge OIDC y
+usuario de dashboard) y mockea la capa Firestore — no toca GCP ni valida tokens reales.
+"""
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import firestore_db as fdb
+from app import main, rbac
+from app.auth import Principal, require_bridge, require_dashboard_user
+from app.models import METRICS_SCHEMA_VERSION
+
+client = TestClient(main.app)
+
+
+def _principal(role: str) -> Principal:
+    return Principal(email=f"{role}@x.z", role=role, caps=rbac.caps_for(role))
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    main.app.dependency_overrides.clear()
+
+
+SAMPLE = {
+    "schema_version": METRICS_SCHEMA_VERSION, "ts": "2026-06-18T00:00:00Z", "window_hours": 24,
+    "voice_summary": {"total": 5, "tp": 4, "fp": 1, "fp_rate": 0.2},
+    "voice_series": {"labels": [1], "series": []},
+    "retrains": [{"version": "v1"}],
+    "llm_summary": {"requests": {"requests": 3}, "llm_calls": {"calls": 9}},
+    "llm_by_model": [{"model": "qwen2.5:7b", "calls": 9}],
+    "llm_by_agent": [{"agent_id": "haos", "steps": 2}],
+    "llm_series": {"labels": [1], "series": []},
+}
+
+
+# ── /ingest/metrics (bridge → nube) ────────────────────────────────────────────
+
+def test_ingest_metrics_stores(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(fdb, "store_metrics", lambda d: captured.update(d))
+    main.app.dependency_overrides[require_bridge] = lambda: "bridge-sa@x"
+    r = client.post("/ingest/metrics", json=SAMPLE)
+    assert r.status_code == 200 and r.json() == {"ok": True}
+    assert captured["voice_summary"]["total"] == 5
+    assert captured["llm_by_model"][0]["model"] == "qwen2.5:7b"
+
+
+def test_ingest_metrics_bad_schema(monkeypatch):
+    monkeypatch.setattr(fdb, "store_metrics", lambda d: None)
+    main.app.dependency_overrides[require_bridge] = lambda: "bridge-sa@x"
+    bad = {**SAMPLE, "schema_version": 999}
+    r = client.post("/ingest/metrics", json=bad)
+    assert r.status_code == 422
+
+
+def test_ingest_metrics_requires_bridge_auth():
+    # sin override de auth → falta Authorization Bearer → 401
+    r = client.post("/ingest/metrics", json=SAMPLE)
+    assert r.status_code == 401
+
+
+# ── /api/metrics (dashboard → nube, con RBAC) ──────────────────────────────────
+
+def test_api_metrics_admin_sees_detail(monkeypatch):
+    monkeypatch.setattr(fdb, "get_metrics", lambda: dict(SAMPLE))
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("admin")
+    r = client.get("/api/metrics")
+    assert r.status_code == 200
+    m = r.json()["metrics"]
+    assert m["llm_by_model"] and m["llm_by_agent"] and m["retrains"]
+
+
+def test_api_metrics_basic_role_filtered(monkeypatch):
+    monkeypatch.setattr(fdb, "get_metrics", lambda: dict(SAMPLE))
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("adolescente")
+    r = client.get("/api/metrics")
+    assert r.status_code == 200
+    m = r.json()["metrics"]
+    assert m["llm_by_model"] == [] and m["llm_by_agent"] == [] and m["retrains"] == []
+    assert m["voice_summary"]["total"] == 5   # resúmenes sí
+
+def test_api_metrics_none_when_empty(monkeypatch):
+    monkeypatch.setattr(fdb, "get_metrics", lambda: None)
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("admin")
+    r = client.get("/api/metrics")
+    assert r.status_code == 200 and r.json() == {"metrics": None}

--- a/cloud/tests/test_metrics_contract.py
+++ b/cloud/tests/test_metrics_contract.py
@@ -1,10 +1,12 @@
 """Tests del contrato de métricas (FASE 35.5) y su RBAC (35.6)."""
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "bridge"))
 from app import rbac
 from app.models import METRICS_SCHEMA_VERSION, MetricsSnapshot
 
@@ -39,3 +41,31 @@ def test_filter_metrics_basic_strips_detail():
     # los resúmenes y series sí se conservan
     assert out["voice_summary"] == {"total": 1} and out["voice_series"] == {"labels": [1]}
     assert out["llm_summary"] == {"requests": {"requests": 2}}
+
+
+# ── Contrato bridge → nube (35.7): el snapshot del bridge valida como MetricsSnapshot ──
+
+def test_bridge_snapshot_validates_against_cloud_model():
+    import metrics_snapshot
+
+    def fake_get(url, **k):
+        if "by-model" in url: return {"models": [{"model": "qwen2.5:7b", "calls": 3}]}
+        if "by-agent" in url: return {"agents": [{"agent_id": "haos", "steps": 2}]}
+        if "retrains" in url: return {"retrains": [{"version": "v1"}]}
+        if "summary" in url:  return {"total": 5, "tp": 4, "fp": 1}
+        return {"labels": [1, 2], "series": [{"name": "tp", "data": [1, 1]}]}
+
+    with patch.object(metrics_snapshot, "_get", fake_get):
+        snap = metrics_snapshot.build_metrics_snapshot()
+    # No debe lanzar: el shape del bridge es aceptado por el contrato de la nube.
+    model = MetricsSnapshot(**snap)
+    assert model.schema_version == METRICS_SCHEMA_VERSION
+    assert model.llm_by_model[0]["model"] == "qwen2.5:7b"
+    assert model.voice_summary["total"] == 5
+
+
+def test_empty_bridge_snapshot_validates():
+    import metrics_snapshot
+    with patch.object(metrics_snapshot, "_get", lambda *a, **k: None):
+        snap = metrics_snapshot.build_metrics_snapshot()
+    MetricsSnapshot(**snap)  # no lanza

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3107,9 +3107,8 @@ Objetivo: Centralizar TODAS las métricas relevantes del análisis de voz (wake 
           (latencias, tokens, tool calls, coordinador, aciertos/errores), exponerlas en
           un dashboard amigable e interactivo en el backoffice local, y pushearlas al
           backoffice cloud (vía el bridge egress-only de FASE 33) con su propio dashboard.
-Estado:   EN CURSO (6/8 — Etapas A+B completas: 35.1-35.3 instrumentación+API,
-          35.4 dashboard backoffice, 35.5 push cloud, 35.6 dashboard cloud).
-          Falta Etapa C (tests adicionales 35.7 + docs 35.8).
+Estado:   COMPLETA (8/8 — Etapa A instrumentación+API, Etapa B dashboards backoffice+cloud
+          + push egress-only, Etapa C tests+docs).
 Deps:     FASE 24 (tracing de interacciones — fuente de métricas LLM), FASE 16 (métricas
           de nodos/voz: _bump_metric, estado del retrain), FASE 33 (bridge egress-only +
           cloud backoffice + RBAC), FASE 12 (backoffice local).
@@ -3166,10 +3165,17 @@ Deps:     FASE 24 (tracing de interacciones — fuente de métricas LLM), FASE 1
             series, sin detalle por modelo/agente ni reentrenamientos).
 
 #### Etapa C - Tests y documentación
-- [ ] 35.7  Tests: agregadores de métricas (voz y LLM) con datos sintéticos; endpoints de
+- [x] 35.7  Tests: agregadores de métricas (voz y LLM) con datos sintéticos; endpoints de
             métricas; contrato del push al cloud mockeando el bridge.
-- [ ] 35.8  Docs: actualizar `README.md`, `masterplan/arquitectura_funcional.md` (sección de
+            Hecho: core `test_metrics_store` (agregadores voz+LLM, datos sintéticos) y
+            `test_metrics_api` (endpoints GET del core). Cloud `test_metrics_api` (endpoints
+            /ingest/metrics y /api/metrics con TestClient, auth override + Firestore mockeado,
+            RBAC) y `test_metrics_contract` (modelo + RBAC + el snapshot del bridge valida
+            como MetricsSnapshot). Bridge: `metrics_snapshot` resiliente.
+- [x] 35.8  Docs: actualizar `README.md`, `masterplan/arquitectura_funcional.md` (sección de
             observabilidad/métricas) y la política de dashboards de `CLAUDE.md`.
+            Hecho: README sección "Observability"; arquitectura_funcional sección
+            "Observabilidad — métricas"; CLAUDE.md política de métricas persistidas + dashboards web.
 
 ### FASE 36 - Continuidad conversacional unificada (voz + WhatsApp)
 


### PR DESCRIPTION
## FASE 35 Etapa C — Tests y documentación (cierra FASE 35)

### 35.7 — Tests
- **cloud/tests/test_metrics_api.py** (nuevo): `/ingest/metrics` (auth de bridge, schema check, 401 sin auth) y `/api/metrics` (RBAC: admin ve detalle, adolescente filtrado, None si vacío) — TestClient con `dependency_overrides` de auth + Firestore mockeado.
- **cloud/tests/test_metrics_contract.py**: ahora también verifica que el snapshot de `metrics_snapshot.build_metrics_snapshot` valida como `MetricsSnapshot` (contrato bridge→nube).
- Cobertura previa (Etapa A): core `test_metrics_store` (agregadores voz+LLM con datos sintéticos), `test_metrics_api` (endpoints GET del core), bridge `metrics_snapshot` resiliente.
- Cloud: **47 passed**; bridge: **7 passed**.

### 35.8 — Docs
- `README.md`: sección **Observability** (métricas voz/LLM, API, dashboards, push egress-only).
- `CLAUDE.md`: política de métricas **persistidas** (`metrics_store`) + dashboards web `/metrics`, además del panel zellij.
- `arquitectura_funcional.md`: sección Observabilidad (ya actualizada en Etapa B).

Con esto **FASE 35 queda COMPLETA (8/8)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)