### PR TITLE
FASE 34 Tanda 3b (backend): logs en vivo del deploy

### DIFF
--- a/cloud/app/firestore_db.py
+++ b/cloud/app/firestore_db.py
@@ -96,6 +96,7 @@ def enqueue_command(cmd_type: str, params: dict, issued_by: str) -> dict:
         "issued_at": now.isoformat(),
         "status": "pending",
         "result": None,
+        "progress": [],   # D5: líneas de log en vivo (append-only, capadas en append_progress)
         "ttl_at": now + timedelta(hours=COMMAND_TTL_HOURS),
     }
     db().collection("commands").document(cmd["id"]).set(cmd)
@@ -146,3 +147,31 @@ def recent_commands(limit: int = 50) -> list[dict]:
     col = db().collection("commands")
     q = col.order_by("issued_at", direction=firestore.Query.DESCENDING).limit(limit)
     return [snap.to_dict() for snap in q.stream()]
+
+
+# Tope de líneas de progreso por comando (evita docs Firestore enormes; el deploy típico
+# emite decenas de líneas). Si se excede, se conservan las últimas.
+PROGRESS_MAX_LINES = 800
+
+
+def append_progress(cmd_id: str, lines: list[str]) -> bool:
+    """Añade líneas de log al progreso del comando (D5: logs en vivo). Único writer = el bridge
+    que ejecuta ESE comando, así leer→extender→escribir es seguro. Capa a PROGRESS_MAX_LINES."""
+    if not lines:
+        return True
+    ref = db().collection("commands").document(cmd_id)
+    snap = ref.get()
+    if not snap.exists:
+        return False
+    cur = snap.to_dict().get("progress") or []
+    cur.extend(str(l)[:500] for l in lines)
+    if len(cur) > PROGRESS_MAX_LINES:
+        cur = cur[-PROGRESS_MAX_LINES:]
+    ref.update({"progress": cur})
+    return True
+
+
+def get_command(cmd_id: str) -> dict | None:
+    """Un comando por id (para que el dashboard polee su progreso/estado en vivo)."""
+    snap = db().collection("commands").document(cmd_id).get()
+    return snap.to_dict() if snap.exists else None

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -30,6 +30,7 @@ from .commands import CommandError, catalog_summary, validate_command
 from .models import (
     METRICS_SCHEMA_VERSION,
     SCHEMA_VERSION,
+    CommandProgress,
     CommandRequest,
     CommandResult,
     MetricsSnapshot,
@@ -93,6 +94,15 @@ def commands_pending(sa: str = Depends(require_bridge)):
     return {"commands": fdb.claim_pending()}
 
 
+@app.post("/commands/{cmd_id}/progress")
+def command_progress(cmd_id: str, prog: CommandProgress, sa: str = Depends(require_bridge)):
+    """D5: el bridge postea líneas de log en vivo mientras ejecuta un comando largo (deploy)."""
+    ratelimit.limit_ingest(sa)
+    if not fdb.append_progress(cmd_id, prog.lines):
+        raise HTTPException(status_code=404, detail="comando inexistente")
+    return {"ok": True}
+
+
 @app.post("/commands/{cmd_id}/result")
 def command_result(cmd_id: str, result: CommandResult, sa: str = Depends(require_bridge)):
     if not fdb.set_result(cmd_id, result.ok, result.output, result.error):
@@ -138,6 +148,16 @@ def api_metrics(p: Principal = Depends(require_dashboard_user)):
 def api_commands(p: Principal = Depends(require_dashboard_user)):
     _require_view_full(p)  # la auditoría sólo para roles con view_full
     return {"commands": fdb.recent_commands()}
+
+
+@app.get("/api/commands/{cmd_id}")
+def api_command(cmd_id: str, p: Principal = Depends(require_dashboard_user)):
+    """D5: el dashboard polea un comando para ver su progreso/estado en vivo durante el deploy."""
+    _require_view_full(p)
+    cmd = fdb.get_command(cmd_id)
+    if not cmd:
+        raise HTTPException(status_code=404, detail="comando inexistente")
+    return {"command": cmd}
 
 
 @app.get("/api/catalog")

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -104,3 +104,8 @@ class CommandResult(BaseModel):
     ok: bool
     output: str = ""
     error: str = ""
+
+
+class CommandProgress(BaseModel):
+    """Líneas de log en vivo que el bridge postea a POST /commands/{id}/progress (D5)."""
+    lines: list[str] = Field(default_factory=list)

--- a/cloud/bridge/cloud_bridge.py
+++ b/cloud/bridge/cloud_bridge.py
@@ -62,6 +62,36 @@ def push_metrics(sess: AuthorizedSession) -> None:
     log.info("push métricas OK (ventana %dh)", snap.get("window_hours"))
 
 
+# Cada cuántas líneas de progreso se hace un POST al cloud (batch para no spamear Firestore).
+PROGRESS_BATCH = int(os.environ.get("PROGRESS_BATCH", "5"))
+
+
+def _progress_emitter(sess: AuthorizedSession, cid: str):
+    """Devuelve un callback `emit(line)` que acumula líneas de log del comando y las postea en
+    lotes a /commands/{id}/progress (D5: logs en vivo). Best-effort: un fallo de red al postear
+    progreso NO interrumpe la ejecución del comando (el resultado final igual se reporta)."""
+    buf: list[str] = []
+
+    def _flush() -> None:
+        if not buf:
+            return
+        try:
+            # Copia: el buffer se vacía a continuación; no compartir la referencia con el POST.
+            sess.post(f"{CLOUD_URL}/commands/{cid}/progress",
+                      json={"lines": list(buf)}, timeout=10)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("no se pudo postear progreso de %s: %s", cid, exc)
+        buf.clear()
+
+    def emit(line: str) -> None:
+        buf.append(line)
+        if len(buf) >= PROGRESS_BATCH:
+            _flush()
+
+    emit.flush = _flush  # type: ignore[attr-defined]
+    return emit
+
+
 def poll_and_execute(sess: AuthorizedSession) -> None:
     r = sess.get(f"{CLOUD_URL}/commands/pending", timeout=15)
     r.raise_for_status()
@@ -69,11 +99,13 @@ def poll_and_execute(sess: AuthorizedSession) -> None:
         cid, ctype, params = cmd["id"], cmd["type"], cmd.get("params", {})
         log.info("comando %s type=%s params=%s issued_by=%s",
                  cid, ctype, params, cmd.get("issued_by"))
+        emit = _progress_emitter(sess, cid)
         try:
             clean = validate_command(ctype, params)  # re-validación defensiva
-            result = executor.execute(ctype, clean)
+            result = executor.execute(ctype, clean, emit=emit)
         except CommandError as exc:
             result = executor.ExecResult(False, "", f"rechazado por catálogo: {exc}")
+        emit.flush()  # vaciar el último lote de progreso antes del resultado
         log.info("comando %s → ok=%s %s", cid, result.ok, result.error or "")
         try:
             rr = sess.post(f"{CLOUD_URL}/commands/{cid}/result",

--- a/cloud/bridge/executor.py
+++ b/cloud/bridge/executor.py
@@ -55,31 +55,38 @@ def _logs_tail(p: dict) -> ExecResult:
     return _run(["journalctl", "--user", "-u", p["service"], "-n", lines, "--no-pager"], timeout=15)
 
 
-def _run_engine(services, repo_refs) -> ExecResult:
+def _run_engine(services, repo_refs, emit=None) -> ExecResult:
     """Invoca el MOTOR único de deploy (FASE 34). El executor NO reimplementa lógica de deploy:
     sólo traduce comando→args, corre el motor in-process (el bridge corre EN el SER9) y reporta
-    el log incremental + el ok/rollback. Ver deploy_engine.run_release / D1, D7."""
+    el log incremental + el ok/rollback. `emit` (D5): callback de progreso en vivo — cada línea
+    del motor se reenvía al cloud mientras el deploy corre. Ver deploy_engine.run_release / D1."""
     import deploy_engine
     lines: list[str] = []
-    res = deploy_engine.run_release(services, repo_refs or None, emit=lines.append)
+
+    def _emit(line: str) -> None:
+        lines.append(line)
+        if emit:
+            emit(line)
+
+    res = deploy_engine.run_release(services, repo_refs or None, emit=_emit)
     err = "" if res.ok else "deploy con fallos (ver rollback en el log)"
     return ExecResult(res.ok, "\n".join(lines), err)
 
 
-def _deploy_run(p: dict) -> ExecResult:
+def _deploy_run(p: dict, emit=None) -> ExecResult:
     """Compat: deploy.run = release de los servicios default a HEAD de main (+ wa si restart_wa)."""
     import deploy_engine
     services = list(deploy_engine.DEFAULT_SERVICES) + (["wa"] if p.get("restart_wa") else [])
-    return _run_engine(services, None)
+    return _run_engine(services, None, emit)
 
 
-def _deploy_release(p: dict) -> ExecResult:
+def _deploy_release(p: dict, emit=None) -> ExecResult:
     """FASE 34: release con pin de ref por repo. `services` acota qué desplegar (default del
     motor si se omite); core_ref/ear_ref/umbrella_ref pinean cada repo (default origin/main)."""
     repo_refs = {repo: p[key] for repo, key in
                  (("core", "core_ref"), ("ear", "ear_ref"), ("umbrella", "umbrella_ref"))
                  if p.get(key)}
-    return _run_engine(p.get("services"), repo_refs)
+    return _run_engine(p.get("services"), repo_refs, emit)
 
 
 def _config_reload(p: dict) -> ExecResult:
@@ -124,10 +131,17 @@ HANDLERS = {
     "voice.reenroll": _voice_reenroll,
 }
 
+# Comandos largos que emiten progreso EN VIVO (D5): el handler acepta un callback `emit` y va
+# reportando líneas mientras corre (deploy). El resto es fire-and-result (sólo resultado final).
+STREAMING = {"deploy.run", "deploy.release"}
 
-def execute(cmd_type: str, params: dict) -> ExecResult:
-    """Despacha al handler concreto. El tipo ya fue validado contra el catálogo."""
+
+def execute(cmd_type: str, params: dict, emit=None) -> ExecResult:
+    """Despacha al handler concreto. El tipo ya fue validado contra el catálogo. `emit`, si se
+    pasa, recibe líneas de progreso en vivo para los comandos de STREAMING."""
     handler = HANDLERS.get(cmd_type)
     if handler is None:
         return ExecResult(False, "", f"sin handler para {cmd_type!r}")
+    if cmd_type in STREAMING:
+        return handler(params, emit)
     return handler(params)

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -172,3 +172,63 @@ def test_deploy_release_failure_reports_not_ok(monkeypatch):
                         type("R", (), {"ok": False})())
     r = executor.execute("deploy.release", {})
     assert r.ok is False and "rollback" in r.error
+
+
+# ── Logs en vivo (D5): emit del executor + batching del bridge ─────────────────
+
+def test_execute_passes_emit_to_deploy(monkeypatch):
+    import deploy_engine
+
+    def _fake(services=None, repo_refs=None, emit=None):
+        if emit:
+            emit("línea del motor")
+        return type("R", (), {"ok": True})()
+
+    monkeypatch.setattr(deploy_engine, "run_release", _fake)
+    got = []
+    r = executor.execute("deploy.run", {}, emit=got.append)
+    assert r.ok and "línea del motor" in got
+
+
+def test_execute_ignores_emit_for_non_streaming(monkeypatch):
+    # service.restart no es streaming → execute no le pasa emit y no rompe.
+    class P:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+    monkeypatch.setattr(executor.subprocess, "run", lambda *a, **k: P())
+    r = executor.execute("service.restart", {"service": "capitan-core"}, emit=lambda l: None)
+    assert r.ok
+
+
+def test_progress_emitter_batches_and_flushes(monkeypatch):
+    # Importa cloud_bridge con los módulos google mockeados (no están en el venv de test) y las
+    # env vars que lee a nivel módulo.
+    import os
+    import sys
+    from unittest.mock import MagicMock
+    for m in ("google", "google.auth", "google.auth.transport",
+              "google.auth.transport.requests", "google.oauth2", "google.oauth2.service_account"):
+        sys.modules.setdefault(m, MagicMock())
+    os.environ.setdefault("CLOUD_URL", "https://cloud.test")
+    os.environ.setdefault("BRIDGE_SA_KEY", "{}")
+    import cloud_bridge
+
+    posts = []
+
+    class _Sess:
+        def post(self, url, json=None, timeout=None):
+            posts.append((url, json))
+            return type("R", (), {"raise_for_status": lambda self: None})()
+
+    monkeypatch.setattr(cloud_bridge, "PROGRESS_BATCH", 2)
+    emit = cloud_bridge._progress_emitter(_Sess(), "cmd1")
+    emit("a")
+    assert posts == []                      # batch incompleto, sin POST
+    emit("b")
+    assert len(posts) == 1                  # flush al llenar el lote
+    assert posts[0][0].endswith("/commands/cmd1/progress")
+    assert posts[0][1] == {"lines": ["a", "b"]}
+    emit("c")
+    emit.flush()
+    assert posts[1][1] == {"lines": ["c"]}  # flush manual vacía el resto

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,6 +22,8 @@ fi
 ARGS+=("$@")
 
 echo "=== Deploy home-agents → capitan-lxc (motor FASE 34) ==="
+# Versionado semver activo por defecto en el deploy local (igual que el bridge). Se puede
+# desactivar para un deploy puntual con DEPLOY_TAG_RELEASES=false bash scripts/deploy.sh.
 ssh capitan-lxc \
-  "cd ~/workspace/home-agents && ~/home-agents-env/bin/python cloud/bridge/deploy_engine.py ${ARGS[*]}"
+  "cd ~/workspace/home-agents && DEPLOY_TAG_RELEASES=${DEPLOY_TAG_RELEASES:-true} ~/home-agents-env/bin/python cloud/bridge/deploy_engine.py ${ARGS[*]}"
 echo "=== Deploy completo (health-gate y rollback los maneja el motor) ==="


### PR DESCRIPTION
Backend de los **logs en vivo** (D5): el comando pasa de fire-and-result a **progreso incremental**.

- `executor.execute(emit)`: deploy.run/release reenvían cada línea del motor mientras corre; el resto sigue fire-and-result.
- `cloud_bridge._progress_emitter`: batchea líneas y las postea a `/commands/{id}/progress`; flush antes del result. Best-effort (no interrumpe el comando si falla el POST).
- `firestore_db`: `progress[]` en el comando, `append_progress()` (capado, single-writer), `get_command()`.
- `main.py`: `POST /commands/{id}/progress` (bridge) + `GET /api/commands/{id}` (dashboard polea).
- `deploy.sh`: propaga `DEPLOY_TAG_RELEASES` (versionado ya validado: v0.1.0 en los 3 repos).

**Falta** (siguiente): frontend del cloud-bo que polee y muestre el progreso en streaming + deploy del cloud para activar el endpoint.

Tests: emit del executor (streaming vs no), batching+flush del bridge. **86 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)