### PR TITLE
fix: supervisor del satélite en script aparte (voice-node.sh) — anti-footgun pkill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,14 @@ Pipeline anterior (hasta FASE 21): laptop con mic/speaker local. Ya reemplazado.
   libicu/clang — un `pkg update` sin upgrade deja `clang` roto (`libicuuc.so.78 not found`).
   La instalación se corre DETACHED con `termux-wake-lock` (una sesión SSH directa la mata a
   mitad porque Android suspende el proceso) y se verifica importando cada módulo, no por rc.
-  El boot script sostiene `termux-wake-lock` y reinicia satellite en loop si crashea (audio
-  HAL puede no estar listo justo tras boot). `nspanel.sh reboot` necesita `su -c reboot` (el
-  firmware eWeLink ignora el reboot sin root). Todo esto ya está en `scripts/nspanel.sh`.
+  El boot script lanza `~/voice-node.sh` (supervisor: sostiene `termux-wake-lock` y reinicia
+  satellite en loop si crashea — audio HAL puede no estar listo justo tras boot). El supervisor
+  vive en un script aparte A PROPÓSITO: su cmdline no contiene `satellite.py`, así
+  `pkill -f satellite.py` mata solo el python y el supervisor lo relanza. FOOTGUN: `pkill -f
+  satellite.py` también mata cualquier shell (incl. el comando SSH remoto) cuya cmdline
+  contenga ese string — al reiniciar por SSH, no metas `satellite.py` en el comando lanzador
+  ni uses esa palabra en el one-liner. Para frenar todo: `pkill -f voice-node.sh` y luego el
+  python. Para arrancar el supervisor por SSH (sobrevive al cierre de sesión):
+  `termux-wake-lock; setsid nohup bash ~/voice-node.sh >/dev/null 2>&1 </dev/null & disown`.
+  `nspanel.sh reboot` necesita `su -c reboot` (el firmware eWeLink ignora el reboot sin root).
+  Todo esto ya está en `scripts/nspanel.sh`.

--- a/scripts/nspanel.sh
+++ b/scripts/nspanel.sh
@@ -289,7 +289,25 @@ SAMPLE_RATE=16000
 EOF
     echo "  ✓ satellite.env"
 
-    echo "\n[8/9] Boot script"
+    echo "\n[8/9] Supervisor del nodo de voz + boot script"
+    # Supervisor en un script aparte (no inline en el boot): su cmdline NO contiene
+    # "satellite.py", así `pkill -f satellite.py` mata solo el python y deja vivo el
+    # supervisor → reiniciar el satélite no deja el nodo sin auto-reinicio.
+    ssh_panel "cat > ~/voice-node.sh" <<'EOF'
+#!/data/data/com.termux/files/usr/bin/bash
+# Supervisor del nodo de voz: relanza satellite.py si crashea (audio HAL no listo tras
+# boot, etc.). Para reiniciar el satélite sin perder el supervisor: pkill -f satellite.py
+# (este script no matchea ese patrón). Para frenar todo: pkill -f voice-node.sh primero.
+export PATH=/data/data/com.termux/files/usr/bin:$PATH
+termux-wake-lock 2>/dev/null
+while true; do
+  echo "[boot] arrancando satellite $(date)" >> ~/.satellite.log
+  python3.13 ~/satellite.py >> ~/.satellite.log 2>&1
+  echo "[boot] satellite salió rc=$? — reintento en 5s" >> ~/.satellite.log
+  sleep 5
+done
+EOF
+    ssh_panel "chmod +x ~/voice-node.sh" 2>/dev/null
     ssh_panel "cat > ~/.termux/boot/start-ha.sh" <<'EOF'
 #!/data/data/com.termux/files/usr/bin/bash
 export PATH=/data/data/com.termux/files/usr/bin:$PATH
@@ -299,8 +317,8 @@ sleep 10
 monkey -p com.termux.gui -c android.intent.category.LAUNCHER 1
 am start -n io.homeassistant.companion.android.minimal/io.homeassistant.companion.android.launch.LaunchActivity
 sleep 15
-# auto-reinicio: si satellite crashea (ej. audio HAL no listo aún tras boot), reintenta
-nohup bash -c 'while true; do echo "[boot] arrancando satellite $(date)" >> ~/.satellite.log; python3.13 ~/satellite.py >> ~/.satellite.log 2>&1; echo "[boot] satellite salió rc=$? — reintento en 5s" >> ~/.satellite.log; sleep 5; done' >/dev/null 2>&1 &
+# Nodo de voz bajo supervisor (auto-reinicio). setsid → sobrevive el cierre de la sesión.
+setsid nohup bash ~/voice-node.sh >/dev/null 2>&1 </dev/null &
 EOF
     ssh_panel "chmod +x ~/.termux/boot/start-ha.sh" 2>/dev/null
     adb_cmd shell am start -n "com.termux.boot/.BootActivity" >/dev/null 2>&1


### PR DESCRIPTION
## Problema

El boot script que genera `provision` tenía el supervisor inline:

```bash
nohup bash -c 'while true; do ... python3.13 ~/satellite.py ...; done' &
```

Su cmdline contiene `satellite.py`, así que `pkill -f satellite.py` (para reiniciar el satélite) mataba **también el supervisor** — y cualquier comando SSH remoto cuyo string incluyera `satellite.py`. Resultado: tras un restart, el nodo quedaba sin auto-reinicio y sin satellite corriendo (visto en producción esta sesión: el panel quedó mudo sin logear nada).

## Fix

- Supervisor movido a `~/voice-node.sh` (script aparte). Su cmdline es `bash ~/voice-node.sh` → no matchea `pkill -f satellite.py`.
- El boot script lo lanza con `setsid nohup bash ~/voice-node.sh ... &`.
- `CLAUDE.md`: documentado el footgun y el procedimiento correcto de restart por SSH (`termux-wake-lock; setsid nohup bash ~/voice-node.sh ...`).

Ya aplicado al panel del comedor en vivo (supervisor + satellite corriendo, escuchando).

🤖 Generated with [Claude Code](https://claude.com/claude-code)