### PR TITLE
fase 37.3 — base SPA con sidebar + router + gating

### DIFF
--- a/cloud/app/static/style.css
+++ b/cloud/app/static/style.css
@@ -1,33 +1,115 @@
-:root { color-scheme: dark; }
+:root { color-scheme: dark; --bg:#0d1117; --panel:#161b22; --line:#21262d; --muted:#7d8590; --sidebar:248px; }
 * { box-sizing: border-box; }
 body {
   margin: 0; font-family: ui-sans-serif, system-ui, sans-serif;
-  background: #0d1117; color: #e6edf3; line-height: 1.4;
+  background: var(--bg); color: #e6edf3; line-height: 1.4;
 }
-header {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 12px 20px; border-bottom: 1px solid #21262d; background: #161b22;
-}
-h1 { font-size: 18px; margin: 0; }
-h2 { font-size: 14px; margin: 0 0 10px; text-transform: uppercase; letter-spacing: .05em; color: #7d8590; }
-main { max-width: 960px; margin: 0 auto; padding: 20px; }
-.card { background: #161b22; border: 1px solid #21262d; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 8px; }
-.muted { color: #7d8590; }
+h1 { font-size: 17px; margin: 0; }
+h2 { font-size: 13px; margin: 0 0 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+h3 { font-size: 13px; margin: 16px 0 8px; }
+.muted { color: var(--muted); }
+.warn { color: #f0a020; }
 .error { color: #f85149; }
 .hidden { display: none; }
+
+/* ── Login ─────────────────────────────────────────────────────────────────── */
+.login-card { max-width: 420px; margin: 12vh auto; }
+
+/* ── Shell: sidebar + content ──────────────────────────────────────────────── */
+#app { display: flex; min-height: 100vh; }
+.sidebar {
+  width: var(--sidebar); flex: 0 0 var(--sidebar); background: var(--panel);
+  border-right: 1px solid var(--line); padding: 14px 0; position: sticky; top: 0;
+  height: 100vh; overflow-y: auto;
+}
+.brand { font-size: 16px; font-weight: 600; padding: 4px 18px 14px; display: flex; align-items: center; gap: 8px; }
+nav { display: flex; flex-direction: column; }
+.nav-group {
+  font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted);
+  padding: 14px 18px 4px;
+}
+nav a {
+  color: #e6edf3; text-decoration: none; padding: 9px 18px; font-size: 14px;
+  border-left: 3px solid transparent;
+}
+nav a:hover { background: #1c2330; }
+nav a.current { background: #1c2330; border-left-color: #2ea043; font-weight: 600; }
+
+.content { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.topbar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 20px; border-bottom: 1px solid var(--line); background: var(--panel);
+  position: sticky; top: 0; z-index: 5;
+}
+.topbar h1 { flex: 1; }
+.userbox { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+main { max-width: 1000px; width: 100%; margin: 0 auto; padding: 20px; }
+.updated-line { font-size: 12px; margin: 0 0 12px; }
+
+/* ── Vistas (router por hash) ──────────────────────────────────────────────── */
+.view { display: none; }
+.view.active { display: block; }
+
+/* ── Cards / grids ─────────────────────────────────────────────────────────── */
+.card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+.placeholder { border-style: dashed; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 8px; }
+
+.tile {
+  background: var(--bg); border: 1px solid var(--line); border-radius: 8px;
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 2px;
+}
+.tile b { font-size: 22px; }
+.tile span { font-size: 12px; color: var(--muted); }
+.tile.ok b { color: #2ea043; }
+.tile.warn b { color: #f0a020; }
+
+.alerts-list { margin: 0; padding-left: 18px; font-size: 14px; }
+.alerts-list li { margin: 4px 0; }
+
+/* ── Botones / forms ───────────────────────────────────────────────────────── */
 button {
   background: #238636; color: #fff; border: 0; border-radius: 6px;
   padding: 8px 14px; cursor: pointer; font-size: 14px;
 }
 button:hover { background: #2ea043; }
+button.mini { font-size: 11px; padding: 2px 8px; margin-left: 6px; }
 #signout { background: #30363d; }
+.icon-btn { background: transparent; color: #e6edf3; font-size: 20px; padding: 2px 8px; }
+.icon-btn:hover { background: #1c2330; }
 input, select {
-  background: #0d1117; color: #e6edf3; border: 1px solid #30363d;
+  background: var(--bg); color: #e6edf3; border: 1px solid #30363d;
   border-radius: 6px; padding: 8px; font-size: 14px;
 }
 form { display: flex; gap: 8px; flex-wrap: wrap; }
 #cmd-params { flex: 1; min-width: 240px; }
+.cmd-log { background:#0d1117; color:#cfc; padding:8px; border-radius:6px; max-height:320px;
+  overflow:auto; font-size:12px; white-space:pre-wrap; }
+.advanced { margin-top: 8px; }
+.advanced summary { cursor: pointer; }
+.advanced .grid { margin-top: 4px; }
+
+/* ── Tablas ────────────────────────────────────────────────────────────────── */
 table { width: 100%; border-collapse: collapse; font-size: 13px; }
-td { padding: 6px 8px; border-bottom: 1px solid #21262d; }
-code { background: #0d1117; padding: 2px 6px; border-radius: 4px; }
+th { text-align: left; padding: 6px 8px; color: var(--muted); font-weight: 500; border-bottom: 1px solid var(--line); }
+td { padding: 6px 8px; border-bottom: 1px solid var(--line); }
+code { background: var(--bg); padding: 2px 6px; border-radius: 4px; }
+canvas { max-width: 100%; }
+
+/* ── Mobile: sidebar → drawer ──────────────────────────────────────────────── */
+.only-mobile { display: none; }
+.scrim { display: none; }
+@media (max-width: 720px) {
+  .only-mobile { display: inline-flex; }
+  .sidebar {
+    position: fixed; top: 0; left: 0; z-index: 20; height: 100vh;
+    transform: translateX(-100%); transition: transform .2s ease;
+  }
+  #app.drawer-open .sidebar { transform: translateX(0); }
+  #app.drawer-open .scrim {
+    display: block; position: fixed; inset: 0; background: rgba(0,0,0,.5); z-index: 15;
+  }
+  .brand { justify-content: space-between; }
+  main { padding: 14px; }
+  .userbox #useremail { display: none; }   /* el email no entra en portrait */
+}

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -7,84 +7,157 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-<header>
+
+<!-- Login (sin sesión) -->
+<section id="login" class="card login-card">
   <h1>Capitán <span class="muted">· nube</span></h1>
-  <div id="userbox" class="hidden">
-    <span id="useremail" class="muted"></span>
-    <button id="signout">salir</button>
-  </div>
-</header>
+  <p>Backoffice remoto. Acceso restringido a: <code>{{ allowed_emails }}</code></p>
+  <button id="signin">Ingresar con Google</button>
+  <p id="login-error" class="error hidden"></p>
+</section>
 
-<main>
-  <section id="login" class="card">
-    <p>Backoffice remoto. Acceso restringido a: <code>{{ allowed_emails }}</code></p>
-    <button id="signin">Ingresar con Google</button>
-    <p id="login-error" class="error hidden"></p>
-  </section>
+<!-- App (con sesión) -->
+<div id="app" class="hidden">
+  <div id="scrim" class="scrim"></div>
 
-  <div id="app" class="hidden">
-    <p class="muted" id="updated"></p>
+  <aside id="sidebar" class="sidebar">
+    <div class="brand">
+      <button id="nav-close" class="icon-btn only-mobile" aria-label="cerrar menú">✕</button>
+      Capitán <span class="muted">· nube</span>
+    </div>
+    <nav id="nav"></nav>
+  </aside>
 
-    <section class="card">
-      <h2>Servicios</h2>
-      <div id="services" class="grid"></div>
-    </section>
-
-    <section class="card">
-      <h2>Latencias (ms)</h2>
-      <div id="latency" class="grid"></div>
-    </section>
-
-    <section class="card">
-      <h2>Agentes</h2>
-      <div id="agents" class="grid"></div>
-    </section>
-
-    <section class="card">
-      <h2>Versiones desplegadas</h2>
-      <div id="versions"></div>
-    </section>
-
-    <section class="card">
-      <h2>Últimos comandos de voz</h2>
-      <table id="recent"><tbody></tbody></table>
-    </section>
-
-    <section class="card" id="metrics-card">
-      <h2>Métricas <span class="muted" id="metrics-window"></span></h2>
-      <div id="metrics-empty" class="muted hidden">sin métricas todavía</div>
-      <div id="metrics-body" class="hidden">
-        <h3>Voz</h3>
-        <div id="m-voice-summary" class="grid"></div>
-        <canvas id="m-voice-chart" height="80"></canvas>
-        <h3>LLM / Agentes</h3>
-        <div id="m-llm-summary" class="grid"></div>
-        <canvas id="m-llm-chart" height="80"></canvas>
-        <div id="m-tables">
-          <table id="m-models"><thead><tr><th>modelo</th><th>llamadas</th><th>lat ms</th><th>tokens</th></tr></thead><tbody></tbody></table>
-          <table id="m-agents"><thead><tr><th>agente</th><th>steps</th><th>aciertos</th><th>lat ms</th></tr></thead><tbody></tbody></table>
-        </div>
+  <div class="content">
+    <header class="topbar">
+      <button id="nav-open" class="icon-btn only-mobile" aria-label="abrir menú">☰</button>
+      <h1 id="section-title">Resumen</h1>
+      <div id="userbox" class="userbox">
+        <span id="useremail" class="muted"></span>
+        <button id="signout">salir</button>
       </div>
-    </section>
+    </header>
 
-    <section class="card hidden" id="actions-card">
-      <h2>Acciones admin</h2>
-      <form id="emit">
-        <select id="cmd-type"></select>
-        <input id="cmd-params" placeholder='params JSON, ej {"service":"capitan-core"}'>
-        <button type="submit">Emitir</button>
-      </form>
-      <p id="emit-msg" class="muted"></p>
-      <pre id="cmd-log" class="hidden" style="background:#111;color:#cfc;padding:8px;
-        border-radius:6px;max-height:320px;overflow:auto;font-size:12px;white-space:pre-wrap"></pre>
-    </section>
+    <main>
+      <p class="muted updated-line" id="updated"></p>
 
-    <section class="card hidden" id="audit-card">
-      <h2>Auditoría de comandos admin</h2>
-      <table id="audit"><tbody></tbody></table>
-    </section>
+      <!-- ── Resumen ─────────────────────────────────────────── -->
+      <section class="view" data-view="resumen">
+        <div class="grid" id="summary-tiles"></div>
+        <div class="card">
+          <h2>Alertas recientes</h2>
+          <ul id="summary-alerts" class="alerts-list"></ul>
+        </div>
+      </section>
+
+      <!-- ── Servicios ───────────────────────────────────────── -->
+      <section class="view" data-view="servicios">
+        <div class="card">
+          <h2>Servicios</h2>
+          <div id="services" class="grid"></div>
+        </div>
+        <div class="card">
+          <h2>Latencias (ms)</h2>
+          <div id="latency" class="grid"></div>
+        </div>
+      </section>
+
+      <!-- ── Métricas ────────────────────────────────────────── -->
+      <section class="view" data-view="metricas">
+        <div class="card" id="metrics-card">
+          <h2>Métricas <span class="muted" id="metrics-window"></span></h2>
+          <div id="metrics-empty" class="muted hidden">sin métricas todavía</div>
+          <div id="metrics-body" class="hidden">
+            <h3>Voz</h3>
+            <div id="m-voice-summary" class="grid"></div>
+            <canvas id="m-voice-chart" height="80"></canvas>
+            <h3>LLM / Agentes</h3>
+            <div id="m-llm-summary" class="grid"></div>
+            <canvas id="m-llm-chart" height="80"></canvas>
+            <div id="m-tables">
+              <table id="m-models"><thead><tr><th>modelo</th><th>llamadas</th><th>lat ms</th><th>tokens</th></tr></thead><tbody></tbody></table>
+              <table id="m-agents"><thead><tr><th>agente</th><th>steps</th><th>aciertos</th><th>lat ms</th></tr></thead><tbody></tbody></table>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ── Alertas (datos en 37.6) ─────────────────────────── -->
+      <section class="view" data-view="alertas">
+        <div class="card"><h2>Alertas</h2><ul id="alerts-list" class="alerts-list"></ul></div>
+      </section>
+
+      <!-- ── Logs (37.6) ─────────────────────────────────────── -->
+      <section class="view" data-view="logs">
+        <div class="card placeholder"><h2>Logs</h2>
+          <p class="muted">Sección en preparación (37.6): traer N líneas de un servicio o satélite por comando tipado.</p>
+        </div>
+      </section>
+
+      <!-- ── Actividad ───────────────────────────────────────── -->
+      <section class="view" data-view="actividad">
+        <div class="card">
+          <h2>Últimos comandos de voz</h2>
+          <table id="recent"><tbody></tbody></table>
+        </div>
+      </section>
+
+      <!-- ── Agentes ─────────────────────────────────────────── -->
+      <section class="view" data-view="agentes">
+        <div class="card"><h2>Agentes</h2><div id="agents" class="grid"></div></div>
+      </section>
+
+      <!-- ── Wake word (37.4) ────────────────────────────────── -->
+      <section class="view" data-view="wakeword">
+        <div class="card" id="wakeword-card"><h2>Wake word</h2>
+          <div id="wakeword-body" class="grid"></div>
+        </div>
+      </section>
+
+      <!-- ── Paneles (37.4) ──────────────────────────────────── -->
+      <section class="view" data-view="paneles">
+        <div class="card placeholder"><h2>Paneles</h2>
+          <p class="muted">Sección en preparación (37.4): estado y reboot por panel.</p>
+        </div>
+      </section>
+
+      <!-- ── Deploy ──────────────────────────────────────────── -->
+      <section class="view" data-view="deploy">
+        <div class="card"><h2>Deploy · versiones desplegadas</h2><div id="versions"></div></div>
+      </section>
+
+      <!-- ── Usuarios ────────────────────────────────────────── -->
+      <section class="view" data-view="usuarios">
+        <div class="card">
+          <h2>Usuarios</h2>
+          <table id="users"><thead><tr><th>usuario</th><th>rol</th><th>pendientes</th><th>email</th></tr></thead><tbody></tbody></table>
+        </div>
+      </section>
+
+      <!-- ── Acciones (UI de comandos: overhaul en 37.5) ─────── -->
+      <section class="view" data-view="acciones">
+        <div class="card" id="actions-card">
+          <h2>Acciones admin</h2>
+          <form id="emit">
+            <select id="cmd-type"></select>
+            <input id="cmd-params" placeholder='params JSON, ej {"service":"capitan-core"}'>
+            <button type="submit">Emitir</button>
+          </form>
+          <p id="emit-msg" class="muted"></p>
+          <pre id="cmd-log" class="hidden cmd-log"></pre>
+        </div>
+      </section>
+
+      <!-- ── Auditoría ───────────────────────────────────────── -->
+      <section class="view" data-view="auditoria">
+        <div class="card">
+          <h2>Auditoría de comandos admin</h2>
+          <table id="audit"><tbody></tbody></table>
+        </div>
+      </section>
+    </main>
   </div>
-</main>
+</div>
 
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
@@ -104,6 +177,73 @@ const $ = (id) => document.getElementById(id);
 const show = (id) => $(id).classList.remove("hidden");
 const hide = (id) => $(id).classList.add("hidden");
 
+// ── Taxonomía del sidebar (paridad con el backoffice local) ───────────────────
+// cap: capacidad mínima para ver la sección. El sidebar oculta lo no permitido y el
+// router rechaza navegar a una vista sin capacidad.
+const SECTIONS = [
+  { group: "Monitoreo", items: [
+    { id: "resumen",   label: "Resumen",   cap: "access" },
+    { id: "servicios", label: "Servicios", cap: "access" },
+    { id: "metricas",  label: "Métricas",  cap: "access" },
+    { id: "alertas",   label: "Alertas",   cap: "access" },
+    { id: "logs",      label: "Logs",      cap: "emit" },
+    { id: "actividad", label: "Actividad", cap: "access" },
+  ]},
+  { group: "Sistema", items: [
+    { id: "agentes",  label: "Agentes",   cap: "access" },
+    { id: "wakeword", label: "Wake word", cap: "access" },
+    { id: "paneles",  label: "Paneles",   cap: "access" },
+    { id: "deploy",   label: "Deploy",    cap: "access" },
+  ]},
+  { group: "Administración", items: [
+    { id: "usuarios",  label: "Usuarios",  cap: "view_full" },
+    { id: "acciones",  label: "Acciones",  cap: "emit" },
+    { id: "auditoria", label: "Auditoría", cap: "view_full" },
+  ]},
+];
+const SECTION_BY_ID = {};
+SECTIONS.forEach(g => g.items.forEach(s => { SECTION_BY_ID[s.id] = s; }));
+const allowedSection = (id) => {
+  const s = SECTION_BY_ID[id];
+  return s && CAPS[s.cap];
+};
+
+let CAPS = {};
+
+function renderNav() {
+  $("nav").innerHTML = SECTIONS.map(g => {
+    const links = g.items.filter(s => CAPS[s.cap]).map(s =>
+      `<a href="#${s.id}" data-link="${s.id}">${s.label}</a>`).join("");
+    return links ? `<div class="nav-group">${g.group}</div>${links}` : "";
+  }).join("");
+}
+
+function firstAllowed() {
+  for (const g of SECTIONS) for (const s of g.items) if (CAPS[s.cap]) return s.id;
+  return null;
+}
+
+// ── Router por hash ───────────────────────────────────────────────────────────
+function route() {
+  let id = (location.hash || "").replace("#", "");
+  if (!allowedSection(id)) id = firstAllowed();
+  if (!id) return;
+  document.querySelectorAll(".view").forEach(v =>
+    v.classList.toggle("active", v.dataset.view === id));
+  document.querySelectorAll("#nav a").forEach(a =>
+    a.classList.toggle("current", a.dataset.link === id));
+  $("section-title").textContent = SECTION_BY_ID[id].label;
+  closeDrawer();
+}
+window.addEventListener("hashchange", route);
+
+// ── Drawer móvil ──────────────────────────────────────────────────────────────
+const openDrawer = () => $("app").classList.add("drawer-open");
+const closeDrawer = () => $("app").classList.remove("drawer-open");
+$("nav-open").onclick = openDrawer;
+$("nav-close").onclick = closeDrawer;
+$("scrim").onclick = closeDrawer;
+
 $("signin").onclick = () => auth.signInWithPopup(provider).catch(e => {
   $("login-error").textContent = e.message; show("login-error");
 });
@@ -118,26 +258,24 @@ async function api(path, opts = {}) {
   return r.json();
 }
 
+const esc = (s) => String(s == null ? "" : s).replace(/[<>&]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;"}[c]));
 function dot(ok) { return ok ? "🟢" : "🔴"; }
 
-// Matriz de versiones (FASE 34 T5): repos del Brain con link al release de GitHub + paneles
-// con su versión y si están al día respecto del código que sirve el Brain.
 // Matriz unificada de TARGETS (34.15): una fila por cosa que corre, un botón que elige el
 // comando solo. El snapshot ya trae version/latest/behind + command+params por target.
 let TARGETS_BY_ID = {};
 const WHERE_ICON = { Brain: "🖥️", GCP: "☁️", NSPanel: "📟" };
 function renderVersions(v) {
-  const esc = (s) => String(s == null ? "" : s).replace(/[<>&]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;"}[c]));
   const link = (text, url) => url ? `<a href="${esc(url)}" target="_blank">${esc(text)}</a>` : esc(text);
   const btn = (label, id) => CAPS.emit
-    ? ` <button onclick="deployTarget('${esc(id)}')" style="font-size:11px;padding:1px 6px;margin-left:6px">${label}</button>` : "";
+    ? ` <button class="mini" onclick="deployTarget('${esc(id)}')">${label}</button>` : "";
   TARGETS_BY_ID = {};
   const all = v.targets || [];
   all.forEach(t => { TARGETS_BY_ID[t.id] = t; });
   const row = (t) => {
     const run = link(t.version || "—", t.url);
     const avail = t.behind
-      ? `<span style="color:#fa0">⬆ ${link(t.latest || "?", t.latest_url)}</span>`
+      ? `<span class="warn">⬆ ${link(t.latest || "?", t.latest_url)}</span>`
       : `<span class="muted">al día</span>`;
     return `<div>${t.behind ? "⚠️" : "🟢"} ${WHERE_ICON[t.where] || ""} <b>${esc(t.label)}</b> `
       + `<span class="muted">${esc(t.where)}</span> ${run} · ${avail}`
@@ -147,8 +285,8 @@ function renderVersions(v) {
   const adv  = all.filter(t => t.advanced).map(row).join("");
   $("versions").innerHTML =
     `<div class="grid">${main || "<span class='muted'>sin datos</span>"}</div>`
-    + (adv ? `<details style="margin-top:8px"><summary class="muted" style="cursor:pointer">avanzado (wa · bridge)</summary>`
-             + `<div class="grid" style="margin-top:4px">${adv}</div></details>` : "");
+    + (adv ? `<details class="advanced"><summary class="muted">avanzado (wa · bridge)</summary>`
+             + `<div class="grid">${adv}</div></details>` : "");
 }
 
 async function emitDeploy(type, params, label) {
@@ -168,39 +306,82 @@ function deployTarget(id) {
   emitDeploy(t.command, t.params, t.label);
 }
 
-let CAPS = {};
+function renderSummary(state) {
+  const svc = Object.values(state.services || {});
+  const up = svc.filter(s => s.up).length;
+  const agents = state.agents || [];
+  const act = agents.filter(a => a.active).length;
+  const c = state.counts || {};
+  const ww = state.wakeword || {};
+  const tile = (n, label, cls) => `<div class="tile ${cls||""}"><b>${n}</b><span>${label}</span></div>`;
+  $("summary-tiles").innerHTML =
+    tile(`${up}/${svc.length || 0}`, "servicios up", up === svc.length ? "ok" : "warn") +
+    tile(`${act}/${agents.length}`, "agentes activos") +
+    tile(c.conversations ?? "—", "conversaciones") +
+    tile(c.intents ?? "—", "intenciones") +
+    tile(c.goals ?? "—", "goals") +
+    tile(c.routines ?? "—", "rutinas") +
+    tile(ww.false_positives_24h ?? "—", "falsos pos. 24h") +
+    tile((state.alerts || []).length, "alertas", (state.alerts||[]).length ? "warn" : "");
+  const alerts = state.alerts || [];
+  $("summary-alerts").innerHTML = alerts.length
+    ? alerts.map(a => `<li>${esc(a)}</li>`).join("")
+    : `<li class="muted">sin alertas</li>`;
+  $("alerts-list").innerHTML = $("summary-alerts").innerHTML;
+}
+
+function renderWakeword(ww) {
+  const st = ww.status || "idle";
+  const stIcon = { running: "🟡", done: "🟢", error: "🔴" }[st] || "⚪";
+  const nodes = (ww.nodes || []).map(n =>
+    `<div>${dot(n.online)} <b>${esc(n.id)}</b> <span class="muted">${esc(n.ip || "")}</span></div>`).join("");
+  $("wakeword-body").innerHTML =
+    `<div>${stIcon} entrenamiento <b>${esc(st)}</b></div>`
+    + `<div><b>${ww.false_positives_24h ?? "—"}</b> falsos pos. 24h</div>`
+    + (nodes || `<div class="muted">sin nodos</div>`);
+}
+
+function renderUsers(users) {
+  $("users").querySelector("tbody").innerHTML = (users || []).map(u =>
+    `<tr><td><b>${esc(u.name)}</b></td><td>${esc(u.role)}</td>`
+    + `<td>${u.intents_pending || 0}</td><td class="muted">${esc(u.email || "—")}</td></tr>`).join("")
+    || `<tr><td class="muted" colspan="4">sin usuarios</td></tr>`;
+}
 
 async function refresh() {
   try {
     const { state } = await api("/api/state");
     if (!state) { $("updated").textContent = "sin datos del Brain todavía"; return; }
     $("updated").textContent = "snapshot: " + (state.ts || "?");
+    renderSummary(state);
     $("services").innerHTML = Object.entries(state.services || {})
-      .map(([k, v]) => `<div>${dot(v.up)} <b>${k}</b> <span class="muted">${v.detail || ""}</span></div>`).join("");
+      .map(([k, v]) => `<div>${dot(v.up)} <b>${k}</b> <span class="muted">${esc(v.detail || "")}</span></div>`).join("");
     const L = state.latency || {};
     $("latency").innerHTML = ["stt_ms", "llm_ms", "haos_ms"]
       .map(k => `<div><b>${k.replace("_ms","").toUpperCase()}</b> ${L[k] ?? "—"}</div>`).join("");
     $("agents").innerHTML = (state.agents || [])
-      .map(a => `<div>${dot(a.active)} <b>${a.id}</b>${a.proactive ? " ⚡" : ""}</div>`).join("");
+      .map(a => `<div>${dot(a.active)} <b>${esc(a.id)}</b>${a.proactive ? " ⚡" : ""}</div>`).join("");
+    renderWakeword(state.wakeword || {});
     renderVersions(state.versions || {});
+    renderUsers(state.users_summary);
     $("recent").querySelector("tbody").innerHTML = (state.recent_commands || [])
-      .map(c => `<tr><td>${dot(c.ok)}</td><td>${c.text}</td><td class="muted">${c.agent}</td><td class="muted">${c.latency_ms ?? "—"}ms</td></tr>`).join("");
+      .map(c => `<tr><td>${dot(c.ok)}</td><td>${esc(c.text) || "<span class='muted'>—</span>"}</td><td class="muted">${esc(c.agent)}</td><td class="muted">${c.latency_ms ?? "—"}ms</td></tr>`).join("");
   } catch (e) { $("updated").textContent = "error: " + e.message; }
   loadMetrics();
   if (!CAPS.view_full) return;  // adolescente: sin auditoría
   try {
     const { commands } = await api("/api/commands");
-    const st = (s) => s === "done" ? "🟢" : s === "error" ? "🔴" : s === "running" ? "🟡" : "⚪";
+    const stIcon = (s) => s === "done" ? "🟢" : s === "error" ? "🔴" : s === "running" ? "🟡" : "⚪";
     $("audit").querySelector("tbody").innerHTML = commands
       .map(c => {
         const r = c.result || {};
         const res = c.status === "pending" || c.status === "running" ? ""
           : (r.ok ? (r.output || "ok") : ("error: " + (r.error || ""))).slice(0, 80);
-        return `<tr><td>${st(c.status)} ${c.status}</td><td><b>${c.type}</b></td>`
-          + `<td class="muted">${JSON.stringify(c.params)}</td>`
-          + `<td class="muted">${c.issued_by}</td>`
-          + `<td class="muted">${c.issued_at}</td>`
-          + `<td class="muted">${res}</td></tr>`;
+        return `<tr><td>${stIcon(c.status)} ${c.status}</td><td><b>${esc(c.type)}</b></td>`
+          + `<td class="muted">${esc(JSON.stringify(c.params))}</td>`
+          + `<td class="muted">${esc(c.issued_by)}</td>`
+          + `<td class="muted">${esc(c.issued_at)}</td>`
+          + `<td class="muted">${esc(res)}</td></tr>`;
       }).join("");
   } catch (e) {}
 }
@@ -212,7 +393,8 @@ const mLabel = (ts) => new Date(ts * 1000).toLocaleString("es", {day:"2-digit",m
 function mkMetricChart(canvasId, type) {
   return new Chart($(canvasId), {
     type, data: {labels: [], datasets: []},
-    options: {responsive: true, plugins: {legend: {labels: {boxWidth: 12}}}, scales: {y: {beginAtZero: true}}},
+    options: {responsive: true, maintainAspectRatio: false,
+      plugins: {legend: {labels: {boxWidth: 12}}}, scales: {y: {beginAtZero: true}}},
   });
 }
 
@@ -257,10 +439,10 @@ async function loadMetrics() {
   const models = metrics.llm_by_model || [], agents = metrics.llm_by_agent || [];
   $("m-tables").style.display = (models.length || agents.length) ? "" : "none";
   $("m-models").querySelector("tbody").innerHTML = models.map(m =>
-    `<tr><td>${m.model || "—"}</td><td>${mFmt(m.calls)}</td><td>${mFmt(m.avg_latency_ms)}</td>` +
+    `<tr><td>${esc(m.model) || "—"}</td><td>${mFmt(m.calls)}</td><td>${mFmt(m.avg_latency_ms)}</td>` +
     `<td class="muted">${mFmt(m.prompt_tokens)}/${mFmt(m.completion_tokens)}</td></tr>`).join("");
   $("m-agents").querySelector("tbody").innerHTML = agents.map(a =>
-    `<tr><td>${a.agent_id || "—"}</td><td>${mFmt(a.steps)}</td><td>${mPct(a.success_rate)}</td>` +
+    `<tr><td>${esc(a.agent_id) || "—"}</td><td>${mFmt(a.steps)}</td><td>${mPct(a.success_rate)}</td>` +
     `<td>${mFmt(a.avg_latency_ms)}</td></tr>`).join("");
 }
 
@@ -316,26 +498,23 @@ let timer = null;
 auth.onAuthStateChanged(async (user) => {
   if (!user) {
     idToken = null; clearInterval(timer);
-    hide("app"); hide("userbox"); show("login");
+    hide("app"); show("login");
     return;
   }
   idToken = await user.getIdToken();
-  $("useremail").textContent = user.email;
   // Autorización + capacidades RBAC (rol resuelto contra el roster del Brain).
   let me;
   try { me = await api("/api/me"); }
   catch (e) {
     $("login-error").textContent = e.message + " — tu cuenta no tiene acceso";
-    show("login"); hide("app"); hide("userbox"); auth.signOut(); return;
+    show("login"); hide("app"); auth.signOut(); return;
   }
   CAPS = me.caps || {};
   $("useremail").textContent = user.email + " · " + me.role;
-  hide("login"); show("app"); show("userbox");
-  if (CAPS.view_full) show("audit-card"); else hide("audit-card");
-  if (CAPS.emit) {
-    show("actions-card");
-    try { await loadCatalog(); } catch (e) { hide("actions-card"); }
-  } else { hide("actions-card"); }
+  hide("login"); show("app");
+  renderNav();
+  route();           // respeta el hash actual si la cap lo permite, si no cae al primero
+  if (CAPS.emit) { try { await loadCatalog(); } catch (e) {} }
   refresh();
   timer = setInterval(async () => { idToken = await user.getIdToken(); refresh(); }, 10000);
 });

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (2/13 — hecho 37.1, 37.2; pendientes 37.3-37.12).
+Estado:   EN CURSO (3/13 — hecho 37.1-37.3; pendientes 37.4-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3506,7 +3506,7 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
             con validadores existentes. Tests de RBAC y de catálogo.
 
 #### Etapa B - Frontend reestructurado (sidebar + secciones)
-- [ ] 37.3  Base SPA con sidebar (Monitoreo/Sistema/Administración), router por hash y links
+- [x] 37.3  Base SPA con sidebar (Monitoreo/Sistema/Administración), router por hash y links
             gated por caps (`access`/`view_full`/`view_pii`/`emit`); el sidebar oculta lo no
             permitido y el router rechaza navegación a vistas sin capacidad.
 - [ ] 37.4  Secciones: Resumen, Servicios, Métricas, Alertas, Logs, Agentes, Actividad, Wake


### PR DESCRIPTION
Etapa B de FASE 37. Reestructura el dashboard cloud de página única (tarjetas apiladas) a un **SPA con sidebar + secciones**.

- **Sidebar** con la taxonomía del backoffice local (Monitoreo / Sistema / Administración).
- **Router client-side por hash**: muestra/oculta vistas; cae a la primera vista accesible si el hash apunta a una sin capacidad.
- **Gating por capacidad** (`access`/`view_full`/`emit`): el sidebar oculta los links no permitidos y el router rechaza navegar a vistas sin cap.
- **Mobile-first**: la sidebar colapsa a drawer con scrim en viewport ≤720px (botón ☰). Charts con reflow.

Preserva toda la lógica existente (auth Firebase, deploy/targets, métricas, auditoría, streaming de comandos) reorganizada en secciones. Las secciones cuyos datos llegan en 37.4/37.6 (Logs, Paneles) quedan como placeholder explícito; Resumen / Usuarios / Wake word ya se alimentan del snapshot contratado en 37.1.

La UI de comandos contextual (reemplazo del `<select>` + JSON) es 37.5.

Verificado: render Jinja del template + suite cloud (71 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)