### PR TITLE
FASE 34 Tanda 2: un motor, dos invocadores + contrato deploy.release

### DIFF
--- a/cloud/app/commands.py
+++ b/cloud/app/commands.py
@@ -8,10 +8,17 @@ Ver masterplan/fase33_cloud_backoffice.md (33.3).
 """
 from __future__ import annotations
 
+import re
 from typing import Any, Callable
 
 SERVICES = ("capitan-core", "capitan-backoffice", "capitan-wa", "capitan-ear")
 CONFIG_TARGETS = ("core", "backoffice")
+# Componentes del motor de deploy (FASE 34). Nombres lógicos del motor (deploy_engine.SERVICES),
+# distintos de las units de SERVICES de arriba.
+DEPLOY_SERVICES = ("core", "ear", "backoffice", "wa", "bridge")
+# Un ref git seguro: sha/tag/branch. Alfanumérico + . _ / - (sin espacios ni metacaracteres de
+# shell). El motor igual usa subprocess con lista de args (sin shell), esto es defensa en capas.
+_REF_RE = re.compile(r"^[A-Za-z0-9._/-]{1,100}$")
 
 
 class CommandError(ValueError):
@@ -50,11 +57,36 @@ def _str(name: str) -> Callable[[Any], str]:
     return check
 
 
+def _git_ref(name: str) -> Callable[[Any], str]:
+    def check(v: Any) -> str:
+        if not isinstance(v, str) or not _REF_RE.match(v):
+            raise CommandError(f"{name!r} debe ser un ref git válido (sha/tag/branch), no {v!r}")
+        return v
+    return check
+
+
+def _str_list(name: str, allowed: tuple[str, ...]) -> Callable[[Any], list[str]]:
+    def check(v: Any) -> list[str]:
+        if not isinstance(v, list) or not v:
+            raise CommandError(f"{name!r} debe ser una lista no vacía")
+        for item in v:
+            if item not in allowed:
+                raise CommandError(f"{name!r}: {item!r} debe ser uno de {allowed}")
+        return v
+    return check
+
+
 # type -> { param_name: (validator, required) }
 CATALOG: dict[str, dict[str, tuple[Callable[[Any], Any], bool]]] = {
     "service.restart": {"service": (_enum("service", SERVICES), True)},
     "service.status":  {"service": (_enum("service", SERVICES), False)},
     "deploy.run":      {"restart_wa": (_bool("restart_wa"), False)},
+    # FASE 34: release con pin de ref por repo. Sin params = todo a HEAD remoto de main
+    # (servicios default del motor). `services` acota qué desplegar; *_ref pinea cada repo.
+    "deploy.release":  {"services": (_str_list("services", DEPLOY_SERVICES), False),
+                        "core_ref": (_git_ref("core_ref"), False),
+                        "ear_ref": (_git_ref("ear_ref"), False),
+                        "umbrella_ref": (_git_ref("umbrella_ref"), False)},
     "logs.tail":       {"service": (_enum("service", SERVICES), True),
                         "lines": (_int_range("lines", 1, 500), False)},
     "config.reload":   {"target": (_enum("target", CONFIG_TARGETS), True)},

--- a/cloud/bridge/deploy_engine.py
+++ b/cloud/bridge/deploy_engine.py
@@ -5,29 +5,28 @@ Principio (FASE 34): existe UN solo motor con la lógica de deploy (snapshot →
 install → restart → health-gate → rollback → registro de versión). Lo invocan dos frontends
 sin reimplementar nada: el executor del bridge (remoto, comando `deploy.release` del cloud-bo)
 y `scripts/deploy.sh` (local, cuando se opera desde la LAN). Ver DECISIONES CONSOLIDADAS en
-masterplan/estado.md (D1–D6).
+masterplan/estado.md (D1–D9).
 
-Esta tanda implementa el dominio SER9 (driver `ser9-service`): los servicios que corren en el
-LXC y se versionan por submodule (core, ear/audio_server) o por el umbrella (backoffice, wa,
-bridge). Los drivers `panel` (NSPanels) y `cloudrun` (GCP) se registran como pendientes y se
-implementan en tandas siguientes.
+Modelo (Tanda 2): se separan dos conceptos que la Tanda 1 mezclaba —
+  - REPO: unidad de VERSIÓN. Un repo git pineable a un ref. Son tres: `core` (submodule),
+    `ear` (submodule) y `umbrella` (el repo raíz, que provee backoffice/wa/bridge).
+  - SERVICE: unidad de RESTART/HEALTH. Una unit systemd servida por un repo, con su /health y
+    sus requirements. Cinco: core, ear(audio_server), backoffice, wa, bridge.
 
-Diseño:
-  - Cada componente desplegable es un TARGET con un driver. El driver expone la misma interfaz:
-    current_version() → str | None, deploy(refs, emit), health() → bool, rollback(snapshot, emit).
-  - `run_release` orquesta: snapshot de versiones actuales → deploy → health-gate → si falla,
-    rollback al snapshot. Emite logs incrementales por un callback (D5: feedback en vivo).
-  - El estado (matriz dispositivo×componente→versión + último release) se persiste local en el
-    SER9 (fuente de verdad) y un subconjunto viaja al snapshot del bridge (D6).
+Pin independiente por repo (clave del submodule↔umbrella): `git checkout` del umbrella mueve
+SÓLO sus archivos rastreados (backoffice/, wa/, cloud/, scripts/…); NO toca los working dirs de
+core/ y ear/ (sólo el puntero de submodule en el índice, que queda como "modified" — cosmético).
+Por eso NO se corre `git submodule update`: cada repo se pinea con su propio checkout, sin
+acoplarse. Atomicidad POR-REPO (D7): si un servicio falla su health, se revierte SU repo (y se
+reinician sus servicios); los otros repos, sanos, quedan.
 
-Sin estado global mutable: el motor es invocable por CLI o importable; los efectos (git,
-systemctl, http) están aislados en helpers mockeables para los tests.
+Sin estado global mutable: los efectos (git, systemctl, http) están aislados en `_run`/`_http_ok`
+para mockearlos en los tests.
 """
 from __future__ import annotations
 
 import json
 import os
-import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -37,12 +36,9 @@ REPO_DIR = os.environ.get("REPO_DIR", os.path.expanduser("~/workspace/home-agent
 PIP = os.environ.get("PIP_BIN", os.path.expanduser("~/home-agents-env/bin/pip"))
 STATE_PATH = os.environ.get(
     "DEPLOY_STATE_PATH", os.path.expanduser("~/.local/share/capitan/deploy_state.json"))
-# Health-gate: reintentos hasta declarar sano (audio_server tarda en cargar whisper).
 HEALTH_RETRIES = int(os.environ.get("DEPLOY_HEALTH_RETRIES", "15"))
 HEALTH_BACKOFF = float(os.environ.get("DEPLOY_HEALTH_BACKOFF", "2.0"))
 
-# Emisor de logs incremental: el orquestador empuja líneas; el invocador decide qué hacer con
-# ellas (postear append-only a Firestore desde el bridge, imprimir en la consola local, etc.).
 LogEmit = Callable[[str], None]
 
 
@@ -58,17 +54,17 @@ class RunResult:
     output: str = ""
 
 
-def _run(args: list[str], emit: LogEmit, *, timeout: int = 300, cwd: Optional[str] = None
-         ) -> RunResult:
+def _run(args: list[str], emit: LogEmit, *, timeout: int = 300) -> RunResult:
     """Corre un subproceso (lista de args, NUNCA shell), emite el comando + su salida en vivo
-    y devuelve (ok, output). El output se acumula para el resultado final del comando."""
+    y devuelve (ok, output)."""
+    import subprocess
     emit(f"$ {' '.join(args)}")
     try:
-        proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
         emit(f"  ✗ timeout tras {timeout}s")
         return RunResult(False, f"timeout: {' '.join(args)}")
-    except Exception as exc:  # binario ausente, etc.
+    except Exception as exc:
         emit(f"  ✗ {type(exc).__name__}: {exc}")
         return RunResult(False, str(exc))
     out = (proc.stdout or "") + (proc.stderr or "")
@@ -80,8 +76,6 @@ def _run(args: list[str], emit: LogEmit, *, timeout: int = 300, cwd: Optional[st
 
 
 def _http_ok(url: str, timeout: float = 5.0) -> bool:
-    """GET a una URL de health; True si responde 2xx/3xx. requests se importa local para no
-    acoplar el import del motor (los tests mockean este helper)."""
     try:
         import requests
         r = requests.get(url, timeout=timeout)
@@ -90,67 +84,66 @@ def _http_ok(url: str, timeout: float = 5.0) -> bool:
         return False
 
 
-# ── Targets y drivers ─────────────────────────────────────────────────────────
+# ── Repos (unidad de versión) ─────────────────────────────────────────────────
 
 @dataclass
-class Ser9ServiceTarget:
-    """Componente que corre en el SER9, versionado por un submodule (core, ear) o por el
-    umbrella (backoffice, wa, bridge), y servido por una unit systemd con un /health opcional.
-
-    - name: id del componente (core, ear, backoffice, wa, bridge).
-    - submodule: ruta del submodule que pinea la versión, o None si es código del umbrella.
-    - service: unit systemd a reiniciar.
-    - health_url: endpoint de readiness, o None si la unit no expone health.
-    - requirements: requirements.txt a instalar si cambió (relativo a REPO_DIR), o None.
-    """
+class Repo:
+    """Repo git pineable a un ref. `subpath` vacío = umbrella (REPO_DIR); si no, submodule."""
     name: str
-    service: str
-    submodule: Optional[str] = None
-    health_url: Optional[str] = None
-    requirements: Optional[str] = None
-    driver: str = "ser9-service"
+    subpath: str
 
-    # ── versión ───────────────────────────────────────────────────────────────
-    def _git_dir(self) -> str:
-        return os.path.join(REPO_DIR, self.submodule) if self.submodule else REPO_DIR
+    def git_dir(self) -> str:
+        return os.path.join(REPO_DIR, self.subpath) if self.subpath else REPO_DIR
 
-    def current_version(self, emit: LogEmit = _noop_emit) -> Optional[str]:
-        """SHA corto del ref desplegado (del submodule si aplica, si no del umbrella)."""
-        r = _run(["git", "-C", self._git_dir(), "rev-parse", "--short", "HEAD"],
-                 emit, timeout=15)
+    def head(self, emit: LogEmit = _noop_emit) -> Optional[str]:
+        r = _run(["git", "-C", self.git_dir(), "rev-parse", "--short", "HEAD"], emit, timeout=15)
         return r.output.strip() if r.ok else None
 
-    # ── deploy ─────────────────────────────────────────────────────────────────
-    def deploy(self, ref: Optional[str], emit: LogEmit) -> bool:
-        """Pin del ref pedido (fetch+checkout) en el git dir del componente; reinstala
-        requirements si cambiaron; reinicia la unit. ref None = HEAD remoto de main."""
-        gd = self._git_dir()
+    def pin(self, ref: Optional[str], emit: LogEmit) -> bool:
+        """fetch + checkout del ref pedido (ref None = HEAD remoto de main). Independiente: no
+        corre `git submodule update`, así pinar el umbrella no pisa core/ear (ni viceversa)."""
+        gd = self.git_dir()
         if not _run(["git", "-C", gd, "fetch", "--tags", "--quiet", "origin"], emit, timeout=120).ok:
             return False
-        target = ref or "origin/main"
-        before = self.current_version(emit)
-        if not _run(["git", "-C", gd, "checkout", "--quiet", target], emit, timeout=60).ok:
-            return False
-        # Submodule: el umbrella debe quedar apuntando al ref nuevo en el working tree (no
-        # commiteamos; el deploy opera sobre el checkout). Para código del umbrella el checkout
-        # de arriba ya movió todo.
-        after = self.current_version(emit)
-        if self.requirements and before != after:
-            req = os.path.join(REPO_DIR, self.requirements)
-            if not _run([PIP, "install", "-q", "-r", req], emit, timeout=300).ok:
-                return False
-        return _run(["systemctl", "--user", "restart", self.service], emit, timeout=60).ok
+        return _run(["git", "-C", gd, "checkout", "--quiet", ref or "origin/main"],
+                    emit, timeout=60).ok
 
-    # ── health ──────────────────────────────────────────────────────────────────
+
+REPOS: dict[str, Repo] = {
+    "umbrella": Repo("umbrella", ""),
+    "core": Repo("core", "core"),
+    "ear": Repo("ear", "ear"),
+}
+
+
+# ── Services (unidad de restart/health) ───────────────────────────────────────
+
+@dataclass
+class Service:
+    """Unit systemd servida por un repo, con su /health opcional y requirements opcionales."""
+    name: str
+    unit: str
+    repo: str
+    health_url: Optional[str] = None
+    requirements: Optional[str] = None   # relativo a REPO_DIR; instalar si el repo cambió
+
+    def install(self, emit: LogEmit) -> bool:
+        if not self.requirements:
+            return True
+        return _run([PIP, "install", "-q", "-r", os.path.join(REPO_DIR, self.requirements)],
+                    emit, timeout=300).ok
+
+    def restart(self, emit: LogEmit) -> bool:
+        return _run(["systemctl", "--user", "restart", self.unit], emit, timeout=60).ok
+
     def health(self, emit: LogEmit) -> bool:
-        """is-active de la unit + (si tiene) health-gate HTTP con reintentos."""
-        if not _run(["systemctl", "--user", "is-active", "--quiet", self.service],
+        if not _run(["systemctl", "--user", "is-active", "--quiet", self.unit],
                     emit, timeout=15).ok:
-            emit(f"  ✗ {self.service} no está active")
+            emit(f"  ✗ {self.unit} no está active")
             return False
         if not self.health_url:
             return True
-        for i in range(HEALTH_RETRIES):
+        for _ in range(HEALTH_RETRIES):
             if _http_ok(self.health_url):
                 emit(f"  ✓ health OK ({self.health_url})")
                 return True
@@ -158,37 +151,29 @@ class Ser9ServiceTarget:
         emit(f"  ✗ health NO responde tras {HEALTH_RETRIES} intentos ({self.health_url})")
         return False
 
-    # ── rollback ─────────────────────────────────────────────────────────────────
-    def rollback(self, snapshot_ref: Optional[str], emit: LogEmit) -> bool:
-        """Revierte al ref del snapshot (sha capturado antes del deploy) y reinicia."""
-        if not snapshot_ref:
-            emit("  ✗ sin ref de snapshot para revertir")
-            return False
-        emit(f"  ↩ rollback de {self.name} a {snapshot_ref}")
-        return self.deploy(snapshot_ref, emit)
 
-
-# Registro de targets del SER9. Los drivers panel/cloudrun se agregan en tandas siguientes.
-SER9_TARGETS: dict[str, Ser9ServiceTarget] = {
-    "core": Ser9ServiceTarget(
-        "core", "capitan-core", submodule="core",
-        health_url="http://localhost:8765/health", requirements="core/requirements.txt"),
-    "ear": Ser9ServiceTarget(
-        "ear", "capitan-audio-server", submodule="ear",
-        health_url="http://localhost:8766/health"),
-    "backoffice": Ser9ServiceTarget(
-        "backoffice", "capitan-backoffice",
-        health_url="http://localhost:8080/", requirements="backoffice/requirements.txt"),
-    "wa": Ser9ServiceTarget("wa", "capitan-wa"),
-    "bridge": Ser9ServiceTarget("bridge", "capitan-bridge"),
+SERVICES: dict[str, Service] = {
+    "core": Service("core", "capitan-core", "core",
+                    "http://localhost:8765/health", "core/requirements.txt"),
+    "ear": Service("ear", "capitan-audio-server", "ear", "http://localhost:8766/health"),
+    "backoffice": Service("backoffice", "capitan-backoffice", "umbrella",
+                          "http://localhost:8080/", "backoffice/requirements.txt"),
+    "wa": Service("wa", "capitan-wa", "umbrella"),
+    "bridge": Service("bridge", "capitan-bridge", "umbrella"),
 }
 
+# Servicios por defecto de un release "todo a main". Se excluyen:
+#  - wa: restart caro (reconectar WhatsApp puede pedir re-escanear el QR).
+#  - bridge: FOOTGUN — si el deploy lo invoca el propio bridge (executor remoto), reiniciar
+#    capitan-bridge mata el proceso que está corriendo el deploy a mitad (auto-suicidio, no
+#    reporta resultado). Desplegar bridge requiere restart DESACOPLADO (systemd-run diferido);
+#    se resuelve en una tanda siguiente. Hasta entonces, bridge sólo por deploy.sh local.
+# Ambos se pueden incluir explícitamente en `services`.
+DEFAULT_SERVICES = ["core", "ear", "backoffice"]
 
-def get_target(name: str) -> Ser9ServiceTarget:
-    if name not in SER9_TARGETS:
-        raise ValueError(f"target de deploy desconocido: {name!r} "
-                         f"(conocidos: {sorted(SER9_TARGETS)})")
-    return SER9_TARGETS[name]
+
+def services_of_repo(repo: str) -> list[str]:
+    return [n for n, s in SERVICES.items() if s.repo == repo]
 
 
 # ── Estado persistido (matriz de versiones) ───────────────────────────────────
@@ -197,7 +182,7 @@ def load_state() -> dict:
     try:
         return json.loads(Path(STATE_PATH).read_text(encoding="utf-8"))
     except Exception:
-        return {"components": {}, "last_release": None}
+        return {"repos": {}, "services": {}, "last_release": None}
 
 
 def save_state(state: dict) -> None:
@@ -206,32 +191,50 @@ def save_state(state: dict) -> None:
     p.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
-def _record_version(state: dict, name: str, version: Optional[str], status: str) -> None:
-    state.setdefault("components", {})[name] = {
-        "version": version, "status": status, "ts": time.time()}
-
-
 # ── Orquestador del release ───────────────────────────────────────────────────
 
 @dataclass
 class ReleaseResult:
     ok: bool
-    components: dict[str, dict] = field(default_factory=dict)  # name → {ok, version, rolled_back}
+    repos: dict[str, dict] = field(default_factory=dict)      # repo → {ok, version, rolled_back}
+    services: dict[str, dict] = field(default_factory=dict)   # svc → {ok, repo}
     log: list[str] = field(default_factory=list)
 
     def as_dict(self) -> dict:
-        return {"ok": self.ok, "components": self.components, "log": self.log}
+        return {"ok": self.ok, "repos": self.repos, "services": self.services, "log": self.log}
 
 
-def run_release(targets: list[str], refs: Optional[dict[str, str]] = None,
+def resolve(services: Optional[list[str]], repo_refs: Optional[dict[str, Optional[str]]]
+            ) -> tuple[list[str], dict[str, Optional[str]]]:
+    """Normaliza la entrada del release a (servicios, refs por repo a pinar).
+
+    - services None → DEFAULT_SERVICES (core/ear/backoffice/bridge; wa excluido).
+    - repo_refs None → {} → todos los repos involucrados a origin/main.
+    Los repos a pinar son los de los servicios pedidos UNIÓN los de repo_refs explícitos; cada
+    repo sin ref explícito queda en None (origin/main)."""
+    svcs = list(services) if services else list(DEFAULT_SERVICES)
+    for s in svcs:
+        if s not in SERVICES:
+            raise ValueError(f"servicio de deploy desconocido: {s!r} (conocidos: {sorted(SERVICES)})")
+    refs = dict(repo_refs or {})
+    for r in refs:
+        if r not in REPOS:
+            raise ValueError(f"repo desconocido: {r!r} (conocidos: {sorted(REPOS)})")
+    repos = {SERVICES[s].repo for s in svcs} | set(refs)
+    return svcs, {r: refs.get(r) for r in repos}
+
+
+def run_release(services: Optional[list[str]] = None,
+                repo_refs: Optional[dict[str, Optional[str]]] = None,
                 emit: Optional[LogEmit] = None) -> ReleaseResult:
-    """Despliega los componentes pedidos de forma atómica por-componente: snapshot de la versión
-    actual → deploy(ref) → health-gate → si algo falla, rollback de ESE componente a su snapshot.
+    """Despliega los `services` pedidos pinando sus repos a `repo_refs` (default origin/main).
 
-    refs: name → ref (sha/tag/branch). Ausente = HEAD remoto de main para ese componente.
-    emit: callback de log incremental (D5); si None, se acumula en el resultado.
+    Flujo: snapshot de la versión de cada repo → pin de todos los repos → por repo, install +
+    restart + health-gate de SUS servicios; si alguno falla, rollback de ESE repo a su snapshot
+    y restart de sus servicios (atomicidad por-repo, D7). Los repos sanos quedan desplegados.
+    `emit` recibe logs incrementales (D5); si None se acumulan en el resultado.
     """
-    refs = refs or {}
+    svcs, refs = resolve(services, repo_refs)
     result = ReleaseResult(ok=True)
 
     def _emit(line: str) -> None:
@@ -240,62 +243,90 @@ def run_release(targets: list[str], refs: Optional[dict[str, str]] = None,
             emit(line)
 
     state = load_state()
-    for name in targets:
-        target = get_target(name)
-        snapshot = target.current_version(_emit)
-        _emit(f"=== deploy {name} (desde {snapshot or '?'} → {refs.get(name) or 'origin/main'}) ===")
-        comp = {"ok": False, "version": None, "rolled_back": False, "snapshot": snapshot}
+    snapshots = {r: REPOS[r].head(_emit) for r in refs}
+    _emit(f"=== release: servicios={svcs} repos={ {r: refs[r] or 'origin/main' for r in refs} } ===")
 
-        deployed = target.deploy(refs.get(name), _emit)
-        healthy = deployed and target.health(_emit)
+    # Pin de todos los repos pedidos (independiente, sin submodule update).
+    pinned: dict[str, bool] = {}
+    for r in refs:
+        _emit(f"--- pin {r}: {snapshots[r] or '?'} → {refs[r] or 'origin/main'}")
+        pinned[r] = REPOS[r].pin(refs[r], _emit)
 
-        if healthy:
-            comp["ok"] = True
-            comp["version"] = target.current_version(_emit)
-            _record_version(state, name, comp["version"], "deployed")
-            _emit(f"  ✓ {name} desplegado y sano ({comp['version']})")
+    # Por repo: desplegar sus servicios (de los pedidos); si algo falla, revertir el repo.
+    for r in refs:
+        repo_svcs = [s for s in svcs if SERVICES[s].repo == r]
+        repo_ok = pinned[r]
+        if not repo_ok:
+            _emit(f"  ✗ pin de {r} falló")
+        for s in repo_svcs if repo_ok else []:
+            svc = SERVICES[s]
+            if not (svc.install(_emit) and svc.restart(_emit) and svc.health(_emit)):
+                _emit(f"  ✗ servicio {s} falló")
+                repo_ok = False
+                break
+
+        if repo_ok:
+            ver = REPOS[r].head(_emit)
+            result.repos[r] = {"ok": True, "version": ver, "rolled_back": False}
+            for s in repo_svcs:
+                result.services[s] = {"ok": True, "repo": r}
+            _emit(f"  ✓ {r} desplegado y sano ({ver})")
         else:
             result.ok = False
-            _emit(f"  ✗ {name} falló ({'health' if deployed else 'deploy'}) — revirtiendo")
-            comp["rolled_back"] = target.rollback(snapshot, _emit)
-            restored = target.health(_emit) if comp["rolled_back"] else False
-            comp["version"] = target.current_version(_emit)
-            _record_version(state, name, comp["version"],
-                            "rolled_back" if restored else "broken")
-            _emit(f"  {'↩ revertido a' if restored else '✗ rollback NO sano en'} "
-                  f"{name} ({comp['version']})")
+            _emit(f"  ↩ rollback {r} → {snapshots[r] or '?'}")
+            rb = REPOS[r].pin(snapshots[r], _emit) if snapshots[r] else False
+            restored = rb
+            for s in repo_svcs:
+                if not (SERVICES[s].install(_emit) and SERVICES[s].restart(_emit)
+                        and SERVICES[s].health(_emit)):
+                    restored = False
+            ver = REPOS[r].head(_emit)
+            result.repos[r] = {"ok": False, "version": ver, "rolled_back": rb,
+                               "restored": restored}
+            for s in repo_svcs:
+                result.services[s] = {"ok": False, "repo": r}
+            _emit(f"  {'↩ revertido a' if restored else '✗ rollback NO sano en'} {r} ({ver})")
 
-        result.components[name] = comp
-
+    # Persistir la matriz de versiones + último release.
+    for r, info in result.repos.items():
+        state.setdefault("repos", {})[r] = {
+            "version": info["version"],
+            "status": "deployed" if info["ok"] else ("rolled_back" if info.get("restored") else "broken"),
+            "ts": time.time()}
+    for s, info in result.services.items():
+        state.setdefault("services", {})[s] = {
+            "version": result.repos[info["repo"]]["version"], "ok": info["ok"], "ts": time.time()}
     state["last_release"] = {"ts": time.time(), "ok": result.ok,
-                             "targets": targets, "refs": refs}
+                             "services": svcs, "refs": {r: refs[r] for r in refs}}
     save_state(state)
     return result
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
 
-def _parse_refs(items: list[str]) -> dict[str, str]:
-    """--ref core=abc123 --ref ear=v1.2 → {'core': 'abc123', 'ear': 'v1.2'}."""
-    out: dict[str, str] = {}
+def _parse_refs(items: list[str]) -> dict[str, Optional[str]]:
+    """--ref core=abc123 --ref umbrella=v1.2 → {'core': 'abc123', 'umbrella': 'v1.2'}."""
+    out: dict[str, Optional[str]] = {}
     for it in items:
         if "=" not in it:
-            raise SystemExit(f"--ref inválido (esperado name=ref): {it!r}")
+            raise SystemExit(f"--ref inválido (esperado repo=ref): {it!r}")
         k, v = it.split("=", 1)
-        out[k.strip()] = v.strip()
+        out[k.strip()] = v.strip() or None
     return out
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     import argparse
     ap = argparse.ArgumentParser(description="Motor de deploy del SER9 (FASE 34)")
-    ap.add_argument("targets", nargs="+", help=f"componentes a desplegar {sorted(SER9_TARGETS)}")
-    ap.add_argument("--ref", action="append", default=[], metavar="name=ref",
-                    help="pin de ref por componente (sha/tag/branch); default HEAD remoto de main")
+    ap.add_argument("--service", action="append", default=[], metavar="name",
+                    help=f"servicio a desplegar {sorted(SERVICES)}; default {DEFAULT_SERVICES}")
+    ap.add_argument("--ref", action="append", default=[], metavar="repo=ref",
+                    help=f"pin de ref por repo {sorted(REPOS)}; default HEAD remoto de main")
     ap.add_argument("--json", action="store_true", help="emitir el resultado como JSON al final")
     args = ap.parse_args(argv)
 
-    res = run_release(args.targets, _parse_refs(args.ref), emit=lambda l: print(l, flush=True))
+    res = run_release(args.service or None, _parse_refs(args.ref) or None,
+                      emit=lambda l: print(l, flush=True))
     if args.json:
         print(json.dumps(res.as_dict(), ensure_ascii=False))
     return 0 if res.ok else 1

--- a/cloud/bridge/executor.py
+++ b/cloud/bridge/executor.py
@@ -55,22 +55,31 @@ def _logs_tail(p: dict) -> ExecResult:
     return _run(["journalctl", "--user", "-u", p["service"], "-n", lines, "--no-pager"], timeout=15)
 
 
+def _run_engine(services, repo_refs) -> ExecResult:
+    """Invoca el MOTOR único de deploy (FASE 34). El executor NO reimplementa lógica de deploy:
+    sólo traduce comando→args, corre el motor in-process (el bridge corre EN el SER9) y reporta
+    el log incremental + el ok/rollback. Ver deploy_engine.run_release / D1, D7."""
+    import deploy_engine
+    lines: list[str] = []
+    res = deploy_engine.run_release(services, repo_refs or None, emit=lines.append)
+    err = "" if res.ok else "deploy con fallos (ver rollback en el log)"
+    return ExecResult(res.ok, "\n".join(lines), err)
+
+
 def _deploy_run(p: dict) -> ExecResult:
-    out = []
-    for step in (
-        ["git", "-C", REPO_DIR, "pull", "--recurse-submodules"],
-        [PIP, "install", "-q", "-r", os.path.join(REPO_DIR, "core/requirements.txt")],
-        [PIP, "install", "-q", "-r", os.path.join(REPO_DIR, "backoffice/requirements.txt")],
-        ["systemctl", "--user", "restart", "capitan-core", "capitan-backoffice"],
-    ):
-        r = _run(step, timeout=180)
-        out.append(f"$ {' '.join(step)}\n{r.output}")
-        if not r.ok:
-            return ExecResult(False, "\n".join(out), r.error)
-    if p.get("restart_wa"):
-        r = _run(["systemctl", "--user", "restart", "capitan-wa"], timeout=30)
-        out.append(f"restart wa: {r.output}")
-    return ExecResult(True, "\n".join(out))
+    """Compat: deploy.run = release de los servicios default a HEAD de main (+ wa si restart_wa)."""
+    import deploy_engine
+    services = list(deploy_engine.DEFAULT_SERVICES) + (["wa"] if p.get("restart_wa") else [])
+    return _run_engine(services, None)
+
+
+def _deploy_release(p: dict) -> ExecResult:
+    """FASE 34: release con pin de ref por repo. `services` acota qué desplegar (default del
+    motor si se omite); core_ref/ear_ref/umbrella_ref pinean cada repo (default origin/main)."""
+    repo_refs = {repo: p[key] for repo, key in
+                 (("core", "core_ref"), ("ear", "ear_ref"), ("umbrella", "umbrella_ref"))
+                 if p.get(key)}
+    return _run_engine(p.get("services"), repo_refs)
 
 
 def _config_reload(p: dict) -> ExecResult:
@@ -109,6 +118,7 @@ HANDLERS = {
     "service.status": _service_status,
     "logs.tail": _logs_tail,
     "deploy.run": _deploy_run,
+    "deploy.release": _deploy_release,
     "config.reload": _config_reload,
     "wakeword.retrain": _wakeword_retrain,
     "voice.reenroll": _voice_reenroll,

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -114,3 +114,61 @@ def test_metrics_snapshot_unwraps_list_envelopes():
     assert snap["llm_by_agent"][0]["agent_id"] == "haos"
     assert snap["retrains"][0]["version"] == "v1"
     assert snap["voice_series"]["labels"] == [1, 2]
+
+
+# ── deploy.run / deploy.release invocan el motor único (FASE 34) ───────────────
+
+def test_deploy_run_invokes_engine(monkeypatch):
+    import deploy_engine
+    captured = {}
+
+    class _Res:
+        ok = True
+        log = ["línea"]
+        def __init__(self): pass
+
+    def _fake(services=None, repo_refs=None, emit=None):
+        captured["services"] = services
+        captured["repo_refs"] = repo_refs
+        if emit:
+            emit("motor corrió")
+        return type("R", (), {"ok": True})()
+
+    monkeypatch.setattr(deploy_engine, "run_release", _fake)
+    r = executor.execute("deploy.run", {})
+    assert r.ok
+    # default: servicios del motor, sin wa
+    assert captured["services"] == list(deploy_engine.DEFAULT_SERVICES)
+    assert "motor corrió" in r.output
+
+
+def test_deploy_run_restart_wa_incluye_wa(monkeypatch):
+    import deploy_engine
+    captured = {}
+    monkeypatch.setattr(deploy_engine, "run_release",
+                        lambda services=None, repo_refs=None, emit=None:
+                        captured.update(services=services) or type("R", (), {"ok": True})())
+    executor.execute("deploy.run", {"restart_wa": True})
+    assert "wa" in captured["services"]
+
+
+def test_deploy_release_passes_refs(monkeypatch):
+    import deploy_engine
+    captured = {}
+    monkeypatch.setattr(deploy_engine, "run_release",
+                        lambda services=None, repo_refs=None, emit=None:
+                        captured.update(services=services, repo_refs=repo_refs)
+                        or type("R", (), {"ok": True})())
+    executor.execute("deploy.release",
+                     {"services": ["core"], "core_ref": "v1.2", "umbrella_ref": "abc"})
+    assert captured["services"] == ["core"]
+    assert captured["repo_refs"] == {"core": "v1.2", "umbrella": "abc"}
+
+
+def test_deploy_release_failure_reports_not_ok(monkeypatch):
+    import deploy_engine
+    monkeypatch.setattr(deploy_engine, "run_release",
+                        lambda services=None, repo_refs=None, emit=None:
+                        type("R", (), {"ok": False})())
+    r = executor.execute("deploy.release", {})
+    assert r.ok is False and "rollback" in r.error

--- a/cloud/bridge/test_deploy_engine.py
+++ b/cloud/bridge/test_deploy_engine.py
@@ -1,5 +1,5 @@
-"""Tests del motor de deploy (FASE 34): orquestación snapshot→deploy→health→rollback con
-git/systemd/http mockeados. No toca el repo real, ni systemctl, ni la red."""
+"""Tests del motor de deploy (FASE 34): modelo repo+service, orquestación snapshot→pin→install
+→restart→health→rollback con git/systemd/http mockeados. No toca el repo real ni la red."""
 import os
 import sys
 
@@ -18,119 +18,155 @@ def state_tmp(tmp_path, monkeypatch):
     return tmp_path
 
 
-class _FakeGit:
-    """Simula `git rev-parse --short HEAD` con un sha que cambia tras un checkout, y registra
-    los comandos corridos. Cualquier otro git/pip/systemctl devuelve ok salvo los marcados fail."""
-    def __init__(self, head="aaaaaaa", fail=()):
-        self.head = head
-        self.fail = set(fail)        # substrings de comando que deben fallar
+class _Fake:
+    """Mock de `_run`: trackea el HEAD por git dir (cambia con checkout), y deja pasar fetch/
+    pip/systemctl salvo los marcados en `fail` (substrings del comando)."""
+    def __init__(self, heads=None, fail=()):
+        self.heads = dict(heads or {})
+        self.fail = set(fail)
         self.calls: list[list[str]] = []
 
-    def __call__(self, args, emit, *, timeout=300, cwd=None):
+    def __call__(self, args, emit, *, timeout=300):
         self.calls.append(args)
         joined = " ".join(args)
         for f in self.fail:
             if f in joined:
-                return de.RunResult(False, f"forced-fail: {f}")
-        if "rev-parse" in args:
-            return de.RunResult(True, self.head)
-        if "checkout" in args:
-            self.head = args[-1].replace("origin/", "")[:7] or self.head  # nuevo sha
+                return de.RunResult(False, f"fail:{f}")
+        if args[0] == "git" and "-C" in args:
+            gd = args[args.index("-C") + 1]
+            if "rev-parse" in args:
+                return de.RunResult(True, self.heads.get(gd, "init000"))
+            if "checkout" in args:
+                self.heads[gd] = (args[-1].replace("origin/", "")[:7]) or self.heads.get(gd, "")
         return de.RunResult(True, "ok")
 
+    def did(self, *substrs) -> bool:
+        return any(all(x in " ".join(c) for x in substrs) for c in self.calls)
 
-def _setup(monkeypatch, fake):
-    monkeypatch.setattr(de, "_run", fake)
+
+def _gd(repo: str) -> str:
+    return de.REPOS[repo].git_dir()
 
 
 # ── happy path ────────────────────────────────────────────────────────────────
 
-def test_release_ok_deploys_and_records_version(state_tmp, monkeypatch):
-    fake = _FakeGit(head="old1234")
-    _setup(monkeypatch, fake)
-    monkeypatch.setattr(de, "_http_ok", lambda url, timeout=5.0: True)
+def test_deploy_core_ok(state_tmp, monkeypatch):
+    fake = _Fake(heads={_gd("core"): "old1234"})
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
 
     res = de.run_release(["core"], {"core": "abc1234"})
     assert res.ok
-    assert res.components["core"]["ok"] is True
-    assert res.components["core"]["rolled_back"] is False
-    # snapshot capturó el sha viejo antes del checkout
-    assert res.components["core"]["snapshot"] == "old1234"
-    # restart de la unit ocurrió
-    assert any("restart" in c and "capitan-core" in c for c in fake.calls)
-    # versión registrada en el estado persistido
-    state = de.load_state()
-    assert state["components"]["core"]["status"] == "deployed"
-    assert state["last_release"]["ok"] is True
+    assert res.repos["core"]["ok"] is True and res.repos["core"]["rolled_back"] is False
+    assert res.services["core"]["ok"] is True
+    # pin (checkout) + restart de la unit
+    assert fake.did("checkout", "abc1234")
+    assert fake.did("restart", "capitan-core")
+    # versión registrada
+    st = de.load_state()
+    assert st["repos"]["core"]["status"] == "deployed"
+    assert st["last_release"]["ok"] is True
 
 
-def test_release_default_ref_is_origin_main(state_tmp, monkeypatch):
-    fake = _FakeGit()
-    _setup(monkeypatch, fake)
+def test_default_services_excluyen_wa(state_tmp, monkeypatch):
+    fake = _Fake()
+    monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
-    de.run_release(["wa"])   # wa no tiene health_url ni requirements
-    assert any(c[:3] == ["git", "-C", os.path.join(de.REPO_DIR, "")] or "checkout" in c
-               and c[-1] == "origin/main" for c in fake.calls)
+    res = de.run_release()   # default
+    assert set(res.services) == set(de.DEFAULT_SERVICES)
+    assert "wa" not in res.services
+    assert not fake.did("restart", "capitan-wa")
 
 
-# ── health falla → rollback ─────────────────────────────────────────────────────
+def test_umbrella_un_ref_para_varios_servicios(state_tmp, monkeypatch):
+    # backoffice y bridge comparten el repo umbrella → un solo checkout del umbrella.
+    fake = _Fake()
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    res = de.run_release(["backoffice", "bridge"], {"umbrella": "v2"})
+    assert res.ok
+    checkouts_umbrella = [c for c in fake.calls
+                          if "checkout" in c and c[c.index("-C") + 1] == _gd("umbrella")]
+    assert len(checkouts_umbrella) == 1   # un único checkout del umbrella
+    assert fake.did("restart", "capitan-backoffice")
+    assert fake.did("restart", "capitan-bridge")
 
-def test_release_health_fail_triggers_rollback(state_tmp, monkeypatch):
-    fake = _FakeGit(head="good999")
-    _setup(monkeypatch, fake)
-    # health HTTP siempre falla → tras el deploy se gatilla rollback; is-active (systemctl) ok
-    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: False)
+
+# ── fallos → rollback ───────────────────────────────────────────────────────────
+
+def test_health_fail_revierte_repo(state_tmp, monkeypatch):
+    fake = _Fake(heads={_gd("core"): "good999"})
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: False)   # health siempre falla
 
     res = de.run_release(["core"], {"core": "bad5678"})
     assert res.ok is False
-    assert res.components["core"]["ok"] is False
-    assert res.components["core"]["rolled_back"] is True
-    # rollback hizo checkout del sha del snapshot (good999)
-    checkouts = [c[-1] for c in fake.calls if "checkout" in c]
-    assert "good999" in checkouts
-    state = de.load_state()
-    assert state["components"]["core"]["status"] in ("rolled_back", "broken")
+    assert res.repos["core"]["ok"] is False
+    assert res.repos["core"]["rolled_back"] is True
+    # rollback hizo checkout del snapshot
+    assert fake.did("checkout", "good999")
 
 
-def test_release_deploy_fail_triggers_rollback(state_tmp, monkeypatch):
-    # el checkout del ref pedido falla → deploy False → rollback
-    fake = _FakeGit(head="snap111", fail=("checkout --quiet bad",))
-    _setup(monkeypatch, fake)
+def test_pin_fail_revierte(state_tmp, monkeypatch):
+    fake = _Fake(heads={_gd("core"): "snap111"}, fail=("checkout --quiet bad",))
+    monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
-
     res = de.run_release(["core"], {"core": "bad"})
     assert res.ok is False
-    assert res.components["core"]["rolled_back"] is True
+    assert res.repos["core"]["rolled_back"] is True
 
 
-def test_release_requirements_install_only_when_version_changed(state_tmp, monkeypatch):
-    # HEAD no cambia (checkout al mismo sha) → no se reinstala requirements
-    fake = _FakeGit(head="same777")
-    monkeypatch.setattr(fake, "head", "same777")
-    # forzar que el checkout NO cambie el head
-    orig = fake.__call__
+def test_atomicidad_por_repo(state_tmp, monkeypatch):
+    # deploy core + backoffice (repos core + umbrella). umbrella health falla, core ok.
+    # core (repo independiente) queda desplegado; umbrella revierte.
+    fake = _Fake(heads={_gd("core"): "c0", _gd("umbrella"): "u0"})
+    monkeypatch.setattr(de, "_run", fake)
+    # health: core (8765) ok, backoffice (8080) falla
+    monkeypatch.setattr(de, "_http_ok", lambda url, timeout=5.0: "8765" in url)
 
-    def _call(args, emit, **kw):
-        if "checkout" in args:
-            fake.calls.append(args)
-            return de.RunResult(True, "ok")   # no muta head
-        return orig(args, emit, **kw)
+    res = de.run_release(["core", "backoffice"], {"core": "c1", "umbrella": "u1"})
+    assert res.ok is False
+    assert res.repos["core"]["ok"] is True            # core sano, no revertido
+    assert res.repos["core"]["rolled_back"] is False
+    assert res.repos["umbrella"]["ok"] is False
+    assert res.repos["umbrella"]["rolled_back"] is True
+    assert fake.did("checkout", "u0")                 # umbrella revertido a su snapshot
+    assert res.services["core"]["ok"] is True
+    assert res.services["backoffice"]["ok"] is False
 
-    monkeypatch.setattr(de, "_run", _call)
+
+def test_install_solo_si_hay_requirements(state_tmp, monkeypatch):
+    # ear no tiene requirements → no se llama pip; core sí.
+    fake = _Fake()
+    monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
-    de.run_release(["core"], {"core": "same777"})
-    assert not any("install" in c for c in fake.calls)
+    de.run_release(["ear"], {"ear": "e1"})
+    assert not fake.did("install")
+    de.run_release(["core"], {"core": "c1"})
+    assert fake.did("install", "core/requirements.txt")
 
 
-# ── targets / parsing ───────────────────────────────────────────────────────────
+# ── resolve / parsing ───────────────────────────────────────────────────────────
 
-def test_unknown_target_raises():
+def test_resolve_default():
+    svcs, refs = de.resolve(None, None)
+    assert svcs == de.DEFAULT_SERVICES
+    assert set(refs) == {"core", "ear", "umbrella"}   # repos de los servicios default
+    assert all(v is None for v in refs.values())
+
+
+def test_resolve_servicio_desconocido():
     with pytest.raises(ValueError):
-        de.get_target("nope")
+        de.resolve(["nope"], None)
+
+
+def test_resolve_repo_desconocido():
+    with pytest.raises(ValueError):
+        de.resolve(["core"], {"nope": "x"})
 
 
 def test_parse_refs():
-    assert de._parse_refs(["core=abc", "ear=v1.2"]) == {"core": "abc", "ear": "v1.2"}
+    assert de._parse_refs(["core=abc", "umbrella=v1.2"]) == {"core": "abc", "umbrella": "v1.2"}
 
 
 def test_parse_refs_invalid():
@@ -138,23 +174,10 @@ def test_parse_refs_invalid():
         de._parse_refs(["coreabc"])
 
 
-def test_emit_callback_receives_lines(state_tmp, monkeypatch):
-    fake = _FakeGit()
-    _setup(monkeypatch, fake)
+def test_emit_recibe_lineas(state_tmp, monkeypatch):
+    fake = _Fake()
+    monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
     lines: list[str] = []
-    res = de.run_release(["wa"], emit=lines.append)
+    res = de.run_release(["bridge"], emit=lines.append)
     assert lines == res.log and len(lines) > 0
-    assert any("deploy wa" in l for l in lines)
-
-
-def test_multiple_targets_independent(state_tmp, monkeypatch):
-    fake = _FakeGit()
-    _setup(monkeypatch, fake)
-    # core sano, ear con health roto
-    monkeypatch.setattr(de, "_http_ok",
-                        lambda url, timeout=5.0: "8765" in url)
-    res = de.run_release(["core", "ear"])
-    assert res.components["core"]["ok"] is True
-    assert res.components["ear"]["ok"] is False
-    assert res.ok is False

--- a/cloud/tests/test_commands.py
+++ b/cloud/tests/test_commands.py
@@ -60,3 +60,40 @@ def test_catalog_summary_shape():
     cat = catalog_summary()
     types = {c["type"] for c in cat}
     assert "service.restart" in types and "voice.reenroll" in types
+
+
+# ── deploy.release (FASE 34): refs por repo + lista de servicios ───────────────
+
+def test_deploy_release_sin_params():
+    assert validate_command("deploy.release", {}) == {}
+
+
+def test_deploy_release_refs_validos():
+    out = validate_command("deploy.release",
+                           {"core_ref": "v1.2.3", "umbrella_ref": "abc1234", "ear_ref": "main"})
+    assert out == {"core_ref": "v1.2.3", "umbrella_ref": "abc1234", "ear_ref": "main"}
+
+
+def test_deploy_release_ref_con_inyeccion_rechazado():
+    for bad in ("a; rm -rf /", "x && y", "$(whoami)", "a b", "v1`id`"):
+        with pytest.raises(CommandError):
+            validate_command("deploy.release", {"core_ref": bad})
+
+
+def test_deploy_release_services_lista_valida():
+    out = validate_command("deploy.release", {"services": ["core", "bridge"]})
+    assert out == {"services": ["core", "bridge"]}
+
+
+def test_deploy_release_services_invalidos():
+    with pytest.raises(CommandError):
+        validate_command("deploy.release", {"services": ["core", "nope"]})
+    with pytest.raises(CommandError):
+        validate_command("deploy.release", {"services": "core"})   # no es lista
+    with pytest.raises(CommandError):
+        validate_command("deploy.release", {"services": []})       # vacía
+
+
+def test_deploy_release_param_desconocido_rechazado():
+    with pytest.raises(CommandError):
+        validate_command("deploy.release", {"wa_ref": "x"})

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,42 +1,27 @@
 #!/usr/bin/env zsh
-# Deploy home-agents al LXC de producción en el SER9.
-# Uso: bash scripts/deploy.sh [--restart-wa]
-
+# Wrapper FINO sobre el MOTOR único de deploy (FASE 34). NO reimplementa lógica: invoca
+# cloud/bridge/deploy_engine.py en el SER9 por SSH. Toda la lógica de deploy (snapshot, pin de
+# ref, install, restart, health-gate, rollback) vive en el motor; este script sólo lo llama.
+# Es el invocador LOCAL (cuando Claude opera desde la LAN); el invocador REMOTO es el comando
+# deploy.release del cloud-bo, que corre el MISMO motor. Ver D1/D9 en masterplan/estado.md.
+#
+# Uso:
+#   bash scripts/deploy.sh                      # default: core+ear+backoffice a HEAD de main
+#   bash scripts/deploy.sh --restart-wa         # + wa
+#   bash scripts/deploy.sh --service bridge     # un servicio puntual
+#   bash scripts/deploy.sh --ref core=v1.2.3    # pin de un ref (rollback/release fijo)
+# Los flags --service/--ref se pasan tal cual al motor (ver deploy_engine.py --help).
 set -euo pipefail
 
-RESTART_WA=0
-[[ "${1:-}" == "--restart-wa" ]] && RESTART_WA=1
-
-echo "=== Deploy home-agents → capitan-lxc ==="
-
-ssh capitan-lxc "
-  set -e
-  cd ~/workspace/home-agents
-  git pull --recurse-submodules
-  ~/home-agents-env/bin/pip install -q -r core/requirements.txt
-  ~/home-agents-env/bin/pip install -q -r backoffice/requirements.txt
-  # capitan-audio-server corre el código de ear/ (audio_server.py) en el LXC: si no se
-  # reinicia, los cambios de ear quedan en disco pero el proceso sigue con el binario viejo.
-  # (El satellite.py de cada NSPanel se despliega aparte con scripts/nspanel.sh — hot-update.)
-  systemctl --user restart capitan-core capitan-backoffice capitan-audio-server
-  echo 'Servicios reiniciados.'
-"
-
-# WA solo se reinicia con --restart-wa (reconectar el cliente WhatsApp es caro:
-# puede requerir re-escanear el QR). El core no depende de WA para arrancar.
-if [[ $RESTART_WA -eq 1 ]]; then
-  echo "Reiniciando WA..."
-  ssh capitan-lxc "systemctl --user restart capitan-wa"
+ARGS=()
+if [[ "${1:-}" == "--restart-wa" ]]; then
+  # Compat con la invocación histórica: default + wa.
+  ARGS=(--service core --service ear --service backoffice --service wa)
+  shift
 fi
+ARGS+=("$@")
 
-echo "=== Smoke test (esperando 5s) ==="
-sleep 5
-ssh capitan-lxc "curl -sf http://localhost:8765/health" && echo "core OK" || echo "core NO responde"
-# El audio-server carga el modelo whisper al arrancar (varios segundos): reintentar ~25s
-# antes de declararlo caído, si no el smoke da falso negativo en cada deploy.
-ssh capitan-lxc "for i in \$(seq 1 12); do curl -sf http://localhost:8766/health >/dev/null && exit 0; sleep 2; done; exit 1" \
-  && echo "audio-server OK" || echo "audio-server NO responde"
-# / redirige a /login (303) cuando no hay sesión — un 3xx es respuesta sana
-ssh capitan-lxc "curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/" | grep -qE '^(2..|3..)' && echo "backoffice OK" || echo "backoffice NO responde"
-
-echo "=== Deploy completo ==="
+echo "=== Deploy home-agents → capitan-lxc (motor FASE 34) ==="
+ssh capitan-lxc \
+  "cd ~/workspace/home-agents && ~/home-agents-env/bin/python cloud/bridge/deploy_engine.py ${ARGS[*]}"
+echo "=== Deploy completo (health-gate y rollback los maneja el motor) ==="


### PR DESCRIPTION
Segunda tanda de FASE 34. Conecta los invocadores al **motor único** y agrega el contrato del release. **Probada contra el SER9 real** (deploy no-op de core: pin→install→restart→health-gate OK).

## Motor — refactor repo+service (resuelve submodule↔umbrella)
Separa dos conceptos que la Tanda 1 mezclaba:
- **Repo** (unidad de versión, pineable): `core`, `ear`, `umbrella`.
- **Service** (unidad de restart/health): core, ear, backoffice, wa, bridge.

Clave del pin independiente: `git checkout` del umbrella **no** toca los working dirs de los submodules (solo el puntero en el índice) → cada repo se pinea con su propio checkout **sin `git submodule update`**. Atomicidad **por-repo** (D7): si un servicio falla health, revierte SU repo; los otros quedan. `bridge` fuera del default (footgun: auto-restart se suicida) y `wa` fuera (restart caro).

## Contrato — `deploy.release` (commands.py)
Validador de **ref git seguro** (`_git_ref`, regex sin metacaracteres de shell) + lista de servicios (`_str_list`). Sin params = todo a HEAD de main. Rechaza inyección (`a; rm -rf /`, `$(...)`, etc.).

## Invocadores sobre el motor único (D1 — cero lógica duplicada)
- `executor.py`: `deploy.run` y `deploy.release` invocan `deploy_engine.run_release` in-process (el bridge corre EN el SER9); reportan el log incremental + ok/rollback. **Se eliminó el `git pull` ciego.**
- `scripts/deploy.sh`: wrapper fino que invoca el motor por SSH.

## Prueba SER9
Read-only: el motor descubre los 3 repos reales (umbrella/core/ear) y sus versiones. Deploy real (no-op de core): `pin → install → restart capitan-core → is-active → /health OK`, versión registrada, `ok: True`, core sano post-prueba.

## Tests
77 passed (motor repo+service, contrato, executor↔motor).

## Bootstrap pendiente (post-merge)
El SER9 tiene el motor Tanda 1 hasta que se actualice el umbrella. Tras mergear: `git pull` en el SER9 + restart `capitan-bridge` para activar el executor/motor nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)