### PR TITLE
FASE 34 Tanda 1: motor de deploy (cimiento, dominio SER9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ wa/.wwebjs_cache/
 cloud/**/*.env
 *-sa-key.json
 bridge-sa-key.json
+# FASE 34 — deploy SA key (driver cloudrun; nunca al repo)
+*-key.json
+deployer-key.json

--- a/cloud/bridge/deploy_engine.py
+++ b/cloud/bridge/deploy_engine.py
@@ -1,0 +1,305 @@
+"""
+core del MOTOR DE DEPLOY (FASE 34) — corre en el SER9, es el ÚNICO backend de deploy.
+
+Principio (FASE 34): existe UN solo motor con la lógica de deploy (snapshot → pin de ref →
+install → restart → health-gate → rollback → registro de versión). Lo invocan dos frontends
+sin reimplementar nada: el executor del bridge (remoto, comando `deploy.release` del cloud-bo)
+y `scripts/deploy.sh` (local, cuando se opera desde la LAN). Ver DECISIONES CONSOLIDADAS en
+masterplan/estado.md (D1–D6).
+
+Esta tanda implementa el dominio SER9 (driver `ser9-service`): los servicios que corren en el
+LXC y se versionan por submodule (core, ear/audio_server) o por el umbrella (backoffice, wa,
+bridge). Los drivers `panel` (NSPanels) y `cloudrun` (GCP) se registran como pendientes y se
+implementan en tandas siguientes.
+
+Diseño:
+  - Cada componente desplegable es un TARGET con un driver. El driver expone la misma interfaz:
+    current_version() → str | None, deploy(refs, emit), health() → bool, rollback(snapshot, emit).
+  - `run_release` orquesta: snapshot de versiones actuales → deploy → health-gate → si falla,
+    rollback al snapshot. Emite logs incrementales por un callback (D5: feedback en vivo).
+  - El estado (matriz dispositivo×componente→versión + último release) se persiste local en el
+    SER9 (fuente de verdad) y un subconjunto viaja al snapshot del bridge (D6).
+
+Sin estado global mutable: el motor es invocable por CLI o importable; los efectos (git,
+systemctl, http) están aislados en helpers mockeables para los tests.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+
+REPO_DIR = os.environ.get("REPO_DIR", os.path.expanduser("~/workspace/home-agents"))
+PIP = os.environ.get("PIP_BIN", os.path.expanduser("~/home-agents-env/bin/pip"))
+STATE_PATH = os.environ.get(
+    "DEPLOY_STATE_PATH", os.path.expanduser("~/.local/share/capitan/deploy_state.json"))
+# Health-gate: reintentos hasta declarar sano (audio_server tarda en cargar whisper).
+HEALTH_RETRIES = int(os.environ.get("DEPLOY_HEALTH_RETRIES", "15"))
+HEALTH_BACKOFF = float(os.environ.get("DEPLOY_HEALTH_BACKOFF", "2.0"))
+
+# Emisor de logs incremental: el orquestador empuja líneas; el invocador decide qué hacer con
+# ellas (postear append-only a Firestore desde el bridge, imprimir en la consola local, etc.).
+LogEmit = Callable[[str], None]
+
+
+def _noop_emit(_line: str) -> None:
+    pass
+
+
+# ── Ejecución de subprocesos (aislada para tests) ─────────────────────────────
+
+@dataclass
+class RunResult:
+    ok: bool
+    output: str = ""
+
+
+def _run(args: list[str], emit: LogEmit, *, timeout: int = 300, cwd: Optional[str] = None
+         ) -> RunResult:
+    """Corre un subproceso (lista de args, NUNCA shell), emite el comando + su salida en vivo
+    y devuelve (ok, output). El output se acumula para el resultado final del comando."""
+    emit(f"$ {' '.join(args)}")
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+    except subprocess.TimeoutExpired:
+        emit(f"  ✗ timeout tras {timeout}s")
+        return RunResult(False, f"timeout: {' '.join(args)}")
+    except Exception as exc:  # binario ausente, etc.
+        emit(f"  ✗ {type(exc).__name__}: {exc}")
+        return RunResult(False, str(exc))
+    out = (proc.stdout or "") + (proc.stderr or "")
+    for line in out.splitlines():
+        emit(f"  {line}")
+    if proc.returncode != 0:
+        emit(f"  ✗ rc={proc.returncode}")
+    return RunResult(proc.returncode == 0, out)
+
+
+def _http_ok(url: str, timeout: float = 5.0) -> bool:
+    """GET a una URL de health; True si responde 2xx/3xx. requests se importa local para no
+    acoplar el import del motor (los tests mockean este helper)."""
+    try:
+        import requests
+        r = requests.get(url, timeout=timeout)
+        return 200 <= r.status_code < 400
+    except Exception:
+        return False
+
+
+# ── Targets y drivers ─────────────────────────────────────────────────────────
+
+@dataclass
+class Ser9ServiceTarget:
+    """Componente que corre en el SER9, versionado por un submodule (core, ear) o por el
+    umbrella (backoffice, wa, bridge), y servido por una unit systemd con un /health opcional.
+
+    - name: id del componente (core, ear, backoffice, wa, bridge).
+    - submodule: ruta del submodule que pinea la versión, o None si es código del umbrella.
+    - service: unit systemd a reiniciar.
+    - health_url: endpoint de readiness, o None si la unit no expone health.
+    - requirements: requirements.txt a instalar si cambió (relativo a REPO_DIR), o None.
+    """
+    name: str
+    service: str
+    submodule: Optional[str] = None
+    health_url: Optional[str] = None
+    requirements: Optional[str] = None
+    driver: str = "ser9-service"
+
+    # ── versión ───────────────────────────────────────────────────────────────
+    def _git_dir(self) -> str:
+        return os.path.join(REPO_DIR, self.submodule) if self.submodule else REPO_DIR
+
+    def current_version(self, emit: LogEmit = _noop_emit) -> Optional[str]:
+        """SHA corto del ref desplegado (del submodule si aplica, si no del umbrella)."""
+        r = _run(["git", "-C", self._git_dir(), "rev-parse", "--short", "HEAD"],
+                 emit, timeout=15)
+        return r.output.strip() if r.ok else None
+
+    # ── deploy ─────────────────────────────────────────────────────────────────
+    def deploy(self, ref: Optional[str], emit: LogEmit) -> bool:
+        """Pin del ref pedido (fetch+checkout) en el git dir del componente; reinstala
+        requirements si cambiaron; reinicia la unit. ref None = HEAD remoto de main."""
+        gd = self._git_dir()
+        if not _run(["git", "-C", gd, "fetch", "--tags", "--quiet", "origin"], emit, timeout=120).ok:
+            return False
+        target = ref or "origin/main"
+        before = self.current_version(emit)
+        if not _run(["git", "-C", gd, "checkout", "--quiet", target], emit, timeout=60).ok:
+            return False
+        # Submodule: el umbrella debe quedar apuntando al ref nuevo en el working tree (no
+        # commiteamos; el deploy opera sobre el checkout). Para código del umbrella el checkout
+        # de arriba ya movió todo.
+        after = self.current_version(emit)
+        if self.requirements and before != after:
+            req = os.path.join(REPO_DIR, self.requirements)
+            if not _run([PIP, "install", "-q", "-r", req], emit, timeout=300).ok:
+                return False
+        return _run(["systemctl", "--user", "restart", self.service], emit, timeout=60).ok
+
+    # ── health ──────────────────────────────────────────────────────────────────
+    def health(self, emit: LogEmit) -> bool:
+        """is-active de la unit + (si tiene) health-gate HTTP con reintentos."""
+        if not _run(["systemctl", "--user", "is-active", "--quiet", self.service],
+                    emit, timeout=15).ok:
+            emit(f"  ✗ {self.service} no está active")
+            return False
+        if not self.health_url:
+            return True
+        for i in range(HEALTH_RETRIES):
+            if _http_ok(self.health_url):
+                emit(f"  ✓ health OK ({self.health_url})")
+                return True
+            time.sleep(HEALTH_BACKOFF)
+        emit(f"  ✗ health NO responde tras {HEALTH_RETRIES} intentos ({self.health_url})")
+        return False
+
+    # ── rollback ─────────────────────────────────────────────────────────────────
+    def rollback(self, snapshot_ref: Optional[str], emit: LogEmit) -> bool:
+        """Revierte al ref del snapshot (sha capturado antes del deploy) y reinicia."""
+        if not snapshot_ref:
+            emit("  ✗ sin ref de snapshot para revertir")
+            return False
+        emit(f"  ↩ rollback de {self.name} a {snapshot_ref}")
+        return self.deploy(snapshot_ref, emit)
+
+
+# Registro de targets del SER9. Los drivers panel/cloudrun se agregan en tandas siguientes.
+SER9_TARGETS: dict[str, Ser9ServiceTarget] = {
+    "core": Ser9ServiceTarget(
+        "core", "capitan-core", submodule="core",
+        health_url="http://localhost:8765/health", requirements="core/requirements.txt"),
+    "ear": Ser9ServiceTarget(
+        "ear", "capitan-audio-server", submodule="ear",
+        health_url="http://localhost:8766/health"),
+    "backoffice": Ser9ServiceTarget(
+        "backoffice", "capitan-backoffice",
+        health_url="http://localhost:8080/", requirements="backoffice/requirements.txt"),
+    "wa": Ser9ServiceTarget("wa", "capitan-wa"),
+    "bridge": Ser9ServiceTarget("bridge", "capitan-bridge"),
+}
+
+
+def get_target(name: str) -> Ser9ServiceTarget:
+    if name not in SER9_TARGETS:
+        raise ValueError(f"target de deploy desconocido: {name!r} "
+                         f"(conocidos: {sorted(SER9_TARGETS)})")
+    return SER9_TARGETS[name]
+
+
+# ── Estado persistido (matriz de versiones) ───────────────────────────────────
+
+def load_state() -> dict:
+    try:
+        return json.loads(Path(STATE_PATH).read_text(encoding="utf-8"))
+    except Exception:
+        return {"components": {}, "last_release": None}
+
+
+def save_state(state: dict) -> None:
+    p = Path(STATE_PATH)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _record_version(state: dict, name: str, version: Optional[str], status: str) -> None:
+    state.setdefault("components", {})[name] = {
+        "version": version, "status": status, "ts": time.time()}
+
+
+# ── Orquestador del release ───────────────────────────────────────────────────
+
+@dataclass
+class ReleaseResult:
+    ok: bool
+    components: dict[str, dict] = field(default_factory=dict)  # name → {ok, version, rolled_back}
+    log: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {"ok": self.ok, "components": self.components, "log": self.log}
+
+
+def run_release(targets: list[str], refs: Optional[dict[str, str]] = None,
+                emit: Optional[LogEmit] = None) -> ReleaseResult:
+    """Despliega los componentes pedidos de forma atómica por-componente: snapshot de la versión
+    actual → deploy(ref) → health-gate → si algo falla, rollback de ESE componente a su snapshot.
+
+    refs: name → ref (sha/tag/branch). Ausente = HEAD remoto de main para ese componente.
+    emit: callback de log incremental (D5); si None, se acumula en el resultado.
+    """
+    refs = refs or {}
+    result = ReleaseResult(ok=True)
+
+    def _emit(line: str) -> None:
+        result.log.append(line)
+        if emit:
+            emit(line)
+
+    state = load_state()
+    for name in targets:
+        target = get_target(name)
+        snapshot = target.current_version(_emit)
+        _emit(f"=== deploy {name} (desde {snapshot or '?'} → {refs.get(name) or 'origin/main'}) ===")
+        comp = {"ok": False, "version": None, "rolled_back": False, "snapshot": snapshot}
+
+        deployed = target.deploy(refs.get(name), _emit)
+        healthy = deployed and target.health(_emit)
+
+        if healthy:
+            comp["ok"] = True
+            comp["version"] = target.current_version(_emit)
+            _record_version(state, name, comp["version"], "deployed")
+            _emit(f"  ✓ {name} desplegado y sano ({comp['version']})")
+        else:
+            result.ok = False
+            _emit(f"  ✗ {name} falló ({'health' if deployed else 'deploy'}) — revirtiendo")
+            comp["rolled_back"] = target.rollback(snapshot, _emit)
+            restored = target.health(_emit) if comp["rolled_back"] else False
+            comp["version"] = target.current_version(_emit)
+            _record_version(state, name, comp["version"],
+                            "rolled_back" if restored else "broken")
+            _emit(f"  {'↩ revertido a' if restored else '✗ rollback NO sano en'} "
+                  f"{name} ({comp['version']})")
+
+        result.components[name] = comp
+
+    state["last_release"] = {"ts": time.time(), "ok": result.ok,
+                             "targets": targets, "refs": refs}
+    save_state(state)
+    return result
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def _parse_refs(items: list[str]) -> dict[str, str]:
+    """--ref core=abc123 --ref ear=v1.2 → {'core': 'abc123', 'ear': 'v1.2'}."""
+    out: dict[str, str] = {}
+    for it in items:
+        if "=" not in it:
+            raise SystemExit(f"--ref inválido (esperado name=ref): {it!r}")
+        k, v = it.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description="Motor de deploy del SER9 (FASE 34)")
+    ap.add_argument("targets", nargs="+", help=f"componentes a desplegar {sorted(SER9_TARGETS)}")
+    ap.add_argument("--ref", action="append", default=[], metavar="name=ref",
+                    help="pin de ref por componente (sha/tag/branch); default HEAD remoto de main")
+    ap.add_argument("--json", action="store_true", help="emitir el resultado como JSON al final")
+    args = ap.parse_args(argv)
+
+    res = run_release(args.targets, _parse_refs(args.ref), emit=lambda l: print(l, flush=True))
+    if args.json:
+        print(json.dumps(res.as_dict(), ensure_ascii=False))
+    return 0 if res.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cloud/bridge/test_deploy_engine.py
+++ b/cloud/bridge/test_deploy_engine.py
@@ -1,0 +1,160 @@
+"""Tests del motor de deploy (FASE 34): orquestación snapshot→deploy→health→rollback con
+git/systemd/http mockeados. No toca el repo real, ni systemctl, ni la red."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import deploy_engine as de  # noqa: E402
+
+
+@pytest.fixture
+def state_tmp(tmp_path, monkeypatch):
+    monkeypatch.setattr(de, "STATE_PATH", str(tmp_path / "deploy_state.json"))
+    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
+    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
+    return tmp_path
+
+
+class _FakeGit:
+    """Simula `git rev-parse --short HEAD` con un sha que cambia tras un checkout, y registra
+    los comandos corridos. Cualquier otro git/pip/systemctl devuelve ok salvo los marcados fail."""
+    def __init__(self, head="aaaaaaa", fail=()):
+        self.head = head
+        self.fail = set(fail)        # substrings de comando que deben fallar
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, emit, *, timeout=300, cwd=None):
+        self.calls.append(args)
+        joined = " ".join(args)
+        for f in self.fail:
+            if f in joined:
+                return de.RunResult(False, f"forced-fail: {f}")
+        if "rev-parse" in args:
+            return de.RunResult(True, self.head)
+        if "checkout" in args:
+            self.head = args[-1].replace("origin/", "")[:7] or self.head  # nuevo sha
+        return de.RunResult(True, "ok")
+
+
+def _setup(monkeypatch, fake):
+    monkeypatch.setattr(de, "_run", fake)
+
+
+# ── happy path ────────────────────────────────────────────────────────────────
+
+def test_release_ok_deploys_and_records_version(state_tmp, monkeypatch):
+    fake = _FakeGit(head="old1234")
+    _setup(monkeypatch, fake)
+    monkeypatch.setattr(de, "_http_ok", lambda url, timeout=5.0: True)
+
+    res = de.run_release(["core"], {"core": "abc1234"})
+    assert res.ok
+    assert res.components["core"]["ok"] is True
+    assert res.components["core"]["rolled_back"] is False
+    # snapshot capturó el sha viejo antes del checkout
+    assert res.components["core"]["snapshot"] == "old1234"
+    # restart de la unit ocurrió
+    assert any("restart" in c and "capitan-core" in c for c in fake.calls)
+    # versión registrada en el estado persistido
+    state = de.load_state()
+    assert state["components"]["core"]["status"] == "deployed"
+    assert state["last_release"]["ok"] is True
+
+
+def test_release_default_ref_is_origin_main(state_tmp, monkeypatch):
+    fake = _FakeGit()
+    _setup(monkeypatch, fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    de.run_release(["wa"])   # wa no tiene health_url ni requirements
+    assert any(c[:3] == ["git", "-C", os.path.join(de.REPO_DIR, "")] or "checkout" in c
+               and c[-1] == "origin/main" for c in fake.calls)
+
+
+# ── health falla → rollback ─────────────────────────────────────────────────────
+
+def test_release_health_fail_triggers_rollback(state_tmp, monkeypatch):
+    fake = _FakeGit(head="good999")
+    _setup(monkeypatch, fake)
+    # health HTTP siempre falla → tras el deploy se gatilla rollback; is-active (systemctl) ok
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: False)
+
+    res = de.run_release(["core"], {"core": "bad5678"})
+    assert res.ok is False
+    assert res.components["core"]["ok"] is False
+    assert res.components["core"]["rolled_back"] is True
+    # rollback hizo checkout del sha del snapshot (good999)
+    checkouts = [c[-1] for c in fake.calls if "checkout" in c]
+    assert "good999" in checkouts
+    state = de.load_state()
+    assert state["components"]["core"]["status"] in ("rolled_back", "broken")
+
+
+def test_release_deploy_fail_triggers_rollback(state_tmp, monkeypatch):
+    # el checkout del ref pedido falla → deploy False → rollback
+    fake = _FakeGit(head="snap111", fail=("checkout --quiet bad",))
+    _setup(monkeypatch, fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+
+    res = de.run_release(["core"], {"core": "bad"})
+    assert res.ok is False
+    assert res.components["core"]["rolled_back"] is True
+
+
+def test_release_requirements_install_only_when_version_changed(state_tmp, monkeypatch):
+    # HEAD no cambia (checkout al mismo sha) → no se reinstala requirements
+    fake = _FakeGit(head="same777")
+    monkeypatch.setattr(fake, "head", "same777")
+    # forzar que el checkout NO cambie el head
+    orig = fake.__call__
+
+    def _call(args, emit, **kw):
+        if "checkout" in args:
+            fake.calls.append(args)
+            return de.RunResult(True, "ok")   # no muta head
+        return orig(args, emit, **kw)
+
+    monkeypatch.setattr(de, "_run", _call)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    de.run_release(["core"], {"core": "same777"})
+    assert not any("install" in c for c in fake.calls)
+
+
+# ── targets / parsing ───────────────────────────────────────────────────────────
+
+def test_unknown_target_raises():
+    with pytest.raises(ValueError):
+        de.get_target("nope")
+
+
+def test_parse_refs():
+    assert de._parse_refs(["core=abc", "ear=v1.2"]) == {"core": "abc", "ear": "v1.2"}
+
+
+def test_parse_refs_invalid():
+    with pytest.raises(SystemExit):
+        de._parse_refs(["coreabc"])
+
+
+def test_emit_callback_receives_lines(state_tmp, monkeypatch):
+    fake = _FakeGit()
+    _setup(monkeypatch, fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    lines: list[str] = []
+    res = de.run_release(["wa"], emit=lines.append)
+    assert lines == res.log and len(lines) > 0
+    assert any("deploy wa" in l for l in lines)
+
+
+def test_multiple_targets_independent(state_tmp, monkeypatch):
+    fake = _FakeGit()
+    _setup(monkeypatch, fake)
+    # core sano, ear con health roto
+    monkeypatch.setattr(de, "_http_ok",
+                        lambda url, timeout=5.0: "8765" in url)
+    res = de.run_release(["core", "ear"])
+    assert res.components["core"]["ok"] is True
+    assert res.components["ear"]["ok"] is False
+    assert res.ok is False

--- a/cloud/infra/provision_deploy_sa.sh
+++ b/cloud/infra/provision_deploy_sa.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Provisiona la SA de DEPLOY para el driver cloudrun del motor de deploy (FASE 34, D9).
+# El SER9 la usa para desplegar Cloud Run (cloud-bo + oauth-app) y revertir revisiones.
+# Idempotente: se puede correr varias veces. Egress-only: el SER9 llama a las APIs de
+# Google (saliente); no abre nada en casa.
+#
+# Permiso MÍNIMO para `gcloud run deploy --source` + rollback:
+#   - run.admin               : deploy de servicios + update-traffic (rollback a revisión previa)
+#   - cloudbuild.builds.editor: build de la imagen desde source
+#   - artifactregistry.writer : push de la imagen al registry
+#   - iam.serviceAccountUser  : actuar como la runtime SA de cada servicio al desplegarlo
+#   - storage.admin (acotado) : bucket de staging que usa Cloud Build para el source
+#
+# Tras correrlo: copiar la key JSON generada al SER9 y apuntar GOOGLE_APPLICATION_CREDENTIALS
+# del entorno del motor a ese archivo (ver instrucciones al final).
+set -euo pipefail
+
+PROJECT="${PROJECT:-capitan-495518}"
+REGION="${REGION:-southamerica-east1}"
+DEPLOY_SA="${DEPLOY_SA:-capitan-deployer}"
+RUNTIME_SA="${RUNTIME_SA:-capitan-cloud-run}"            # runtime SA del cloud-bo
+OAUTH_RUNTIME_SA="${OAUTH_RUNTIME_SA:-}"                 # runtime SA de oauth-app, si difiere
+KEY_OUT="${KEY_OUT:-./capitan-deployer-key.json}"       # NO commitear (gitignored)
+
+DEPLOY_SA_EMAIL="${DEPLOY_SA}@${PROJECT}.iam.gserviceaccount.com"
+RUNTIME_SA_EMAIL="${RUNTIME_SA}@${PROJECT}.iam.gserviceaccount.com"
+
+gcloud config set project "$PROJECT" >/dev/null
+echo "== Proyecto: $PROJECT  Región: $REGION  Deploy SA: $DEPLOY_SA_EMAIL =="
+
+echo "== APIs (idempotente) =="
+gcloud services enable \
+  run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com \
+  storage.googleapis.com --project "$PROJECT"
+
+echo "== Service Account de deploy =="
+gcloud iam service-accounts describe "$DEPLOY_SA_EMAIL" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create "$DEPLOY_SA" \
+    --display-name="Capitán deployer (SER9) — deploy Cloud Run, permiso mínimo"
+
+echo "== Roles a nivel proyecto (permiso mínimo para deploy + rollback) =="
+for ROLE in \
+  roles/run.admin \
+  roles/cloudbuild.builds.editor \
+  roles/artifactregistry.writer ; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+    --role="$ROLE" --condition=None >/dev/null
+  echo "   + $ROLE"
+done
+
+echo "== actAs sobre las runtime SA de los servicios desplegados =="
+# Cloud Run deploy requiere que el deployer pueda 'actuar como' la runtime SA del servicio.
+gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA_EMAIL" \
+  --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+  --role="roles/iam.serviceAccountUser" >/dev/null
+echo "   + actAs ${RUNTIME_SA_EMAIL}"
+if [[ -n "$OAUTH_RUNTIME_SA" ]]; then
+  gcloud iam service-accounts add-iam-policy-binding \
+    "${OAUTH_RUNTIME_SA}@${PROJECT}.iam.gserviceaccount.com" \
+    --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+    --role="roles/iam.serviceAccountUser" >/dev/null
+  echo "   + actAs ${OAUTH_RUNTIME_SA}@${PROJECT}.iam.gserviceaccount.com"
+fi
+
+echo "== Storage del bucket de staging de Cloud Build =="
+# `gcloud run deploy --source` sube el source a un bucket de staging gestionado por Cloud Build.
+STAGING_BUCKET="${PROJECT}_cloudbuild"
+gcloud storage buckets add-iam-policy-binding "gs://${STAGING_BUCKET}" \
+  --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+  --role="roles/storage.admin" >/dev/null 2>&1 \
+  && echo "   + storage.admin sobre gs://${STAGING_BUCKET}" \
+  || echo "   · gs://${STAGING_BUCKET} aún no existe (lo crea el primer build); re-correr tras el 1er deploy"
+
+echo "== Key JSON (para el SER9) =="
+if [[ -f "$KEY_OUT" ]]; then
+  echo "   · $KEY_OUT ya existe — no se regenera (borralo para rotar)."
+else
+  gcloud iam service-accounts keys create "$KEY_OUT" \
+    --iam-account="$DEPLOY_SA_EMAIL"
+  echo "   ✓ key escrita en $KEY_OUT (NO commitear)"
+fi
+
+cat <<EOF
+
+=== Listo. Próximo paso en el SER9 ===
+1) Copiar la key al LXC (fuera del repo):
+     scp $KEY_OUT capitan-lxc:~/.config/capitan/deployer-key.json
+2) En el entorno del motor (bridge.env / unit del bridge) exportar:
+     GOOGLE_APPLICATION_CREDENTIALS=\$HOME/.config/capitan/deployer-key.json
+3) Verificar (egress-only, saliente):
+     ssh capitan-lxc 'gcloud auth activate-service-account --key-file ~/.config/capitan/deployer-key.json \\
+       && gcloud run services list --region $REGION'
+
+La key da poder de deploy: mantenerla fuera del repo (gitignored) y rotarla periódicamente.
+EOF

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3064,6 +3064,41 @@ Arquitectura (un motor, dos invocadores):
                   → FAIL: rollback al snapshot (registra evento sobre los refs versionados)
 ```
 
+DECISIONES CONSOLIDADAS (2026-06-20, al tomar la fase — amplían el alcance de arriba):
+  D1. SER9 = ejecutor UNIVERSAL. TODO el deploy (de cualquier componente, en cualquier
+      dominio) se dispara como comando del backoffice CLOUD y lo ejecuta el SER9 al polearlo
+      (egress-only). No hay deploy directo desde la notebook fuera del flujo de comandos. Razón:
+      desde fuera de casa la notebook NO tiene ruta a la LAN (SER9/paneles); el único plano de
+      control común es el cloud-bo. El `scripts/deploy.sh` local queda como wrapper fino para
+      cuando Claude opera DESDE la LAN, invocando el mismo motor.
+  D2. El motor tiene UN driver por tipo de target (misma interfaz: snapshot→deploy→health→
+      rollback→registro de versión):
+        - driver `ser9-service` (core, wa, backoffice-local, ear/audio_server, bridge):
+          git pin ref → install si cambió requirements → systemctl restart → health-gate
+          (/health) → rollback = checkout del ref del snapshot.
+        - driver `panel` (satellite.py/satellite_ui.py por NSPanel): el motor (en la LAN)
+          hace el push VERIFICADO (checksum+readback) → restart vía supervisor → health =
+          el nodo re-registra en audio_server con su versión → rollback = push del ref previo.
+          Absorbe la Etapa E (deploy a paneles robusto) y los footguns de pkill/supervisor.
+        - driver `cloudrun` (cloud-bo, oauth-app/meli): `gcloud run deploy --source` (egress
+          a GCP) → health-gate = curl a la URL pública → rollback = `gcloud run services
+          update-traffic` a la revisión previa (Cloud Run conserva revisiones).
+  D3. El SER9 requiere credencial gcloud con rol run.admin (+ acceso al build) para el driver
+      cloudrun. Sigue siendo EGRESS-ONLY (llama a las APIs de Google, saliente). Aprovisionar.
+  D4. Circularidad de la cloud (desplegar cloud-bo y romperla = perder el canal de comandos):
+      se mitiga con health-gate + rollback automático a la revisión previa de Cloud Run que el
+      propio SER9 dispara (no depende de la cloud para revertir). Escape hatch documentado:
+      `gcloud run deploy` manual desde la notebook si el rollback automático también falla.
+  D5. Feedback rico con LOGS EN VIVO (requisito de UX): el modelo de comandos pasa de
+      fire-and-result a PROGRESO INCREMENTAL — el motor emite líneas de log; el bridge las
+      postea append-only (Firestore) por comando; el cloud-bo las polea y las muestra en
+      streaming durante el deploy. La consola local tail-ea el log del motor directo. Aplica a
+      deploys disparados desde cloud-bo Y desde la consola local.
+  D6. Visualización de versión (requisito de UX): la versión corriendo de CADA componente, con
+      LINK a la versión tageada en GitHub (release), se muestra en LOS DOS backoffices (local y
+      cloud). Es la matriz dispositivo×componente→versión de 34.14, con deep-link al release.
+```
+
 #### Etapa A - Contrato del release
 - [ ] 34.1  Extender el comando tipado a `deploy.release` (o ampliar `deploy.run`) en
             `cloud/app/commands.py`: aceptar `core_ref` y `ear_ref` opcionales (default =

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3097,6 +3097,17 @@ DECISIONES CONSOLIDADAS (2026-06-20, al tomar la fase — amplían el alcance de
   D6. Visualización de versión (requisito de UX): la versión corriendo de CADA componente, con
       LINK a la versión tageada en GitHub (release), se muestra en LOS DOS backoffices (local y
       cloud). Es la matriz dispositivo×componente→versión de 34.14, con deep-link al release.
+  D7. Atomicidad POR-COMPONENTE (no por-release): si un release toca varios componentes y uno
+      falla su health-gate, sólo ESE componente revierte a su snapshot; los demás (sanos) quedan
+      desplegados. No se revierte un componente sano porque otro falló. (Confirmado 2026-06-20.)
+  D8. Versionado SEMVER (vX.Y.Z) por componente; el tag vive en el repo de cada componente
+      (core/ear/umbrella) y el GitHub Release referencia ese tag. El bump (patch auto vs
+      minor/major explícito) se define en 34.12. (Confirmado 2026-06-20.)
+  D9. El driver cloudrun usa una SA de deploy DEDICADA (separada de runtime y bridge SA), con
+      permiso mínimo: run.admin (deploy + update-traffic/rollback), cloudbuild.builds.editor,
+      artifactregistry.writer, iam.serviceAccountUser (actuar como la runtime SA), storage sobre
+      el bucket de staging de Cloud Build. Key JSON en el SER9 (egress-only). Script idempotente:
+      cloud/infra/provision_deploy_sa.sh. (Confirmado 2026-06-20.)
 ```
 
 #### Etapa A - Contrato del release
@@ -3198,9 +3209,16 @@ Trabajo a formalizar como tareas (Etapa E) al tomar la fase:
        el repo → certeza de qué corre en cada panel. Cierra la matriz dispositivo×componente.
   E.3  Robustez de arranque: asegurar que Termux:Boot dispare start-ha.sh tras reboot
        (battery-optimization/permisos), supervisor único con wake-lock, y health-check del nodo
-       (audio_server marca offline + alerta si un panel deja de reportar).
+       (audio_server marca offline + alerta si un panel deja de reportar). [issue #602]
   E.4  Convergencia de provisioning: `nspanel.sh` lleva CUALQUIER panel al estado canónico
-       (mismo voice-node.sh/start-ha.sh/deps), detectando y corrigiendo setups viejos (pieza).
+       (mismo voice-node.sh/start-ha.sh/deps), detectando y corrigiendo setups viejos (pieza). [issue #602]
+
+BUG abierto [issue #602] — arranque no convergente comedor vs pieza: el comedor (instalado a
+mano) bootea a HA Companion limpio y con sshd accesible desde el momento 1; la pieza (provision
+sistémico) abre el dashboard de fábrica primero, a veces no llega a HA Companion, y sshd no
+arranca solo (hay que abrir Termux por ADB y tipear sshd). El provisioning sistémico NO replica
+lo que se logró a mano en el comedor (permiso de Termux:Boot, battery-optimization, app por
+defecto/supresión del launcher de fábrica). Diagnóstico y fix en E.3/E.4.
 ```
 
 #### Etapa D - Tests y documentación


### PR DESCRIPTION
Primera tanda de FASE 34 (deploy remoto CD). Establece el **motor único** de deploy que correrá en el SER9 y será el único backend (lo invocarán el executor del bridge y `deploy.sh`, sin reimplementar lógica).

## Alcance de esta tanda
Dominio **SER9** (driver `ser9-service`): core, ear/audio_server, backoffice, wa, bridge.

- `cloud/bridge/deploy_engine.py`:
  - `run_release(targets, refs, emit)` — orquesta por componente: snapshot de versión actual → `deploy(pin de ref)` → health-gate → **rollback al snapshot si falla**.
  - `Ser9ServiceTarget` — driver: `git fetch+checkout` del ref pedido, `pip install` condicional (solo si cambió la versión), `systemctl restart`, health = `is-active` + `/health` con reintentos.
  - Estado persistido local (matriz componente→versión + último release).
  - Emisor de logs **incremental** (base de los logs en vivo, D5). CLI invocable.
  - Drivers `panel` (NSPanels) y `cloudrun` (GCP) pendientes — tandas siguientes.

## Seguridad
Código nuevo **aislado**: nadie lo invoca aún (el executor del bridge y `deploy.sh` siguen con su lógica vieja hasta la Tanda 2). **No cambia producción** — seguro de mergear.

## Decisiones consolidadas (estado.md, D1–D6)
SER9 = ejecutor universal; un driver por dominio; `gcloud run deploy` egress desde el SER9 para Cloud Run; circularidad de la cloud mitigada por rollback a revisión previa; logs en vivo; versión + link a GitHub release en ambos backoffices.

## Pendiente conocido (Tanda 2)
Orden de pin **submodule↔umbrella** (que el checkout del umbrella no pise refs pineados de submodules) — aislado en `Ser9ServiceTarget.deploy()`.

## Tests
snapshot→deploy→health→rollback, health-fail/deploy-fail gatillan rollback, install condicional, multi-target independiente, parsing de refs. **64 passed** (suite cloud completa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)