### PR TITLE
feat: deploy local por target (mismo funnel que el cloud-bo)

### DIFF
--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,8 +1,20 @@
-Desplegá home-agents al LXC de producción en el Brain (capitan-lxc, 192.168.68.132).
+Desplegá home-agents al Brain (LXC de producción, capitan-lxc 192.168.68.132) por TARGET.
 
-El script hace: git pull --recurse-submodules, pip install, restart capitan-core y capitan-backoffice, smoke test.
+`scripts/deploy.sh <target>` resuelve el target al MISMO comando tipado que emite el cloud-bo
+(deploy.release / deploy.cloud / deploy.satellites) y lo corre con validate_command +
+executor.execute en el Brain — el mismo funnel que el bridge usa al desencolar un comando de la
+nube. Desplegar desde acá es idéntico a hacerlo desde el cloud-bo. El motor hace pin a HEAD de
+main, install, restart, health-gate y rollback automático si el health falla.
 
-Pasá `--restart-wa` si también hay que reiniciar el cliente WhatsApp.
+Targets (mismos que la matriz del cloud-bo):
+- `core` `audio_server` `backoffice` `wa` `bridge` — services del Brain (deploy.release)
+- `cloud-bo` — Cloud Run en GCP (deploy.cloud; activa la SA de deploy)
+- `panels` o un `<node_id>` (ej. `nspanel-comedor`) — fuerza el pull del satélite (deploy.satellites)
+- sin target — services default (core + ear + backoffice) a HEAD de main
+- `--ref repo=ref` — pin a un tag/sha (rollback o release fijo), ej. `--ref core=v0.1.0`
+- `--restart-wa` — compat: services default + wa
+
+Prerrequisito: el cambio ya tiene que estar mergeado a main (el motor pinea HEAD de main).
 
 Comando a ejecutar:
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,10 +388,37 @@ satélite por panel — con la versión que corre, la última disponible, link a
 y (en el cloud, rol admin) un botón "Actualizar" que elige el comando solo. `wa`/`bridge` en
 "avanzado". El cloud-bo opera el deploy; el backoffice local es read-only (egress-only).
 
-Comandos: `deploy.release {services?, *_ref?}` (services del Brain), `deploy.cloud` (cloud-bo
-en GCP, build `gcloud run deploy --source` desde el Brain), `deploy.satellites {node_id?}`
-(fuerza el pull de un panel o todos vía la respuesta del heartbeat). Detalle en
-`cloud/bridge/README.md`. Tag semver por repo gateado por `DEPLOY_TAG_RELEASES`.
+### Desplegar desde Claude (mismo camino que el cloud-bo)
+
+`scripts/deploy.sh <target>` es el invocador LOCAL. Resuelve el target al MISMO comando tipado
+que emite el cloud-bo y lo corre con `validate_command` + `executor.execute` en el Brain — el
+mismo funnel que el bridge usa al desencolar un comando de la nube. **Desplegar desde Claude es
+idéntico a hacerlo desde el cloud-bo**; sólo cambia el disparador (LAN/SSH vs cola en Firestore).
+No usar `gcloud`, `git pull` ni `systemctl` sueltos para desplegar: siempre por este camino, así
+hay health-gate, rollback y registro de versión.
+
+Un target por componente de la matriz (health-gate + rollback automático en todos):
+
+```zsh
+bash scripts/deploy.sh                 # services default: core + ear(audio_server) + backoffice
+bash scripts/deploy.sh core            # un service del Brain (deploy.release)
+bash scripts/deploy.sh audio_server    # repo ear → capitan-audio-server
+bash scripts/deploy.sh backoffice
+bash scripts/deploy.sh cloud-bo        # Cloud Run (activa la SA de deploy) → deploy.cloud
+bash scripts/deploy.sh panels          # fuerza el pull de TODOS los paneles → deploy.satellites
+bash scripts/deploy.sh nspanel-comedor # fuerza el pull de un panel
+bash scripts/deploy.sh core --ref core=v0.1.0   # pin a un tag/sha (rollback o release fijo)
+bash scripts/deploy.sh wa              # (avanzado) reinicia WhatsApp; bridge requiere restart desacoplado
+```
+
+Mapeo target → comando (registro `TARGETS` en `deploy_engine.py`, compartido con el cloud-bo y
+el snapshot): `core/audio_server/backoffice/wa/bridge` → `deploy.release`; `cloud-bo` →
+`deploy.cloud`; `panels`/`<node_id>` → `deploy.satellites`. Detalle del motor y los comandos en
+`cloud/bridge/README.md`. Tag semver por repo gateado por `DEPLOY_TAG_RELEASES` (default on).
+
+**Flujo correcto al desplegar un cambio**: mergear el PR a main (branch→PR→merge) → `bash
+scripts/deploy.sh <target>`. El motor hace el pin a HEAD de main, restart, health-gate y, si
+falla, rollback. NO hace falta entrar al Brain a mano.
 
 > El Brain es el rol del servidor central (LXC capitan-lxc). "SER9" es sólo el modelo de
 > hardware actual (Beelink SER9 Pro) — no usarlo como nombre del rol.

--- a/cloud/bridge/README.md
+++ b/cloud/bridge/README.md
@@ -11,12 +11,17 @@ salientes** hacia el servicio Cloud Run (`cloud/`):
   (subprocess con lista de args, sin shell). El catálogo es el mismo de la nube
   (`cloud/app/commands.py`), re-validado en el bridge.
 - `deploy_engine.py` — el **motor de deploy** (FASE 34): único backend para todo deploy.
+- `deploy_cli.py` — invocador LOCAL por target: resuelve `<target>` al mismo comando tipado que
+  el cloud-bo y lo corre con `validate_command` + `executor.execute` (lo llama `scripts/deploy.sh`).
 
 ## Motor de deploy (FASE 34)
 
 `deploy_engine.py` es el ÚNICO lugar con lógica de deploy (snapshot → pin de ref → install →
-restart → health-gate → rollback → registro de versión). Lo invocan dos frontends sin
-reimplementar nada: el `executor` (remoto, comando del cloud-bo) y `scripts/deploy.sh` (local).
+restart → health-gate → rollback → registro de versión). Lo invocan dos disparadores que
+convergen en el MISMO funnel `validate_command` + `executor.execute`:
+- **remoto** — el cloud-bo encola un comando → el bridge lo polea → `executor.execute`.
+- **local** — `scripts/deploy.sh <target>` → `deploy_cli.py` resuelve el target al mismo comando
+  → `executor.execute`. Desplegar desde la LAN (Claude) es idéntico a hacerlo desde el cloud-bo.
 
 Modelo en tres capas:
 - **Repo** (unidad de versión): `core`, `ear`, `umbrella`. Pin independiente por repo con

--- a/cloud/bridge/deploy_cli.py
+++ b/cloud/bridge/deploy_cli.py
@@ -1,0 +1,112 @@
+"""deploy_cli.py — invocador LOCAL de deploy por TARGET (FASE 34, 34.15).
+
+Da, desde la LAN (Claude / operador), EXACTAMENTE el mismo camino que el cloud-bo remoto:
+resuelve un nombre de target → el comando tipado que emite el cloud-bo (deploy.release /
+deploy.cloud / deploy.satellites) y lo corre con `validate_command` + `executor.execute` —
+el mismo funnel que el bridge usa al desencolar un comando de la nube. No reimplementa nada:
+la lógica vive en el motor (deploy_engine) y el contrato en commands.py.
+
+Targets (mismos que muestra la matriz del cloud-bo):
+  core | audio_server | backoffice | wa | bridge   (services del Brain → deploy.release)
+  cloud-bo                                          (Cloud Run        → deploy.cloud)
+  panels | <node_id> (ej. nspanel-comedor)          (satélites        → deploy.satellites)
+  (sin target)                                      → deploy.release de los services default
+
+Uso:
+  python deploy_cli.py <target> [--ref repo=ref ...] [--json]
+  python deploy_cli.py                       # services default a HEAD de main
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))            # deploy_engine, executor
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))  # app.commands
+
+import deploy_engine as de  # noqa: E402
+import executor  # noqa: E402
+from app.commands import CommandError, validate_command  # noqa: E402
+
+
+def _static_targets() -> dict[str, "de.Target"]:
+    return {t.id: t for t in de.TARGETS}
+
+
+def resolve_target(name: str | None, refs: dict[str, str] | None) -> tuple[str, dict]:
+    """target → (cmd_type, params), con el MISMO mapeo que usa el cloud-bo (registro TARGETS).
+
+    Sin name → deploy.release de los services default (todo a HEAD de main).
+    Un id de la matriz → su comando+params. `panels`/`*` → todos los paneles. Cualquier otro
+    nombre se trata como node_id de un panel (deploy.satellites). Lanza ValueError si el nombre
+    no es ni un target conocido ni un id de panel plausible (evita que un typo dispare un no-op)."""
+    refs = refs or {}
+    if not name:
+        params: dict = {}
+        if refs:
+            params.update(refs)
+        return "deploy.release", params
+
+    targets = _static_targets()
+    if name in targets:
+        t = targets[name]
+        params = dict(t.params)
+        if t.command == "deploy.release" and refs:
+            params.update(refs)            # core_ref / ear_ref / umbrella_ref
+        return t.command, params
+
+    if name in ("panels", "all-panels", "*", "all"):
+        return "deploy.satellites", {"node_id": "*"}
+
+    # node_id de un panel: aceptamos el prefijo habitual o "panel:<id>"
+    node = name[len("panel:"):] if name.startswith("panel:") else name
+    if node.startswith("nspanel-") or node.startswith("panel-"):
+        return "deploy.satellites", {"node_id": node}
+
+    valid = sorted(targets) + ["panels", "<node_id> (nspanel-...)"]
+    raise ValueError(f"target desconocido: {name!r}. Válidos: {valid}")
+
+
+def run(name: str | None, refs: dict[str, str] | None, *, emit=print) -> "executor.ExecResult":
+    cmd_type, params = resolve_target(name, refs)
+    params = validate_command(cmd_type, params)          # mismo gate que la nube + el bridge
+    emit(f"=== {cmd_type} {params} ===")
+    return executor.execute(cmd_type, params, emit=emit)
+
+
+def _parse_refs(items: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for it in items:
+        if "=" not in it:
+            raise SystemExit(f"--ref inválido (esperado repo=ref): {it!r}")
+        k, v = it.split("=", 1)
+        # core/ear/umbrella → core_ref/ear_ref/umbrella_ref (params de deploy.release)
+        out[f"{k.strip()}_ref"] = v.strip()
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    ap = argparse.ArgumentParser(description="Deploy por target (mismo camino que el cloud-bo)")
+    ap.add_argument("target", nargs="?", default=None,
+                    help="core|audio_server|backoffice|wa|bridge|cloud-bo|panels|<node_id>")
+    ap.add_argument("--ref", action="append", default=[], metavar="repo=ref",
+                    help="pin de ref por repo (solo deploy.release)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+    try:
+        res = run(args.target, _parse_refs(args.ref), emit=lambda l: print(l, flush=True))
+    except (ValueError, CommandError) as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        import json
+        print(json.dumps({"ok": res.ok, "output": res.output, "error": res.error},
+                         ensure_ascii=False))
+    else:
+        print(("✓ " + (res.output or "OK")) if res.ok else ("✗ " + (res.error or "fallo")))
+    return 0 if res.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cloud/bridge/test_deploy_cli.py
+++ b/cloud/bridge/test_deploy_cli.py
@@ -1,0 +1,51 @@
+"""Tests del invocador local por target (deploy_cli): resuelve el target al MISMO comando
+tipado que el cloud-bo y lo valida con el contrato. No ejecuta deploy real."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import deploy_cli as dc  # noqa: E402
+from app.commands import validate_command  # noqa: E402
+
+
+def test_sin_target_es_release_default():
+    assert dc.resolve_target(None, None) == ("deploy.release", {})
+
+
+def test_services_del_brain():
+    assert dc.resolve_target("core", None) == ("deploy.release", {"services": ["core"]})
+    # audio_server es el target, el repo/service subyacente es ear
+    assert dc.resolve_target("audio_server", None) == ("deploy.release", {"services": ["ear"]})
+    assert dc.resolve_target("backoffice", None) == ("deploy.release", {"services": ["backoffice"]})
+
+
+def test_cloud_bo():
+    assert dc.resolve_target("cloud-bo", None) == ("deploy.cloud", {"services": ["cloud-bo"]})
+
+
+def test_paneles():
+    assert dc.resolve_target("panels", None) == ("deploy.satellites", {"node_id": "*"})
+    assert dc.resolve_target("nspanel-comedor", None) == ("deploy.satellites", {"node_id": "nspanel-comedor"})
+    assert dc.resolve_target("panel:nspanel-pieza", None) == ("deploy.satellites", {"node_id": "nspanel-pieza"})
+
+
+def test_ref_solo_para_release():
+    _, params = dc.resolve_target("core", {"core_ref": "v0.1.0"})
+    assert params == {"services": ["core"], "core_ref": "v0.1.0"}
+
+
+def test_typo_no_es_no_op_silencioso():
+    # un nombre que no es target ni node_id plausible → error explícito (no un deploy vacío)
+    with pytest.raises(ValueError):
+        dc.resolve_target("backofice", None)   # typo
+
+
+def test_targets_resueltos_pasan_el_contrato():
+    # cada target estático resuelve a params que el catálogo TIPADO acepta (mismo gate que la nube)
+    for name in ("core", "audio_server", "backoffice", "wa", "bridge", "cloud-bo", "panels"):
+        cmd, params = dc.resolve_target(name, None)
+        validate_command(cmd, params)   # no lanza

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,29 +1,55 @@
 #!/usr/bin/env zsh
-# Wrapper FINO sobre el MOTOR único de deploy (FASE 34). NO reimplementa lógica: invoca
-# cloud/bridge/deploy_engine.py en el Brain por SSH. Toda la lógica de deploy (snapshot, pin de
-# ref, install, restart, health-gate, rollback) vive en el motor; este script sólo lo llama.
-# Es el invocador LOCAL (cuando Claude opera desde la LAN); el invocador REMOTO es el comando
-# deploy.release del cloud-bo, que corre el MISMO motor. Ver D1/D9 en masterplan/estado.md.
+# Wrapper FINO del deploy por TARGET (FASE 34, 34.15). NO reimplementa lógica: invoca
+# cloud/bridge/deploy_cli.py en el Brain por SSH, que resuelve el target al MISMO comando
+# tipado que emite el cloud-bo (deploy.release / deploy.cloud / deploy.satellites) y lo corre
+# con validate_command + executor.execute — el MISMO funnel que el bridge usa al desencolar un
+# comando de la nube. Así desplegar desde Claude (LAN) es idéntico a hacerlo desde el cloud-bo
+# (remoto). Toda la lógica (pin, install, restart, health-gate, rollback, tag) vive en el motor.
 #
 # Uso:
-#   bash scripts/deploy.sh                      # default: core+ear+backoffice a HEAD de main
-#   bash scripts/deploy.sh --restart-wa         # + wa
-#   bash scripts/deploy.sh --service bridge     # un servicio puntual
-#   bash scripts/deploy.sh --ref core=v1.2.3    # pin de un ref (rollback/release fijo)
-# Los flags --service/--ref se pasan tal cual al motor (ver deploy_engine.py --help).
+#   bash scripts/deploy.sh                       # services default (core+ear+backoffice) a HEAD
+#   bash scripts/deploy.sh core                  # un service del Brain
+#   bash scripts/deploy.sh audio_server          # (repo ear)
+#   bash scripts/deploy.sh backoffice
+#   bash scripts/deploy.sh cloud-bo              # Cloud Run (activa la SA de deploy)
+#   bash scripts/deploy.sh panels                # fuerza el pull de TODOS los paneles
+#   bash scripts/deploy.sh nspanel-comedor       # fuerza el pull de un panel
+#   bash scripts/deploy.sh core --ref core=v1.2.3   # pin de un ref (rollback/release fijo)
+#   bash scripts/deploy.sh --restart-wa          # compat: services default + wa
 set -euo pipefail
 
-ARGS=()
-if [[ "${1:-}" == "--restart-wa" ]]; then
-  # Compat con la invocación histórica: default + wa.
-  ARGS=(--service core --service ear --service backoffice --service wa)
-  shift
-fi
-ARGS+=("$@")
+REMOTE_DIR="~/workspace/home-agents"
+PY="~/home-agents-env/bin/python"
+TAG="${DEPLOY_TAG_RELEASES:-true}"
 
-echo "=== Deploy home-agents → capitan-lxc (motor FASE 34) ==="
-# Versionado semver activo por defecto en el deploy local (igual que el bridge). Se puede
-# desactivar para un deploy puntual con DEPLOY_TAG_RELEASES=false bash scripts/deploy.sh.
-ssh capitan-lxc \
-  "cd ~/workspace/home-agents && DEPLOY_TAG_RELEASES=${DEPLOY_TAG_RELEASES:-true} ~/home-agents-env/bin/python cloud/bridge/deploy_engine.py ${ARGS[*]}"
+run_target() {            # $1 = target (puede ser ""), resto = flags (--ref, --json)
+  local target="$1"; shift || true
+  # cloud-bo: activar la SA de deploy (el bridge ya la tiene en su entorno; acá la activamos
+  # para que el camino sea autocontenido). Idempotente.
+  if [[ "$target" == "cloud-bo" ]]; then
+    ssh capitan-lxc 'test -f ~/.config/capitan/deployer-key.json && \
+      CLOUDSDK_CORE_DISABLE_PROMPTS=1 gcloud auth activate-service-account \
+      --key-file=~/.config/capitan/deployer-key.json >/dev/null 2>&1 || true'
+  fi
+  ssh capitan-lxc \
+    "cd $REMOTE_DIR && DEPLOY_TAG_RELEASES=$TAG $PY cloud/bridge/deploy_cli.py $target $*"
+}
+
+echo "=== Deploy home-agents → capitan-lxc (target = ${1:-services default}) ==="
+
+# Compat histórico: --restart-wa = deploy de los services default + wa.
+if [[ "${1:-}" == "--restart-wa" ]]; then
+  shift
+  run_target "" "$@"
+  run_target "wa" "$@"
+  echo "=== Deploy completo ==="
+  exit 0
+fi
+
+# Primer arg = target (salvo que sea un flag --…, en cuyo caso no hay target).
+TARGET=""
+if [[ "${1:-}" != "" && "${1:-}" != --* ]]; then
+  TARGET="$1"; shift
+fi
+run_target "$TARGET" "$@"
 echo "=== Deploy completo (health-gate y rollback los maneja el motor) ==="


### PR DESCRIPTION
scripts/deploy.sh <target> ahora resuelve el target al MISMO comando tipado que
emite el cloud-bo (deploy.release/deploy.cloud/deploy.satellites) y lo corre con
validate_command + executor.execute en el Brain — idéntico a lo que hace el bridge
al desencolar un comando de la nube. Un solo camino coherente para todos los
componentes (services, cloud-bo, paneles), con health-gate + rollback + tag.

- cloud/bridge/deploy_cli.py: resolve_target (reusa el registro TARGETS) + run.
- scripts/deploy.sh: front-end por target; activa la SA para cloud-bo; --restart-wa compat.
- tests: test_deploy_cli.py (resolución + contrato).
- docs: sección Deploy de CLAUDE.md con ejemplos por componente, skill /deploy, bridge README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
