### PR TITLE
FASE 34 T5: matriz de versiones (snapshot + cloud-bo)

### DIFF
--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -74,6 +74,9 @@ class StateSnapshot(BaseModel):
     recent_commands: list[RecentCommand] = Field(default_factory=list)
     wakeword: Wakeword = Field(default_factory=Wakeword)
     users_summary: list[UserSummary] = Field(default_factory=list)
+    # Matriz de versiones dispositivo×componente (FASE 34 T5): {ser9: {repo: {version,tag,url}},
+    # panels: [{node_id,version,up_to_date}], satellite_expected}. Opcional (retrocompat).
+    versions: dict[str, Any] = Field(default_factory=dict)
 
 
 class MetricsSnapshot(BaseModel):

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -41,6 +41,11 @@
     </section>
 
     <section class="card">
+      <h2>Versiones desplegadas</h2>
+      <div id="versions"></div>
+    </section>
+
+    <section class="card">
       <h2>Últimos comandos de voz</h2>
       <table id="recent"><tbody></tbody></table>
     </section>
@@ -115,6 +120,25 @@ async function api(path, opts = {}) {
 
 function dot(ok) { return ok ? "🟢" : "🔴"; }
 
+// Matriz de versiones (FASE 34 T5): repos del SER9 con link al release de GitHub + paneles
+// con su versión y si están al día respecto del código que sirve el SER9.
+function renderVersions(v) {
+  const esc = (s) => String(s == null ? "" : s).replace(/[<>&]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;"}[c]));
+  const ser9 = v.ser9 || {};
+  const repos = Object.entries(ser9).map(([name, i]) => {
+    const ver = esc(i.tag || i.version || "?");
+    const label = i.url ? `<a href="${esc(i.url)}" target="_blank">${ver}</a>` : ver;
+    return `<div><b>${esc(name)}</b> ${label}${i.tag && i.version ? ` <span class="muted">(${esc(i.version)})</span>` : ""}</div>`;
+  }).join("");
+  const panels = (v.panels || []).map(p =>
+    `<div>${p.up_to_date ? "🟢" : "⚠️"} <b>${esc(p.node_id)}</b> <span class="muted">${esc(p.version) || "—"}</span></div>`
+  ).join("");
+  $("versions").innerHTML =
+    `<h3>SER9 (repos)</h3><div class="grid">${repos || "<span class='muted'>sin datos</span>"}</div>`
+    + `<h3>Paneles${v.satellite_expected ? ` <span class="muted">esperado ${esc(v.satellite_expected)}</span>` : ""}</h3>`
+    + `<div class="grid">${panels || "<span class='muted'>sin paneles</span>"}</div>`;
+}
+
 let CAPS = {};
 
 async function refresh() {
@@ -129,6 +153,7 @@ async function refresh() {
       .map(k => `<div><b>${k.replace("_ms","").toUpperCase()}</b> ${L[k] ?? "—"}</div>`).join("");
     $("agents").innerHTML = (state.agents || [])
       .map(a => `<div>${dot(a.active)} <b>${a.id}</b>${a.proactive ? " ⚡" : ""}</div>`).join("");
+    renderVersions(state.versions || {});
     $("recent").querySelector("tbody").innerHTML = (state.recent_commands || [])
       .map(c => `<tr><td>${dot(c.ok)}</td><td>${c.text}</td><td class="muted">${c.agent}</td><td class="muted">${c.latency_ms ?? "—"}ms</td></tr>`).join("");
   } catch (e) { $("updated").textContent = "error: " + e.message; }

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -158,6 +158,33 @@ def _users() -> list[dict]:
     return out
 
 
+def _versions(nodes: list[dict]) -> dict:
+    """Matriz de versiones dispositivo×componente (FASE 34 T5 / 34.7/34.14): por repo del SER9
+    (core/ear/umbrella) el sha+tag+link al release de GitHub que corre, y por panel la versión
+    de código reportada (heartbeat) vs la esperada (la que sirve el audio_server). Best-effort."""
+    out: dict = {"ser9": {}, "panels": [], "satellite_expected": None}
+    try:
+        import deploy_engine as de
+        for name, repo in de.REPOS.items():
+            gd = repo.git_dir()
+            sha = repo.head(de._noop_emit)
+            tag = de._tag_at(gd, sha, de._noop_emit) if sha else None
+            slug = de._repo_slug(gd, de._noop_emit)
+            url = f"https://github.com/{slug}/releases/tag/{tag}" if (slug and tag) else None
+            out["ser9"][name] = {"version": sha, "tag": tag, "url": url}
+    except Exception:
+        pass
+    expected = (_get(f"{AUDIO_URL}/satellite/version") or {}).get("version")
+    out["satellite_expected"] = (expected or "")[:12] or None
+    for n in nodes:
+        v = n.get("version")
+        out["panels"].append({
+            "node_id": n.get("node_id"), "version": v,
+            "up_to_date": bool(v and expected and expected[:12] == v),
+        })
+    return out
+
+
 def build_snapshot() -> dict:
     """Arma el snapshot completo. Nunca lanza: campos faltantes quedan vacíos."""
     nodes = _nodes()
@@ -171,4 +198,5 @@ def build_snapshot() -> dict:
         "recent_commands": _recent_commands(nodes),
         "wakeword": _wakeword(nodes),
         "users_summary": _users(),
+        "versions": _versions(nodes),
     }

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -232,3 +232,26 @@ def test_progress_emitter_batches_and_flushes(monkeypatch):
     emit("c")
     emit.flush()
     assert posts[1][1] == {"lines": ["c"]}  # flush manual vacía el resto
+
+
+# ── Matriz de versiones en el snapshot (FASE 34 T5) ───────────────────────────
+
+def test_snapshot_versions_panels_y_ser9():
+    def fake_get(url, timeout=4):
+        if url.endswith("/satellite/version"):
+            return {"version": "abc123def456789xyz"}
+        if url.endswith("/nodes"):
+            return [{"node_id": "comedor", "state": "active", "version": "abc123def456"},
+                    {"node_id": "pieza", "state": "active", "version": "vieja000"}]
+        if url.endswith("/health"):
+            return {"status": "ok", "nodes": 2}
+        return None
+    with patch.object(snapshot, "_get", fake_get), \
+         patch.object(snapshot, "_systemctl_active", lambda u: True):
+        snap = snapshot.build_snapshot()
+    v = snap["versions"]
+    assert isinstance(v["ser9"], dict)                  # repos del SER9 (best-effort)
+    assert v["satellite_expected"] == "abc123def456"    # [:12]
+    byid = {p["node_id"]: p for p in v["panels"]}
+    assert byid["comedor"]["up_to_date"] is True        # version == expected[:12]
+    assert byid["pieza"]["up_to_date"] is False         # rezagado


### PR DESCRIPTION
snapshot.\_versions() arma la matriz dispositivo×componente (repos SER9 con sha+tag+link GH + paneles con versión vs esperada + up_to_date). cloud-bo muestra la sección 'Versiones desplegadas' con links a los releases. Falta: backoffice local + panel deploy (34.8). 93 passed.