### PR TITLE
FASE 34 T5: última versión disponible + flag behind

### DIFF
--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -128,7 +128,11 @@ function renderVersions(v) {
   const repos = Object.entries(ser9).map(([name, i]) => {
     const ver = esc(i.tag || i.version || "?");
     const label = i.url ? `<a href="${esc(i.url)}" target="_blank">${ver}</a>` : ver;
-    return `<div><b>${esc(name)}</b> ${label}${i.tag && i.version ? ` <span class="muted">(${esc(i.version)})</span>` : ""}</div>`;
+    const avail = i.behind
+      ? ` <span style="color:#fa0">⬆ disponible ${esc(i.latest_tag || i.latest_sha)}</span>`
+      : "";
+    return `<div>${i.behind ? "⚠️" : "🟢"} <b>${esc(name)}</b> ${label}`
+      + `${i.tag && i.version ? ` <span class="muted">(${esc(i.version)})</span>` : ""}${avail}</div>`;
   }).join("");
   const panels = (v.panels || []).map(p =>
     `<div>${p.up_to_date ? "🟢" : "⚠️"} <b>${esc(p.node_id)}</b> <span class="muted">${esc(p.version) || "—"}</span></div>`

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -158,20 +158,49 @@ def _users() -> list[dict]:
     return out
 
 
+_FETCH_INTERVAL = int(os.environ.get("VERSIONS_FETCH_INTERVAL", "1800"))   # cada cuánto fetch (s)
+_last_fetch = 0.0
+
+
+def _maybe_fetch(repos, de) -> None:
+    """git fetch de los repos para conocer la ÚLTIMA versión disponible (origin/main + tags), con
+    throttle (no en cada snapshot). Egress-only: el SER9 sólo hace una conexión saliente a GitHub."""
+    global _last_fetch
+    import time
+    if time.time() - _last_fetch < _FETCH_INTERVAL:
+        return
+    _last_fetch = time.time()
+    for repo in repos.values():
+        de._run(["git", "-C", repo.git_dir(), "fetch", "--quiet", "--tags", "origin"],
+                de._noop_emit, timeout=60)
+
+
 def _versions(nodes: list[dict]) -> dict:
     """Matriz de versiones dispositivo×componente (FASE 34 T5 / 34.7/34.14): por repo del SER9
-    (core/ear/umbrella) el sha+tag+link al release de GitHub que corre, y por panel la versión
-    de código reportada (heartbeat) vs la esperada (la que sirve el audio_server). Best-effort."""
+    (core/ear/umbrella) el sha+tag+link al release de GitHub que CORRE y la ÚLTIMA disponible
+    (origin/main + último tag) con flag `behind` para detectar rezago → disparar update; y por
+    panel la versión reportada (heartbeat) vs la esperada (la que sirve el audio_server). Best-effort."""
     out: dict = {"ser9": {}, "panels": [], "satellite_expected": None}
     try:
         import deploy_engine as de
+        _maybe_fetch(de.REPOS, de)
         for name, repo in de.REPOS.items():
             gd = repo.git_dir()
             sha = repo.head(de._noop_emit)
             tag = de._tag_at(gd, sha, de._noop_emit) if sha else None
             slug = de._repo_slug(gd, de._noop_emit)
             url = f"https://github.com/{slug}/releases/tag/{tag}" if (slug and tag) else None
-            out["ser9"][name] = {"version": sha, "tag": tag, "url": url}
+            # última disponible: origin/main + mayor tag semver conocido (tras el fetch)
+            r = de._run(["git", "-C", gd, "rev-parse", "--short", "origin/main"],
+                        de._noop_emit, timeout=15)
+            latest_sha = r.output.strip() if r.ok and r.output.strip() else None
+            lv = de._latest_semver(gd, de._noop_emit)
+            latest_tag = ("v%d.%d.%d" % lv) if lv else None
+            out["ser9"][name] = {
+                "version": sha, "tag": tag, "url": url,
+                "latest_sha": latest_sha, "latest_tag": latest_tag,
+                "behind": bool(latest_sha and sha and latest_sha != sha),
+            }
     except Exception:
         pass
     expected = (_get(f"{AUDIO_URL}/satellite/version") or {}).get("version")

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -247,7 +247,8 @@ def test_snapshot_versions_panels_y_ser9():
             return {"status": "ok", "nodes": 2}
         return None
     with patch.object(snapshot, "_get", fake_get), \
-         patch.object(snapshot, "_systemctl_active", lambda u: True):
+         patch.object(snapshot, "_systemctl_active", lambda u: True), \
+         patch.object(snapshot, "_maybe_fetch", lambda *a, **k: None):  # sin git fetch real
         snap = snapshot.build_snapshot()
     v = snap["versions"]
     assert isinstance(v["ser9"], dict)                  # repos del SER9 (best-effort)


### PR DESCRIPTION
La matriz reporta la última versión disponible por repo (origin/main + último tag, git fetch throttled egress-only) y un flag `behind` (corre != disponible). El cloud-bo muestra '⬆ disponible' en los rezagados → base para disparar update. 93 passed.