### PR TITLE
fase 37.2 — view_pii + comandos de operación acotados

### DIFF
--- a/cloud/app/commands.py
+++ b/cloud/app/commands.py
@@ -13,6 +13,8 @@ from typing import Any, Callable
 
 SERVICES = ("capitan-core", "capitan-backoffice", "capitan-wa", "capitan-ear")
 CONFIG_TARGETS = ("core", "backoffice")
+# Estados de agente que admite el core (PATCH /agents/{id}/status). FASE 37.2.
+AGENT_STATUSES = ("active", "planned", "unavailable")
 # Componentes del motor de deploy (FASE 34). Nombres lógicos del motor (deploy_engine.SERVICES),
 # distintos de las units de SERVICES de arriba.
 DEPLOY_SERVICES = ("core", "ear", "backoffice", "wa", "bridge")
@@ -99,6 +101,12 @@ CATALOG: dict[str, dict[str, tuple[Callable[[Any], Any], bool]]] = {
     "wakeword.retrain": {},
     "voice.reenroll":  {"node_id": (_str("node_id"), True),
                         "user_id": (_str("user_id"), True)},
+    # FASE 37.2: comandos de operación acotados (sólo admin). El bridge los ejecuta contra
+    # APIs/scripts existentes del Brain (37.8). Sin shell arbitrario.
+    "agent.toggle":    {"agent_id": (_str("agent_id"), True),
+                        "status": (_enum("status", AGENT_STATUSES), True)},
+    "panel.reboot":    {"node_id": (_str("node_id"), True)},
+    "proactive.run":   {"agent_id": (_str("agent_id"), True)},
 }
 
 

--- a/cloud/app/rbac.py
+++ b/cloud/app/rbac.py
@@ -8,14 +8,19 @@ Capacidades por rol (consistente con los roles de la gestión de usuarios del co
 """
 from __future__ import annotations
 
-# access: puede entrar al dashboard | view_full: ve users/auditoría | emit: emite comandos
+# Capacidades:
+#   access    → puede entrar al dashboard
+#   view_full → ve roster de usuarios, auditoría y detalle operativo de métricas
+#   view_pii  → ve CONTENIDO sensible (texto de comandos/conversaciones); admin-only (FASE 37.2),
+#               estrictamente más restrictiva que view_full. Sin ella se ven sólo conteos.
+#   emit      → emite comandos admin
 ROLE_CAPS: dict[str, dict[str, bool]] = {
-    "admin":       {"access": True,  "view_full": True,  "emit": True},
-    "familiar":    {"access": True,  "view_full": True,  "emit": False},
-    "adolescente": {"access": True,  "view_full": False, "emit": False},
+    "admin":       {"access": True,  "view_full": True,  "view_pii": True,  "emit": True},
+    "familiar":    {"access": True,  "view_full": True,  "view_pii": False, "emit": False},
+    "adolescente": {"access": True,  "view_full": False, "view_pii": False, "emit": False},
 }
 
-_NO_ACCESS = {"access": False, "view_full": False, "emit": False}
+_NO_ACCESS = {"access": False, "view_full": False, "view_pii": False, "emit": False}
 
 
 def caps_for(role: str | None) -> dict[str, bool]:
@@ -23,12 +28,21 @@ def caps_for(role: str | None) -> dict[str, bool]:
 
 
 def filter_state(state: dict, caps: dict[str, bool]) -> dict:
-    """Aplica RBAC al snapshot que ve el dashboard: oculta PII de usuarios a quien
-    no tiene view_full."""
-    if caps.get("view_full"):
-        return state
+    """Aplica RBAC al snapshot que ve el dashboard.
+
+    Dos niveles de redacción (FASE 37.2):
+      - sin `view_full`: oculta el roster de usuarios (PII de identidad).
+      - sin `view_pii`: oculta el CONTENIDO de la actividad (el texto de cada comando en
+        `recent_commands`) dejando la metadata (ts/agente/ok/latencia). Los `counts` —que son
+        sólo enteros— se conservan siempre: el detalle queda detrás de view_pii, los conteos no.
+    """
     redacted = dict(state)
-    redacted["users_summary"] = []  # adolescente no ve la lista de usuarios
+    if not caps.get("view_full"):
+        redacted["users_summary"] = []  # adolescente no ve la lista de usuarios
+    if not caps.get("view_pii"):
+        redacted["recent_commands"] = [
+            {**c, "text": ""} for c in redacted.get("recent_commands", [])
+        ]
     return redacted
 
 

--- a/cloud/tests/test_commands.py
+++ b/cloud/tests/test_commands.py
@@ -128,3 +128,39 @@ def test_deploy_satellites_node_id():
 def test_deploy_satellites_param_desconocido():
     with pytest.raises(CommandError):
         validate_command("deploy.satellites", {"nodo": "comedor"})
+
+
+# ── FASE 37.2: comandos de operación acotados ─────────────────────────────────
+
+def test_agent_toggle_ok():
+    assert validate_command("agent.toggle", {"agent_id": "haos", "status": "planned"}) == {
+        "agent_id": "haos", "status": "planned"}
+
+
+def test_agent_toggle_status_invalido():
+    with pytest.raises(CommandError):
+        validate_command("agent.toggle", {"agent_id": "haos", "status": "on"})
+
+
+def test_agent_toggle_requiere_agent_y_status():
+    with pytest.raises(CommandError):
+        validate_command("agent.toggle", {"agent_id": "haos"})
+    with pytest.raises(CommandError):
+        validate_command("agent.toggle", {"status": "active"})
+
+
+def test_panel_reboot_ok():
+    assert validate_command("panel.reboot", {"node_id": "comedor"}) == {"node_id": "comedor"}
+    with pytest.raises(CommandError):
+        validate_command("panel.reboot", {})
+
+
+def test_proactive_run_ok():
+    assert validate_command("proactive.run", {"agent_id": "clima"}) == {"agent_id": "clima"}
+    with pytest.raises(CommandError):
+        validate_command("proactive.run", {})
+
+
+def test_new_commands_in_catalog_summary():
+    types = {c["type"] for c in catalog_summary()}
+    assert {"agent.toggle", "panel.reboot", "proactive.run"} <= types

--- a/cloud/tests/test_rbac.py
+++ b/cloud/tests/test_rbac.py
@@ -8,7 +8,7 @@ from app import rbac
 
 def test_admin_full():
     c = rbac.caps_for("admin")
-    assert c == {"access": True, "view_full": True, "emit": True}
+    assert c == {"access": True, "view_full": True, "view_pii": True, "emit": True}
 
 
 def test_familiar_readonly():
@@ -24,6 +24,32 @@ def test_adolescente_basic_readonly():
 def test_nino_invitado_guest_no_access():
     for role in ("niño", "invitado", "guest", "", None, "loquesea"):
         assert rbac.caps_for(role)["access"] is False
+
+
+# ── FASE 37.2: view_pii admin-only, estrictamente más restrictiva que view_full ──
+
+def test_view_pii_admin_only():
+    assert rbac.caps_for("admin")["view_pii"] is True
+    assert rbac.caps_for("familiar")["view_pii"] is False
+    assert rbac.caps_for("adolescente")["view_pii"] is False
+    assert rbac.caps_for(None)["view_pii"] is False
+
+
+def test_filter_state_redacts_command_text_without_view_pii():
+    state = {"recent_commands": [{"ts": "t", "text": "prendé la luz del cuarto",
+                                  "agent": "comedor", "ok": True, "latency_ms": 12}],
+             "counts": {"conversations": 5}}
+    out = rbac.filter_state(state, rbac.caps_for("familiar"))   # view_full sí, view_pii no
+    assert out["recent_commands"][0]["text"] == ""              # contenido redactado
+    assert out["recent_commands"][0]["agent"] == "comedor"      # metadata conservada
+    assert out["recent_commands"][0]["latency_ms"] == 12
+    assert out["counts"] == {"conversations": 5}                # conteos siempre quedan
+
+
+def test_filter_state_keeps_command_text_for_admin():
+    state = {"recent_commands": [{"ts": "t", "text": "prendé la luz", "agent": "x", "ok": True}]}
+    out = rbac.filter_state(state, rbac.caps_for("admin"))
+    assert out["recent_commands"][0]["text"] == "prendé la luz"
 
 
 def test_filter_state_redacts_users_for_basic():

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (1/13 — hecho 37.1; pendientes 37.2-37.12).
+Estado:   EN CURSO (2/13 — hecho 37.1, 37.2; pendientes 37.3-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3500,7 +3500,7 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
             intents/goals/routines/conversaciones y versión desplegada (cruza FASE 34).
             Documentar qué sale y qué NO (sin contenido PII en claro). Tests de contrato del
             snapshot (`cloud/tests`).
-- [ ] 37.2  Capacidad `view_pii` (admin-only) en `cloud/app/rbac.py`, distinta de `view_full`;
+- [x] 37.2  Capacidad `view_pii` (admin-only) en `cloud/app/rbac.py`, distinta de `view_full`;
             `filter_state` redacta el detalle PII según ella (deja conteos). Catálogo de comandos
             extendido en `cloud/app/commands.py` (`agent.toggle`, `panel.reboot`, `proactive.run`)
             con validadores existentes. Tests de RBAC y de catálogo.


### PR DESCRIPTION
Etapa A de FASE 37.

**RBAC** (`cloud/app/rbac.py`): nueva capacidad `view_pii` admin-only, estrictamente más restrictiva que `view_full`. `filter_state` redacta el **contenido** (`text` de `recent_commands`) para roles sin `view_pii`, conservando metadata (ts/agente/ok/latencia) y los `counts`.

**Catálogo** (`cloud/app/commands.py`): comandos de operación acotados, validados como los existentes:
- `agent.toggle` — `agent_id` + `status` (active/planned/unavailable)
- `panel.reboot` — `node_id`
- `proactive.run` — `agent_id`

Los handlers del bridge se implementan en 37.8 (hoy el executor devuelve error limpio "sin handler").

Tests de RBAC y de catálogo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)