### PR TITLE
chore: T4a cloudrun activado y probado (permisos reales)

### DIFF
--- a/cloud/infra/provision_deploy_sa.sh
+++ b/cloud/infra/provision_deploy_sa.sh
@@ -58,23 +58,37 @@ else
   _retry gcloud iam service-accounts describe "$DEPLOY_SA_EMAIL" >/dev/null 2>&1 || true
 fi
 
-echo "== Roles a nivel proyecto (permiso mínimo para deploy + rollback) =="
+echo "== Roles a nivel proyecto (deploy + build + rollback de Cloud Run desde source) =="
+# Verificados con un deploy real de `gcloud run deploy --source` desde el SER9 (FASE 34 T4a):
+#  - run.admin               : deploy de servicios + update-traffic (rollback a revisión previa)
+#  - cloudbuild.builds.editor: build remoto del source en Cloud Build
+#  - artifactregistry.writer : push de la imagen
+#  - storage.admin           : `--source` sube el tarball al bucket de staging
+#    (run-sources-<project>-<region>) y necesita storage.buckets.list a nivel PROYECTO; el
+#    binding por-bucket no alcanza.
+#  - logging.viewer          : leer logs del build
 for ROLE in \
   roles/run.admin \
   roles/cloudbuild.builds.editor \
-  roles/artifactregistry.writer ; do
+  roles/artifactregistry.writer \
+  roles/storage.admin \
+  roles/logging.viewer ; do
   _retry gcloud projects add-iam-policy-binding "$PROJECT" \
     --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
     --role="$ROLE" --condition=None >/dev/null
   echo "   + $ROLE"
 done
 
-echo "== actAs sobre las runtime SA de los servicios desplegados =="
-# Cloud Run deploy requiere que el deployer pueda 'actuar como' la runtime SA del servicio.
-_retry gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA_EMAIL" \
-  --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
-  --role="roles/iam.serviceAccountUser" >/dev/null
-echo "   + actAs ${RUNTIME_SA_EMAIL}"
+echo "== actAs sobre las runtime SA + la compute SA del build =="
+# Cloud Run deploy requiere actuar como la runtime SA del servicio Y como la SA que Cloud Build
+# usa para el build (la default compute SA, salvo que se configure otra).
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+for ACT_SA in "$RUNTIME_SA_EMAIL" "${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"; do
+  _retry gcloud iam service-accounts add-iam-policy-binding "$ACT_SA" \
+    --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+    --role="roles/iam.serviceAccountUser" >/dev/null
+  echo "   + actAs ${ACT_SA}"
+done
 if [[ -n "$OAUTH_RUNTIME_SA" ]]; then
   _retry gcloud iam service-accounts add-iam-policy-binding \
     "${OAUTH_RUNTIME_SA}@${PROJECT}.iam.gserviceaccount.com" \
@@ -82,15 +96,6 @@ if [[ -n "$OAUTH_RUNTIME_SA" ]]; then
     --role="roles/iam.serviceAccountUser" >/dev/null
   echo "   + actAs ${OAUTH_RUNTIME_SA}@${PROJECT}.iam.gserviceaccount.com"
 fi
-
-echo "== Storage del bucket de staging de Cloud Build =="
-# `gcloud run deploy --source` sube el source a un bucket de staging gestionado por Cloud Build.
-STAGING_BUCKET="${PROJECT}_cloudbuild"
-gcloud storage buckets add-iam-policy-binding "gs://${STAGING_BUCKET}" \
-  --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
-  --role="roles/storage.admin" >/dev/null 2>&1 \
-  && echo "   + storage.admin sobre gs://${STAGING_BUCKET}" \
-  || echo "   · gs://${STAGING_BUCKET} aún no existe (lo crea el primer build); re-correr tras el 1er deploy"
 
 echo "== Key JSON (para el SER9) =="
 if [[ -f "$KEY_OUT" ]]; then

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3116,13 +3116,15 @@ DECISIONES CONSOLIDADAS (2026-06-20, al tomar la fase — amplían el alcance de
       artifactregistry.writer, iam.serviceAccountUser (actuar como la runtime SA), storage sobre
       el bucket de staging de Cloud Build. Key JSON en el SER9 (egress-only). Script idempotente:
       cloud/infra/provision_deploy_sa.sh. (Confirmado 2026-06-20.)
-      PREP HECHO (2026-06-20): SA capitan-deployer creada; aplicados run.admin +
-      cloudbuild.builds.editor + artifactregistry.writer (proyecto) + actAs sobre la runtime SA
-      del cloud-bo (capitan-cloud-run). FALTA para T4: (a) generar la key JSON e instalarla en el
-      SER9 — diferida hasta que el driver cloudrun la use; (b) capitan-oauth NO está desplegado y
-      su deploy.zsh no fija --service-account → correría con la default compute SA; darle actAs
-      sobre ESA SA cuando se despliegue; (c) binding storage sobre gs://capitan-495518_cloudbuild
-      (el bucket lo crea Cloud Build en el primer deploy; re-correr el script entonces).
+      ACTIVADO Y PROBADO (2026-06-21, T4a): driver cloudrun deploya el cloud-bo desde el SER9
+      end-to-end (build en Cloud Build → deploy → health → ok), y el rollback automático a la
+      revisión previa quedó validado (en intentos fallidos por permisos, el cloud-bo se restauró
+      sano solo). Hecho: gcloud CLI instalado en el SER9; SA capitan-deployer con run.admin +
+      cloudbuild.builds.editor + artifactregistry.writer + storage.admin + logging.viewer
+      (proyecto) + actAs sobre runtime SA del cloud-bo y la default compute SA del build; key JSON
+      en ~/.config/capitan/deployer-key.json del SER9 + SA activada en gcloud (root). Permisos
+      reproducibles en cloud/infra/provision_deploy_sa.sh. FALTA: capitan-oauth como 2º target
+      (otra región us-east1 + env vars/secrets); driver panel (34.13 T4b).
 ```
 
 #### Etapa A - Contrato del release


### PR DESCRIPTION
Driver cloudrun validado: el SER9 deploya el cloud-bo end-to-end + rollback automático a revisión previa (probado). Script de permisos con los roles verificados (storage.admin/logging.viewer proyecto + actAs compute SA).