### PR TITLE
test+docs: fase 34.10/34.11 — cierre de FASE 34

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,29 @@ python scripts/sync_issues.py
 git submodule update --remote
 ```
 
+## Deploy (FASE 34 — motor único + matriz de targets)
+
+Existe UN motor de deploy (`cloud/bridge/deploy_engine.py`) que corre en el Brain y es el
+único backend: snapshot → pin de ref → install → restart → health-gate → rollback → tag.
+Lo invocan dos frontends sin reimplementar nada:
+- **Remoto** — el backoffice **cloud** emite un comando, el bridge del Brain lo polea y lo
+  ejecuta (egress-only; sirve desde fuera de la LAN). Es la vía principal.
+- **Local** — `scripts/deploy.sh` (mismo motor por SSH) cuando se opera desde la LAN.
+
+**Matriz de targets** (operatoria, 34.15): ambos backoffices (`/dashboard` cloud, `/deploy`
+local) muestran UNA fila por cosa que corre — core, audio_server, backoffice, cloud-bo, y un
+satélite por panel — con la versión que corre, la última disponible, link al release de GitHub
+y (en el cloud, rol admin) un botón "Actualizar" que elige el comando solo. `wa`/`bridge` en
+"avanzado". El cloud-bo opera el deploy; el backoffice local es read-only (egress-only).
+
+Comandos: `deploy.release {services?, *_ref?}` (services del Brain), `deploy.cloud` (cloud-bo
+en GCP, build `gcloud run deploy --source` desde el Brain), `deploy.satellites {node_id?}`
+(fuerza el pull de un panel o todos vía la respuesta del heartbeat). Detalle en
+`cloud/bridge/README.md`. Tag semver por repo gateado por `DEPLOY_TAG_RELEASES`.
+
+> El Brain es el rol del servidor central (LXC capitan-lxc). "SER9" es sólo el modelo de
+> hardware actual (Beelink SER9 Pro) — no usarlo como nombre del rol.
+
 ## Pipeline actual (objetivo FASE 16)
 
 ```

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -44,6 +44,20 @@ Dashboard (navegador → nube, auth Firebase + allow-list email):
 - `POST /api/commands` — emite un comando validado contra el catálogo.
 - `GET  /` — dashboard.
 
+## Deploy de servicios (FASE 34)
+
+El dashboard incluye una **matriz de targets**: una fila por componente que corre (core,
+audio_server, backoffice, cloud-bo, un satélite por panel) con la versión que corre, la última
+disponible y un botón "Actualizar" (rol admin). El botón emite el comando que el bridge del
+Brain polea y ejecuta con el motor único (`cloud/bridge/deploy_engine.py`): `deploy.release`
+(services del Brain), `deploy.cloud` (cloud-bo en GCP), `deploy.satellites` (force pull de un
+panel). Health-gate + rollback automático; logs en vivo en el dashboard. Detalle del motor en
+`cloud/bridge/README.md`.
+
+El **deploy del propio cloud-bo** lo dispara el Brain (`gcloud run deploy --source` desde el
+LXC, egress a Google) — NO pasa por el bridge (evita la circularidad de reiniciarse a sí mismo,
+D4); si rompe, el rollback a la revisión previa lo hace el Brain.
+
 ## Provisión / deploy
 
 ```bash

--- a/cloud/bridge/README.md
+++ b/cloud/bridge/README.md
@@ -10,6 +10,38 @@ salientes** hacia el servicio Cloud Run (`cloud/`):
 - `executor.py` — ejecuta cada comando del catálogo TIPADO con una función concreta
   (subprocess con lista de args, sin shell). El catálogo es el mismo de la nube
   (`cloud/app/commands.py`), re-validado en el bridge.
+- `deploy_engine.py` — el **motor de deploy** (FASE 34): único backend para todo deploy.
+
+## Motor de deploy (FASE 34)
+
+`deploy_engine.py` es el ÚNICO lugar con lógica de deploy (snapshot → pin de ref → install →
+restart → health-gate → rollback → registro de versión). Lo invocan dos frontends sin
+reimplementar nada: el `executor` (remoto, comando del cloud-bo) y `scripts/deploy.sh` (local).
+
+Modelo en tres capas:
+- **Repo** (unidad de versión): `core`, `ear`, `umbrella`. Pin independiente por repo con
+  `git checkout` (NO `git submodule update`): pinar el umbrella no pisa core/ear.
+- **Service** (unidad de restart/health): `core`, `ear`(audio_server), `backoffice`, `wa`,
+  `bridge`. Atomicidad POR-REPO (D7): si un service falla su health, se revierte SU repo.
+- **Target** (unidad de operación, 34.15): lo que se ve y se opera en la matriz. Registro
+  `TARGETS` (core, audio_server, backoffice, cloud-bo, + un satélite por panel). Cada target
+  mapea a un comando: services → `deploy.release`, cloud-bo → `deploy.cloud`, paneles →
+  `deploy.satellites`. El snapshot (`snapshot._versions`) produce `versions.targets` con la
+  versión que corre + la última disponible + `behind` + el comando que lo despliega; ambos
+  frontends sólo renderizan y emiten.
+
+Comandos de deploy (catálogo tipado, validados en nube y bridge):
+- `deploy.release {services?, core_ref?, ear_ref?, umbrella_ref?}` — services del Brain; sin
+  params = todo a HEAD de main; `*_ref` pinea cada repo a un tag/sha.
+- `deploy.cloud {services?}` — targets de Cloud Run (cloud-bo). Build `gcloud run deploy
+  --source` desde el Brain (egress a Google) + `--to-latest`; health-gate por curl; rollback
+  a la revisión previa (`update-traffic --to-revisions`). Registra el sha de umbrella que corre.
+- `deploy.satellites {node_id?}` — fuerza el pull de código de un panel (o todos con `*`/ausente):
+  marca el nodo en el audio_server (`POST /nodes/{id}/update`); su próximo heartbeat devuelve
+  `update:true` y el satélite corre `_check_code_update()` fuera del ciclo de 10 min.
+
+Versionado: tras un deploy sano, tag semver por repo (gate `DEPLOY_TAG_RELEASES`). Estado
+persistido en `~/.local/share/capitan/deploy_state.json` (matriz de versiones + último release).
 
 ## Credencial (33.13)
 

--- a/cloud/bridge/test_deploy_engine.py
+++ b/cloud/bridge/test_deploy_engine.py
@@ -297,9 +297,7 @@ class _FakeGcloud:
         return any(all(s in " ".join(c) for s in subs) for c in self.calls)
 
 
-def test_cloud_release_ok(monkeypatch):
-    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
-    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
+def test_cloud_release_ok(state_tmp, monkeypatch):
     fake = _FakeGcloud(revision="capitan-cloud-00010")
     monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
@@ -308,9 +306,21 @@ def test_cloud_release_ok(monkeypatch):
     assert fake.did("run", "deploy", "capitan-cloud", "--source")
 
 
-def test_cloud_release_health_fail_rollback(monkeypatch):
-    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
-    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
+def test_cloud_release_registra_version_en_estado(state_tmp, monkeypatch):
+    # 34.15/34.2: tras un deploy ok, el state guarda la versión (sha de umbrella) que corre en
+    # el target cloudrun → la matriz puede mostrar qué versión sirve cloud-bo en GCP.
+    fake = _FakeGcloud(revision="capitan-cloud-00010")
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    de.run_cloud_release(["cloud-bo"])
+    ci = de.load_state().get("cloud", {}).get("cloud-bo", {})
+    assert ci.get("ok") is True
+    assert ci.get("version")                 # sha del repo fuente (umbrella)
+    assert ci.get("revision") == "capitan-cloud-00010"
+    assert ci.get("repo") == "umbrella"
+
+
+def test_cloud_release_health_fail_rollback(state_tmp, monkeypatch):
     fake = _FakeGcloud(revision="capitan-cloud-prev")
     monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: False)   # health falla siempre
@@ -319,21 +329,39 @@ def test_cloud_release_health_fail_rollback(monkeypatch):
     assert res.services["cloud-bo"]["rolled_back"] is True
     # rollback a la revisión previa
     assert fake.did("update-traffic", "capitan-cloud-prev=100")
+    # el state marca el target como no-ok (no pisa la versión sana con una rota)
+    assert de.load_state().get("cloud", {}).get("cloud-bo", {}).get("ok") is False
 
 
-def test_cloud_release_unknown_target():
+def test_cloud_release_unknown_target(state_tmp):
     import pytest
     with pytest.raises(ValueError):
         de.run_cloud_release(["nope"])
 
 
-def test_cloud_deploy_forces_to_latest(monkeypatch):
+def test_cloud_deploy_forces_to_latest(state_tmp, monkeypatch):
     # tras el deploy, despinea el tráfico → --to-latest (si no, un rollback previo deja la
     # revisión nueva sin tráfico). Regresión del bug T5.
-    monkeypatch.setattr(de, "HEALTH_RETRIES", 2)
-    monkeypatch.setattr(de, "HEALTH_BACKOFF", 0.0)
     fake = _FakeGcloud()
     monkeypatch.setattr(de, "_run", fake)
     monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
     de.run_cloud_release(["cloud-bo"])
     assert fake.did("update-traffic", "--to-latest")
+
+
+# ── Registro TARGETS (34.15): consistencia con el motor ───────────────────────
+
+def test_targets_consistentes_con_el_motor():
+    """Cada target declara un comando y params válidos contra los registros del motor."""
+    for t in de.TARGETS:
+        assert t.repo in de.REPOS, f"{t.id}: repo {t.repo!r} desconocido"
+        if t.kind == "service":
+            assert t.command == "deploy.release"
+            for s in t.params["services"]:
+                assert s in de.SERVICES, f"{t.id}: service {s!r} no está en SERVICES"
+        elif t.kind == "cloudrun":
+            assert t.command == "deploy.cloud"
+            for s in t.params["services"]:
+                assert s in de.CLOUDRUN_TARGETS, f"{t.id}: {s!r} no es target cloudrun"
+        else:
+            raise AssertionError(f"{t.id}: kind inesperado {t.kind!r}")

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -726,6 +726,41 @@ y rate limiting que el resto del bridge. La nube los guarda en Firestore (`metri
 
 ---
 
+## Deploy y versionado (FASE 34)
+
+Un **motor único** (`cloud/bridge/deploy_engine.py`) corre en el Brain y concentra TODA la
+lógica de deploy. Dos frontends lo invocan sin reimplementar nada: el **executor** del bridge
+(remoto, comando emitido desde el cloud-bo y poleado por el Brain — egress-only, opera desde
+fuera de la LAN) y `scripts/deploy.sh` (local, en la LAN).
+
+**Modelo en tres capas.** *Repo* = unidad de versión (core, ear, umbrella; pin independiente
+con `git checkout`, sin `git submodule update`). *Service* = unidad de restart/health
+(core, audio_server, backoffice, wa, bridge). *Target* = unidad de operación que ve el usuario:
+una lista plana (core, audio_server, backoffice, cloud-bo, un satélite por panel) en la matriz
+de versiones de ambos backoffices, cada uno con la versión que corre, la última disponible
+(origin/main + tag), flag `behind`, link al release de GitHub, y el comando que lo despliega.
+
+**Flujo de release** (por repo, atómico — D7): snapshot de la versión actual → pin del ref
+pedido (default origin/main) → `pip install` si cambió requirements → restart del service →
+**health-gate** (`/health` con reintentos). Si el health falla, **rollback** automático: re-pin
+al snapshot previo + restart; los repos sanos quedan desplegados. Tras un release sano se crea
+un **tag semver** por repo (gate `DEPLOY_TAG_RELEASES`). El estado (versión por repo/service,
+último release, rollback) se persiste en `~/.local/share/capitan/deploy_state.json` y un
+subconjunto viaja en el snapshot a la nube.
+
+**Targets especiales.** *cloud-bo* (Cloud Run): `gcloud run deploy --source` desde el Brain
+(egress a Google) + `--to-latest`; health por curl a la URL pública; rollback a la revisión
+previa (`update-traffic --to-revisions`); registra el sha de umbrella que corre en GCP.
+*Satélites* (NSPanel): auto-pull cada `MODEL_SYNC_SECS` (md5 de `satellite.py`/`satellite_ui.py`
+que sirve el audio_server desde su checkout de `ear`); `deploy.satellites` fuerza el pull ya,
+marcando el nodo → su próximo heartbeat devuelve `update:true` → `_check_code_update()`.
+
+Comandos tipados (validados en nube y bridge): `deploy.release`, `deploy.cloud`,
+`deploy.satellites`. RBAC: sólo rol admin emite; el cloud-bo oculta la acción al resto y el
+backoffice local es read-only (el deploy se opera desde la nube por el modelo egress-only).
+
+---
+
 ## Persistencia en disco
 
 Todos los datos del usuario se almacenan en `~/.local/share/capitan/`:

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3006,21 +3006,16 @@ Objetivo: Desplegar al Brain desde cualquier lado (fuera de la LAN) de forma seg
           dashboard cloud lo emite, el Brain lo polea y lo ejecuta como un release CD
           (pin de ref por submodule → snapshot → deploy atómico → health-gate →
           rollback automático si falla), registra la versión desplegada y la reporta.
-Estado:   EN CURSO — motor único operativo y LIVE en el Brain. Hechas: 34.1 (contrato
-          deploy.release), 34.3-34.6 (motor: pin/health/rollback), 34.9 (invocadores: executor
-          + deploy.sh sobre el motor), 34.12 (versionado semver: tag+push por repo, ACTIVO —
-          v0.1.0 en core/ear/umbrella; falta sólo el GitHub Release formal con notas = token GH),
-          y LOGS EN VIVO (D5) end-to-end: el motor emite progreso → bridge lo postea por lotes →
-          la nube lo acumula → el cloud-bo lo muestra en streaming (executor emit, /commands/
-          {id}/progress, /api/commands/{id}, frontend). T4a driver cloudrun ACTIVADO+probado
-          (deploy del cloud-bo desde el Brain + rollback a revisión previa); gcloud en el Brain.
-          T4b: #602 resuelto, provisioning robusto (converge + escritura verificada por checksum),
-          satélites bajo el motor (34.13: auto-update por pull + reportan versión). T5 parcial:
-          MATRIZ DE VERSIONES en el snapshot + cloud-bo (34.7/34.14) — por repo del Brain la versión
-          que corre (sha+tag+link al release GH) y la ÚLTIMA disponible (origin/main + tag, fetch
-          throttled) con flag `behind`; por panel versión vs esperada (up_to_date). Prep permisos
-          gcloud (D9). Pendientes: matriz en BACKOFFICE LOCAL (34.7/34.14), panel de deploy admin
-          en cloud (34.8), tests e2e + docs (34.10/34.11).
+Estado:   COMPLETA (34.17 postergada — extracción de submodules, tanda aparte). Motor único
+          LIVE en el Brain con dos invocadores (executor remoto + deploy.sh), pin/health/rollback
+          atómico por repo, versionado semver (34.12, v0.1.0), logs en vivo end-to-end (D5),
+          driver cloudrun (cloud-bo desde el Brain + rollback a revisión previa) y satélites bajo
+          el motor (34.13 auto-update + 34.16 force pull). MATRIZ UNIFICADA DE TARGETS (34.15):
+          una fila por cosa que corre (core/audio_server/backoffice/cloud-bo + un satélite por
+          panel) con versión que corre + última disponible + link a GH + botón "Actualizar" que
+          elige el comando solo; en cloud-bo (opera) y backoffice local (read-only). Contrato de
+          release persistido (34.2: refs/ts/resultado/rollback en deploy_state.json; "quién emitió"
+          por la auditoría de comandos 33.15). Tests (34.10) + docs (34.11) completos.
 Deps:     FASE 33 (bridge egress-only + allowlist tipado + auth/audit/RBAC — COMPLETA,
           ya existe el comando `deploy.run` que esta fase eleva a CD real),
           FASE 21 (Brain estable — COMPLETA), FASE 12 (backoffice — COMPLETA).
@@ -3138,7 +3133,7 @@ DECISIONES CONSOLIDADAS (2026-06-20, al tomar la fase — amplían el alcance de
             `cloud/app/commands.py`: aceptar `core_ref` y `ear_ref` opcionales (default =
             HEAD remoto de main), validados como sha/tag/branch con un validador estricto
             (rechazar refs arbitrarios/inyección); mantener `restart_wa`. Tests del catálogo.
-- [ ] 34.2  Definir el contrato de "release" como dato versionado: refs desplegados por
+- [x] 34.2  Definir el contrato de "release" como dato versionado: refs desplegados por
             submodule + commit del umbrella, timestamp, quién lo emitió, resultado y estado
             del health-gate, y si hubo rollback. Persistencia local en el Brain (fuente de
             verdad) y subconjunto reportado en el snapshot a la nube.
@@ -3262,10 +3257,11 @@ Etapa E (T4b) — HECHO 2026-06-21 (escritura verificada + convergencia + #602 r
             grande y casi irreversible (repos GH nuevos, CI, paths de deploy) → tanda aparte.
 
 #### Etapa D - Tests y documentación
-- [ ] 34.10 Tests: validación del comando con refs (`cloud/tests`); executor con snapshot /
+- [x] 34.10 Tests: validación del comando con refs (`cloud/tests`); executor con snapshot /
             health / rollback mockeando git + systemd + HTTP (`cloud/bridge/test_bridge.py`);
-            caso e2e del flujo deploy → health falla → rollback al ref previo.
-- [ ] 34.11 Docs: actualizar `cloud/README.md`, `cloud/bridge/README.md`, la sección de
+            caso e2e del flujo deploy → health falla → rollback al ref previo. + registro de
+            versión cloud en el state, consistencia del registro TARGETS, deploy.satellites.
+- [x] 34.11 Docs: actualizar `cloud/README.md`, `cloud/bridge/README.md`, la sección de
             deploy de `CLAUDE.md`, `masterplan/arquitectura_funcional.md` (flujo de release y
             rollback) y este plan. Reflejar la nueva versión visible en el dashboard.
 


### PR DESCRIPTION
34.10: tests del registro de versión cloud en el state, consistencia del registro
TARGETS contra el motor, y deploy.satellites (comando + executor). El e2e de rollback
ya estaba cubierto.
34.11: motor de deploy + matriz de targets documentados en cloud/README.md,
cloud/bridge/README.md, sección Deploy de CLAUDE.md y arquitectura_funcional.md
(flujo de release/rollback). Marca 34.2/34.10/34.11/34.15/34.16; FASE 34 COMPLETA
(34.17 extracción de submodules postergada).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
