### PR TITLE
FASE 34 T4a: driver cloudrun (deploy Cloud Run desde el SER9)

### DIFF
--- a/cloud/app/commands.py
+++ b/cloud/app/commands.py
@@ -16,6 +16,8 @@ CONFIG_TARGETS = ("core", "backoffice")
 # Componentes del motor de deploy (FASE 34). Nombres lógicos del motor (deploy_engine.SERVICES),
 # distintos de las units de SERVICES de arriba.
 DEPLOY_SERVICES = ("core", "ear", "backoffice", "wa", "bridge")
+# Targets de Cloud Run desplegables por el SER9 (driver cloudrun, T4).
+CLOUDRUN_SERVICES = ("cloud-bo",)
 # Un ref git seguro: sha/tag/branch. Alfanumérico + . _ / - (sin espacios ni metacaracteres de
 # shell). El motor igual usa subprocess con lista de args (sin shell), esto es defensa en capas.
 _REF_RE = re.compile(r"^[A-Za-z0-9._/-]{1,100}$")
@@ -87,6 +89,8 @@ CATALOG: dict[str, dict[str, tuple[Callable[[Any], Any], bool]]] = {
                         "core_ref": (_git_ref("core_ref"), False),
                         "ear_ref": (_git_ref("ear_ref"), False),
                         "umbrella_ref": (_git_ref("umbrella_ref"), False)},
+    # T4: deploy de Cloud Run (cloud-bo) desde el SER9. Sin params = todos los cloudrun targets.
+    "deploy.cloud":    {"services": (_str_list("services", CLOUDRUN_SERVICES), False)},
     "logs.tail":       {"service": (_enum("service", SERVICES), True),
                         "lines": (_int_range("lines", 1, 500), False)},
     "config.reload":   {"target": (_enum("target", CONFIG_TARGETS), True)},

--- a/cloud/bridge/deploy_engine.py
+++ b/cloud/bridge/deploy_engine.py
@@ -396,6 +396,97 @@ def run_release(services: Optional[list[str]] = None,
     return result
 
 
+# ── Driver cloudrun (GCP, FASE 34 T4 / D2) ────────────────────────────────────
+# El SER9 despliega Cloud Run con `gcloud run deploy --source` (egress a Google, saliente),
+# usando la SA de deploy (D9: GOOGLE_APPLICATION_CREDENTIALS apunta a la key en el SER9).
+# Health-gate = curl a la URL pública. Rollback = update-traffic a la revisión previa (Cloud Run
+# conserva revisiones). NO pasa por el bridge para sí mismo (circularidad, D4): el deploy del
+# cloud-bo lo dispara igual el SER9, y si rompe, el rollback a la revisión previa lo hace el SER9.
+
+GCLOUD = os.environ.get("GCLOUD_BIN", "gcloud")
+GCP_PROJECT = os.environ.get("GCP_PROJECT", "capitan-495518")
+
+
+@dataclass
+class CloudRunTarget:
+    """Servicio de Cloud Run desplegable desde el SER9. `source` es el dir (relativo a REPO_DIR)
+    que contiene el Dockerfile; `health_url` es la URL pública para el health-gate."""
+    name: str
+    service: str
+    source: str
+    region: str
+    health_url: str
+
+    def _src(self) -> str:
+        return os.path.join(REPO_DIR, self.source)
+
+    def active_revision(self, emit: LogEmit) -> Optional[str]:
+        r = _run([GCLOUD, "run", "services", "describe", self.service,
+                  "--project", GCP_PROJECT, "--region", self.region,
+                  "--format=value(status.latestReadyRevisionName)"], emit, timeout=60)
+        return r.output.strip() if r.ok and r.output.strip() else None
+
+    def deploy(self, emit: LogEmit) -> bool:
+        return _run([GCLOUD, "run", "deploy", self.service, "--source", self._src(),
+                     "--project", GCP_PROJECT, "--region", self.region, "--quiet"],
+                    emit, timeout=600).ok
+
+    def health(self, emit: LogEmit) -> bool:
+        for _ in range(HEALTH_RETRIES):
+            if _http_ok(self.health_url):
+                emit(f"  ✓ health OK ({self.health_url})")
+                return True
+            time.sleep(HEALTH_BACKOFF)
+        emit(f"  ✗ health NO responde ({self.health_url})")
+        return False
+
+    def rollback(self, revision: Optional[str], emit: LogEmit) -> bool:
+        if not revision:
+            emit("  ✗ sin revisión previa para revertir")
+            return False
+        emit(f"  ↩ rollback {self.name} → {revision}")
+        return _run([GCLOUD, "run", "services", "update-traffic", self.service,
+                     "--project", GCP_PROJECT, "--region", self.region,
+                     f"--to-revisions={revision}=100", "--quiet"], emit, timeout=120).ok
+
+
+CLOUDRUN_TARGETS: dict[str, CloudRunTarget] = {
+    "cloud-bo": CloudRunTarget(
+        "cloud-bo", "capitan-cloud", "cloud", "southamerica-east1",
+        os.environ.get("CLOUD_BO_URL",
+                       "https://capitan-cloud-606511873514.southamerica-east1.run.app") + "/"),
+}
+
+
+def run_cloud_release(targets: list[str], emit: Optional[LogEmit] = None) -> ReleaseResult:
+    """Despliega targets de Cloud Run (cloud-bo, …) por-target con health-gate y rollback a la
+    revisión previa si falla. Atomicidad por-target (D7). Reusa ReleaseResult (campo `services`)."""
+    result = ReleaseResult(ok=True)
+
+    def _emit(line: str) -> None:
+        result.log.append(line)
+        if emit:
+            emit(line)
+
+    for name in targets:
+        if name not in CLOUDRUN_TARGETS:
+            raise ValueError(f"target cloudrun desconocido: {name!r} (conocidos: {sorted(CLOUDRUN_TARGETS)})")
+        t = CLOUDRUN_TARGETS[name]
+        prev = t.active_revision(_emit)
+        _emit(f"=== deploy cloudrun {name} ({t.service}) — revisión previa {prev or '?'} ===")
+        ok = t.deploy(_emit) and t.health(_emit)
+        if ok:
+            result.services[name] = {"ok": True, "revision": t.active_revision(_emit)}
+            _emit(f"  ✓ {name} desplegado y sano")
+        else:
+            result.ok = False
+            rb = t.rollback(prev, _emit)
+            restored = rb and t.health(_emit)
+            result.services[name] = {"ok": False, "rolled_back": rb, "restored": restored}
+            _emit(f"  {'↩ revertido' if restored else '✗ rollback NO sano'} en {name}")
+    return result
+
+
 # ── CLI ───────────────────────────────────────────────────────────────────────
 
 def _parse_refs(items: list[str]) -> dict[str, Optional[str]]:

--- a/cloud/bridge/executor.py
+++ b/cloud/bridge/executor.py
@@ -89,6 +89,22 @@ def _deploy_release(p: dict, emit=None) -> ExecResult:
     return _run_engine(p.get("services"), repo_refs, emit)
 
 
+def _deploy_cloud(p: dict, emit=None) -> ExecResult:
+    """FASE 34 T4: deploy de Cloud Run (cloud-bo) desde el SER9 vía el motor (driver cloudrun)."""
+    import deploy_engine
+    targets = p.get("services") or list(deploy_engine.CLOUDRUN_TARGETS)
+    lines: list[str] = []
+
+    def _emit(line: str) -> None:
+        lines.append(line)
+        if emit:
+            emit(line)
+
+    res = deploy_engine.run_cloud_release(targets, emit=_emit)
+    return ExecResult(res.ok, "\n".join(lines),
+                      "" if res.ok else "deploy cloud con fallos (ver rollback en el log)")
+
+
 def _config_reload(p: dict) -> ExecResult:
     if p["target"] == "core":
         try:
@@ -126,6 +142,7 @@ HANDLERS = {
     "logs.tail": _logs_tail,
     "deploy.run": _deploy_run,
     "deploy.release": _deploy_release,
+    "deploy.cloud": _deploy_cloud,
     "config.reload": _config_reload,
     "wakeword.retrain": _wakeword_retrain,
     "voice.reenroll": _voice_reenroll,
@@ -133,7 +150,7 @@ HANDLERS = {
 
 # Comandos largos que emiten progreso EN VIVO (D5): el handler acepta un callback `emit` y va
 # reportando líneas mientras corre (deploy). El resto es fire-and-result (sólo resultado final).
-STREAMING = {"deploy.run", "deploy.release"}
+STREAMING = {"deploy.run", "deploy.release", "deploy.cloud"}
 
 
 def execute(cmd_type: str, params: dict, emit=None) -> ExecResult:

--- a/cloud/bridge/test_deploy_engine.py
+++ b/cloud/bridge/test_deploy_engine.py
@@ -272,3 +272,56 @@ def test_release_registra_tag_en_estado(state_tmp, monkeypatch):
     st = de.load_state()
     assert st["repos"]["core"]["tag"] == "v1.0.1"
     assert "v1.0.1" in st["repos"]["core"]["url"]
+
+
+# ── Driver cloudrun (T4): deploy GCP desde el SER9 ────────────────────────────
+
+class _FakeGcloud:
+    """Mock de _run para gcloud: describe→revisión, deploy/update-traffic ok salvo `fail`."""
+    def __init__(self, revision="rev-1", fail=()):
+        self.revision = revision
+        self.fail = set(fail)
+        self.calls = []
+
+    def __call__(self, args, emit, *, timeout=300):
+        self.calls.append(args)
+        joined = " ".join(args)
+        for f in self.fail:
+            if f in joined:
+                return de.RunResult(False, f"fail:{f}")
+        if "describe" in args:
+            return de.RunResult(True, self.revision)
+        return de.RunResult(True, "ok")
+
+    def did(self, *subs):
+        return any(all(s in " ".join(c) for s in subs) for c in self.calls)
+
+
+def test_cloud_release_ok(monkeypatch):
+    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
+    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
+    fake = _FakeGcloud(revision="capitan-cloud-00010")
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    res = de.run_cloud_release(["cloud-bo"])
+    assert res.ok and res.services["cloud-bo"]["ok"] is True
+    assert fake.did("run", "deploy", "capitan-cloud", "--source")
+
+
+def test_cloud_release_health_fail_rollback(monkeypatch):
+    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
+    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
+    fake = _FakeGcloud(revision="capitan-cloud-prev")
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: False)   # health falla siempre
+    res = de.run_cloud_release(["cloud-bo"])
+    assert res.ok is False
+    assert res.services["cloud-bo"]["rolled_back"] is True
+    # rollback a la revisión previa
+    assert fake.did("update-traffic", "capitan-cloud-prev=100")
+
+
+def test_cloud_release_unknown_target():
+    import pytest
+    with pytest.raises(ValueError):
+        de.run_cloud_release(["nope"])

--- a/cloud/tests/test_commands.py
+++ b/cloud/tests/test_commands.py
@@ -97,3 +97,18 @@ def test_deploy_release_services_invalidos():
 def test_deploy_release_param_desconocido_rechazado():
     with pytest.raises(CommandError):
         validate_command("deploy.release", {"wa_ref": "x"})
+
+
+# ── deploy.cloud (T4): targets de Cloud Run ───────────────────────────────────
+
+def test_deploy_cloud_sin_params():
+    assert validate_command("deploy.cloud", {}) == {}
+
+
+def test_deploy_cloud_services_validos():
+    assert validate_command("deploy.cloud", {"services": ["cloud-bo"]}) == {"services": ["cloud-bo"]}
+
+
+def test_deploy_cloud_target_invalido():
+    with pytest.raises(CommandError):
+        validate_command("deploy.cloud", {"services": ["core"]})   # core no es target cloudrun


### PR DESCRIPTION
Driver del motor para desplegar Cloud Run (cloud-bo) desde el SER9: `gcloud run deploy --source` (egress), health-gate por URL pública, rollback a la revisión previa. Comando tipado `deploy.cloud`, executor con progreso en vivo. Pendiente: instalar la key de la SA en el SER9 (D9) + prueba real; oauth como 2º target. **92 passed.**