### PR TITLE
fase 37.1 — contrato del snapshot ampliado

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -105,6 +105,23 @@ lo verifica, resuelve email→usuario→rol contra su DB y abre sesión con RBAC
 familiar/adolescente read-only). El `redirect_uri` se valida contra `LOCAL_SSO_ORIGINS`. El
 codec del token está espejado en `cloud/app/sso.py` y en el backoffice.
 
+## Contrato del snapshot — qué sale y qué NO (FASE 37.1)
+
+El `StateSnapshot` (`app/models.py`) es una **allow-list cerrada**: sólo viaja lo enumerado.
+Campos ampliados en FASE 37 y su gate RBAC:
+
+| Campo | Contenido | Gate | PII |
+|-------|-----------|------|-----|
+| `alerts` | textos de alertas proactivas (listas para TTS) | `access` | no secreta — son avisos del hogar, no contenido de conversaciones |
+| `wakeword.status` | estado del último retrain (idle/running/done/error) | `access` | no |
+| `counts.{intents,goals,routines,conversations}` | **sólo enteros** | `access` | no — el contenido nunca sale |
+| `versions` | matriz de targets desplegables (FASE 34) | `access`/`emit` | no |
+
+**Nunca sale de la LAN**: `.env`, tokens HAOS/OAuth, ni el **contenido** de intents, goals,
+rutinas o conversaciones (sólo su conteo). El detalle PII queda detrás de la capacidad
+`view_pii` (admin-only, 37.2), que **no** se sirve por este snapshot — se obtiene por
+comando-poll explícito. El tipo de `counts` son enteros: es imposible filtrar texto por ahí.
+
 ## Seguridad
 
 - Secretos y PII **nunca** cruzan a la nube (ver contrato 33.1/33.2).

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -52,7 +52,20 @@ class WakewordNode(BaseModel):
 class Wakeword(BaseModel):
     last_score: float | None = None
     false_positives_24h: int | None = None
+    status: str = "idle"   # estado del último retrain (idle/running/done/error), FASE 37.1
     nodes: list[WakewordNode] = Field(default_factory=list)
+
+
+class Counts(BaseModel):
+    """Conteos agregados (sin contenido PII en claro). FASE 37.1.
+
+    El detalle (contenido de intents/goals/rutinas/conversaciones) NO sale de la LAN:
+    sólo viaja el conteo, gated por `access`. El contenido queda detrás de `view_pii`
+    (capacidad admin-only, 37.2) que no expone este snapshot."""
+    intents: int = 0
+    goals: int = 0
+    routines: int = 0
+    conversations: int = 0
 
 
 class UserSummary(BaseModel):
@@ -74,6 +87,10 @@ class StateSnapshot(BaseModel):
     recent_commands: list[RecentCommand] = Field(default_factory=list)
     wakeword: Wakeword = Field(default_factory=Wakeword)
     users_summary: list[UserSummary] = Field(default_factory=list)
+    # FASE 37.1: alertas proactivas (texto listo para TTS; gated por `access`, no PII secreta)
+    # y conteos agregados de intents/goals/rutinas/conversaciones (sin contenido en claro).
+    alerts: list[str] = Field(default_factory=list)
+    counts: Counts = Field(default_factory=Counts)
     # Matriz unificada de targets (34.15): {targets: [{id,label,where,kind,version,url,latest,
     # latest_url,behind,command,params,advanced}], satellite_expected}. Opcional (retrocompat).
     versions: dict[str, Any] = Field(default_factory=dict)

--- a/cloud/tests/test_models.py
+++ b/cloud/tests/test_models.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from app.models import SCHEMA_VERSION, StateSnapshot
+from app.models import SCHEMA_VERSION, Counts, StateSnapshot, Wakeword
 
 
 def test_schema_version_constant_matches_default():
@@ -25,3 +25,34 @@ def test_minimal_snapshot_validates():
 def test_ts_and_host_required():
     with pytest.raises(Exception):
         StateSnapshot()
+
+
+# ── FASE 37.1: campos ampliados (alerts, wakeword.status, counts) ──
+
+def test_new_fields_default_empty():
+    snap = StateSnapshot(ts="2026-06-21T00:00:00Z", host="capitan-lxc")
+    d = snap.model_dump()
+    assert d["alerts"] == []
+    assert d["counts"] == {"intents": 0, "goals": 0, "routines": 0, "conversations": 0}
+    assert d["wakeword"]["status"] == "idle"
+
+
+def test_counts_are_only_aggregates():
+    # El contrato sólo admite enteros: imposible filtrar contenido PID por este campo.
+    c = Counts(intents=3, goals=1, routines=2, conversations=7)
+    assert c.model_dump() == {"intents": 3, "goals": 1, "routines": 2, "conversations": 7}
+    with pytest.raises(Exception):
+        Counts(intents=[{"text": "secreto"}])  # listas/objetos rechazados
+
+
+def test_alerts_and_wakeword_status_roundtrip():
+    snap = StateSnapshot(
+        ts="2026-06-21T00:00:00Z", host="capitan-lxc",
+        alerts=["El documento de X vence en 3 días"],
+        wakeword=Wakeword(status="running"),
+        counts=Counts(conversations=5),
+    )
+    d = snap.model_dump()
+    assert d["alerts"] == ["El documento de X vence en 3 días"]
+    assert d["wakeword"]["status"] == "running"
+    assert d["counts"]["conversations"] == 5

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   Pendiente.
+Estado:   EN CURSO (1/13 — hecho 37.1; pendientes 37.2-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3488,8 +3488,15 @@ Mapa de paridad local→cloud (qué se incluye y bajo qué gate):
           - FUERA del cloud: Shared State, Ambientes (rooms), Integraciones (OAuth/tokens).
 ```
 
+PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
+          catálogo, observabilidad del estado (pending→running→done/error), y la UX de
+          definición de parámetros— debe construirse con calidad de producto final-user,
+          aunque el ítem no lo detalle explícitamente. Nada de inputs JSON crudos ni jerga
+          interna: widgets tipados, labels claros, validación inline, feedback legible.
+          Aplica especialmente a 37.5/37.6 pero gobierna toda superficie de comandos.
+
 #### Etapa A - Contrato y RBAC
-- [ ] 37.1  Contrato del snapshot ampliado: campos `alerts`, `wakeword.status`, conteos de
+- [x] 37.1  Contrato del snapshot ampliado: campos `alerts`, `wakeword.status`, conteos de
             intents/goals/routines/conversaciones y versión desplegada (cruza FASE 34).
             Documentar qué sale y qué NO (sin contenido PII en claro). Tests de contrato del
             snapshot (`cloud/tests`).


### PR DESCRIPTION
Etapa A de FASE 37. Extiende `StateSnapshot` con campos egress-only sin PII en claro:

- `alerts: list[str]` — textos de alertas proactivas (gated por `access`)
- `wakeword.status` — estado del último retrain (idle/running/done/error)
- `counts` — conteos de intents/goals/routines/conversations (**sólo enteros**, sin contenido)

La versión desplegada ya viaja en `versions` (FASE 34), no se agrega campo.

Documenta el contrato (qué sale y qué NO) en `cloud/README.md`. Tests de contrato en `cloud/tests/test_models.py`. La emisión real de estos campos es 37.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)