### PR TITLE
feat: matriz versiones — links para todos + disponible siempre

### DIFF
--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -125,14 +125,15 @@ function dot(ok) { return ok ? "🟢" : "🔴"; }
 function renderVersions(v) {
   const esc = (s) => String(s == null ? "" : s).replace(/[<>&]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;"}[c]));
   const ser9 = v.ser9 || {};
+  const link = (text, url) => url ? `<a href="${esc(url)}" target="_blank">${esc(text)}</a>` : esc(text);
   const repos = Object.entries(ser9).map(([name, i]) => {
-    const ver = esc(i.tag || i.version || "?");
-    const label = i.url ? `<a href="${esc(i.url)}" target="_blank">${ver}</a>` : ver;
-    const avail = i.behind
-      ? ` <span style="color:#fa0">⬆ disponible ${esc(i.latest_tag || i.latest_sha)}</span>`
-      : "";
-    return `<div>${i.behind ? "⚠️" : "🟢"} <b>${esc(name)}</b> ${label}`
-      + `${i.tag && i.version ? ` <span class="muted">(${esc(i.version)})</span>` : ""}${avail}</div>`;
+    const run = link(i.tag || i.version || "?", i.url);
+    const avail = link(i.latest_tag || i.latest_sha || "?", i.latest_url);
+    const availPart = i.behind
+      ? ` · <span style="color:#fa0">⬆ disp. ${avail}</span>`
+      : ` · <span class="muted">al día</span>`;
+    return `<div>${i.behind ? "⚠️" : "🟢"} <b>${esc(name)}</b> ${run}`
+      + `${i.tag && i.version ? ` <span class="muted">(${esc(i.version)})</span>` : ""}${availPart}</div>`;
   }).join("");
   const panels = (v.panels || []).map(p =>
     `<div>${p.up_to_date ? "🟢" : "⚠️"} <b>${esc(p.node_id)}</b> <span class="muted">${esc(p.version) || "—"}</span></div>`

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -189,16 +189,23 @@ def _versions(nodes: list[dict]) -> dict:
             sha = repo.head(de._noop_emit)
             tag = de._tag_at(gd, sha, de._noop_emit) if sha else None
             slug = de._repo_slug(gd, de._noop_emit)
-            url = f"https://github.com/{slug}/releases/tag/{tag}" if (slug and tag) else None
             # última disponible: origin/main + mayor tag semver conocido (tras el fetch)
             r = de._run(["git", "-C", gd, "rev-parse", "--short", "origin/main"],
                         de._noop_emit, timeout=15)
             latest_sha = r.output.strip() if r.ok and r.output.strip() else None
             lv = de._latest_semver(gd, de._noop_emit)
             latest_tag = ("v%d.%d.%d" % lv) if lv else None
+
+            def _gh(ref, is_tag):  # link a release si es tag, al commit si es sha — siempre hay link
+                if not slug or not ref:
+                    return None
+                return (f"https://github.com/{slug}/releases/tag/{ref}" if is_tag
+                        else f"https://github.com/{slug}/commit/{ref}")
+
             out["ser9"][name] = {
-                "version": sha, "tag": tag, "url": url,
+                "version": sha, "tag": tag, "url": _gh(tag or sha, bool(tag)),
                 "latest_sha": latest_sha, "latest_tag": latest_tag,
+                "latest_url": _gh(latest_tag or latest_sha, bool(latest_tag)),
                 "behind": bool(latest_sha and sha and latest_sha != sha),
             }
     except Exception:


### PR DESCRIPTION
Link al commit si el sha no tiene tag (todos los componentes con link, no solo core) + latest_url. El dashboard muestra 'corre · disponible' siempre con links. 94 passed.