### PR TITLE
fix: driver cloudrun despinea tráfico (--to-latest)

### DIFF
--- a/cloud/bridge/deploy_engine.py
+++ b/cloud/bridge/deploy_engine.py
@@ -427,9 +427,16 @@ class CloudRunTarget:
         return r.output.strip() if r.ok and r.output.strip() else None
 
     def deploy(self, emit: LogEmit) -> bool:
-        return _run([GCLOUD, "run", "deploy", self.service, "--source", self._src(),
+        if not _run([GCLOUD, "run", "deploy", self.service, "--source", self._src(),
                      "--project", GCP_PROJECT, "--region", self.region, "--quiet"],
-                    emit, timeout=600).ok
+                    emit, timeout=600).ok:
+            return False
+        # Forzar tráfico a la última revisión: tras un rollback el servicio queda con el tráfico
+        # PINEADO a una revisión vieja (update-traffic --to-revisions), y `deploy` NO lo mueve
+        # solo → la revisión nueva quedaría sin tráfico. --to-latest despinea y sirve la nueva.
+        return _run([GCLOUD, "run", "services", "update-traffic", self.service,
+                     "--project", GCP_PROJECT, "--region", self.region, "--to-latest", "--quiet"],
+                    emit, timeout=120).ok
 
     def health(self, emit: LogEmit) -> bool:
         for _ in range(HEALTH_RETRIES):

--- a/cloud/bridge/test_deploy_engine.py
+++ b/cloud/bridge/test_deploy_engine.py
@@ -325,3 +325,15 @@ def test_cloud_release_unknown_target():
     import pytest
     with pytest.raises(ValueError):
         de.run_cloud_release(["nope"])
+
+
+def test_cloud_deploy_forces_to_latest(monkeypatch):
+    # tras el deploy, despinea el tráfico → --to-latest (si no, un rollback previo deja la
+    # revisión nueva sin tráfico). Regresión del bug T5.
+    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
+    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
+    fake = _FakeGcloud()
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    de.run_cloud_release(["cloud-bo"])
+    assert fake.did("update-traffic", "--to-latest")


### PR DESCRIPTION
Tras un rollback el tráfico queda pineado a la revisión vieja → los deploys nuevos no reciben tráfico (el cloud-bo servía el dashboard viejo). deploy() ahora hace --to-latest tras el deploy.