### PR TITLE
fase 37.4 — sección Paneles + secciones completas

### DIFF
--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -114,11 +114,9 @@
         </div>
       </section>
 
-      <!-- ── Paneles (37.4) ──────────────────────────────────── -->
+      <!-- ── Paneles ─────────────────────────────────────────── -->
       <section class="view" data-view="paneles">
-        <div class="card placeholder"><h2>Paneles</h2>
-          <p class="muted">Sección en preparación (37.4): estado y reboot por panel.</p>
-        </div>
+        <div class="card"><h2>Paneles (NSPanel)</h2><div id="panels"></div></div>
       </section>
 
       <!-- ── Deploy ──────────────────────────────────────────── -->
@@ -341,6 +339,23 @@ function renderWakeword(ww) {
     + (nodes || `<div class="muted">sin nodos</div>`);
 }
 
+function renderPanels(state) {
+  const nodes = (state.wakeword || {}).nodes || [];
+  // versión/al-día por panel desde la matriz de targets (kind satellite)
+  const tgt = {};
+  ((state.versions || {}).targets || []).filter(t => t.kind === "satellite")
+    .forEach(t => { tgt[t.label] = t; });
+  $("panels").innerHTML = nodes.length ? `<div class="grid">` + nodes.map(n => {
+    const t = tgt[n.id] || {};
+    const ver = t.version ? `<span class="muted">${esc(t.version)}</span>` : "";
+    const upd = t.behind ? ` <span class="warn">⬆ desactualizado</span>` : "";
+    const rms = n.rms != null ? ` · rms ${n.rms}` : "";
+    return `<div class="tile"><b>${dot(n.online)} ${esc(n.id)}</b>`
+      + `<span>${esc(n.ip || "sin ip")}${rms}</span>`
+      + `<span>${ver}${upd}</span></div>`;
+  }).join("") + `</div>` : `<span class="muted">sin paneles registrados</span>`;
+}
+
 function renderUsers(users) {
   $("users").querySelector("tbody").innerHTML = (users || []).map(u =>
     `<tr><td><b>${esc(u.name)}</b></td><td>${esc(u.role)}</td>`
@@ -362,6 +377,7 @@ async function refresh() {
     $("agents").innerHTML = (state.agents || [])
       .map(a => `<div>${dot(a.active)} <b>${esc(a.id)}</b>${a.proactive ? " ⚡" : ""}</div>`).join("");
     renderWakeword(state.wakeword || {});
+    renderPanels(state);
     renderVersions(state.versions || {});
     renderUsers(state.users_summary);
     $("recent").querySelector("tbody").innerHTML = (state.recent_commands || [])

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (3/13 — hecho 37.1-37.3; pendientes 37.4-37.12).
+Estado:   EN CURSO (4/13 — hecho 37.1-37.4; pendientes 37.5-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3509,8 +3509,9 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
 - [x] 37.3  Base SPA con sidebar (Monitoreo/Sistema/Administración), router por hash y links
             gated por caps (`access`/`view_full`/`view_pii`/`emit`); el sidebar oculta lo no
             permitido y el router rechaza navegación a vistas sin capacidad.
-- [ ] 37.4  Secciones: Resumen, Servicios, Métricas, Alertas, Logs, Agentes, Actividad, Wake
+- [x] 37.4  Secciones: Resumen, Servicios, Métricas, Alertas, Logs, Agentes, Actividad, Wake
             word, Paneles, Usuarios, Deploy, Auditoría. Cada vista gated por capacidad.
+            (Logs queda como placeholder gated hasta el endpoint de 37.6.)
 - [ ] 37.5  Interfaz de comandos contextual (reemplaza el `<select>` + input JSON): acciones
             por entidad (restart/toggle/reboot/retrain/reload/run) con widgets propios,
             confirmación en destructivas y feedback inline del estado; formularios tipados para


### PR DESCRIPTION
Etapa B. Completa la sección **Paneles** (estado online/ip/rms por NSPanel desde el snapshot + versión/desactualizado desde la matriz de targets). El resto de secciones ya renderizan desde 37.3. Logs sigue placeholder gated hasta el endpoint de 37.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)