### PR TITLE
fase 37.6 — metadata de presentación del catálogo + /api/alerts y /api/logs

### DIFF
--- a/cloud/app/commands.py
+++ b/cloud/app/commands.py
@@ -134,12 +134,76 @@ def validate_command(cmd_type: str, params: dict[str, Any] | None) -> dict[str, 
     return out
 
 
+# ── Metadata de PRESENTACIÓN (FASE 37.6) ──────────────────────────────────────
+# Describe cómo renderizar cada comando/parámetro en una UI final-user (sin JSON crudo):
+# label legible, `kind` de widget y restricciones. NO participa de la validación
+# (validate_command sigue siendo la única autoridad); es sólo presentación.
+#   kind: enum   → dropdown (choices)
+#         multi  → checkboxes (choices, lista)
+#         bool   → toggle
+#         int    → número (min/max)
+#         str    → texto libre
+#         node   → selector de panel (poblado por el front desde el snapshot)
+#         user   → selector de usuario
+#         agent  → selector de agente
+# Comandos con entidad-ancla (agent.toggle/panel.reboot/proactive.run/...) se invocan como
+# acciones contextuales en su sección; igual se exponen aquí para completitud.
+CMD_LABELS: dict[str, str] = {
+    "service.restart": "Reiniciar servicio",
+    "service.status": "Estado de servicio",
+    "deploy.run": "Deploy (legacy)",
+    "deploy.release": "Release de servicios",
+    "deploy.cloud": "Deploy Cloud Run",
+    "deploy.satellites": "Actualizar paneles",
+    "logs.tail": "Ver logs de servicio",
+    "config.reload": "Recargar configuración",
+    "wakeword.retrain": "Reentrenar wake word",
+    "voice.reenroll": "Re-enrolar voz",
+    "agent.toggle": "Cambiar estado de agente",
+    "panel.reboot": "Reiniciar panel",
+    "proactive.run": "Correr agente proactivo",
+}
+
+PRESENTATION: dict[str, dict[str, dict[str, Any]]] = {
+    "service.restart": {"service": {"kind": "enum", "label": "Servicio", "choices": SERVICES}},
+    "service.status":  {"service": {"kind": "enum", "label": "Servicio", "choices": SERVICES}},
+    "deploy.run":      {"restart_wa": {"kind": "bool", "label": "Reiniciar WhatsApp", "default": False}},
+    "deploy.release":  {"services": {"kind": "multi", "label": "Servicios", "choices": DEPLOY_SERVICES},
+                        "core_ref": {"kind": "str", "label": "Ref core (sha/tag/branch)"},
+                        "ear_ref": {"kind": "str", "label": "Ref ear"},
+                        "umbrella_ref": {"kind": "str", "label": "Ref umbrella"}},
+    "deploy.cloud":    {"services": {"kind": "multi", "label": "Targets Cloud Run", "choices": CLOUDRUN_SERVICES}},
+    "deploy.satellites": {"node_id": {"kind": "node", "label": "Panel (vacío = todos)"}},
+    "logs.tail":       {"service": {"kind": "enum", "label": "Servicio", "choices": SERVICES},
+                        "lines": {"kind": "int", "label": "Líneas", "min": 1, "max": 500, "default": 100}},
+    "config.reload":   {"target": {"kind": "enum", "label": "Target", "choices": CONFIG_TARGETS}},
+    "wakeword.retrain": {},
+    "voice.reenroll":  {"node_id": {"kind": "node", "label": "Panel"},
+                        "user_id": {"kind": "user", "label": "Usuario"}},
+    "agent.toggle":    {"agent_id": {"kind": "agent", "label": "Agente"},
+                        "status": {"kind": "enum", "label": "Estado", "choices": AGENT_STATUSES}},
+    "panel.reboot":    {"node_id": {"kind": "node", "label": "Panel"}},
+    "proactive.run":   {"agent_id": {"kind": "agent", "label": "Agente"}},
+}
+
+
 def catalog_summary() -> list[dict[str, Any]]:
-    """Resumen del catálogo para el frontend (qué comandos se pueden emitir)."""
+    """Resumen del catálogo para el frontend, enriquecido con metadata de presentación (37.6).
+
+    Cada comando lleva un `label` legible y cada parámetro un `kind` de widget + restricciones
+    (`choices`/`min`/`max`/`default`). Si un parámetro no tiene presentación declarada, cae a
+    `kind=str`. No altera la validación: es sólo para renderizar la UI."""
     out = []
     for t, spec in CATALOG.items():
-        out.append({
-            "type": t,
-            "params": [{"name": n, "required": req} for n, (_, req) in spec.items()],
-        })
+        pres = PRESENTATION.get(t, {})
+        params = []
+        for n, (_, req) in spec.items():
+            meta = dict(pres.get(n) or {})
+            meta.setdefault("kind", "str")
+            meta.setdefault("label", n)
+            # choices como lista (las constantes son tuplas) para serializar a JSON
+            if "choices" in meta:
+                meta["choices"] = list(meta["choices"])
+            params.append({"name": n, "required": req, **meta})
+        out.append({"type": t, "label": CMD_LABELS.get(t, t), "params": params})
     return out

--- a/cloud/app/main.py
+++ b/cloud/app/main.py
@@ -166,6 +166,30 @@ def api_catalog(p: Principal = Depends(require_dashboard_user)):
     return {"catalog": catalog_summary()}
 
 
+@app.get("/api/alerts")
+def api_alerts(p: Principal = Depends(require_dashboard_user)):
+    """Alertas proactivas vigentes (FASE 37.6). Viajan en el snapshot (37.1/37.7); este
+    endpoint las expone aisladas para la sección Alertas. Gated por `access`."""
+    state = fdb.get_state()
+    alerts = (state or {}).get("alerts", []) if state else []
+    return {"alerts": alerts}
+
+
+# Tipos de comando que producen logs poleables por la sección Logs (37.6/37.10).
+_LOG_COMMANDS = ("logs.tail", "logs.satellite")
+
+
+@app.get("/api/logs")
+def api_logs(p: Principal = Depends(require_dashboard_user)):
+    """Último resultado de un comando de logs (poll del resultado de logs.tail). El front emite
+    el comando y luego polea acá el output ya ejecutado por el bridge. Gated por `emit`."""
+    _require_emit(p)
+    for c in fdb.recent_commands(limit=50):
+        if c.get("type") in _LOG_COMMANDS:
+            return {"log": c}
+    return {"log": None}
+
+
 @app.post("/api/commands")
 def api_emit_command(req: CommandRequest, p: Principal = Depends(require_dashboard_user)):
     _require_emit(p)

--- a/cloud/tests/test_commands.py
+++ b/cloud/tests/test_commands.py
@@ -164,3 +164,57 @@ def test_proactive_run_ok():
 def test_new_commands_in_catalog_summary():
     types = {c["type"] for c in catalog_summary()}
     assert {"agent.toggle", "panel.reboot", "proactive.run"} <= types
+
+
+# ── FASE 37.6: metadata de presentación en el catálogo ────────────────────────
+
+def _cmd(t):
+    return next(c for c in catalog_summary() if c["type"] == t)
+
+
+def _param(t, name):
+    return next(p for p in _cmd(t)["params"] if p["name"] == name)
+
+
+def test_catalog_has_command_label():
+    assert _cmd("service.restart")["label"] == "Reiniciar servicio"
+    # comando sin label declarado cae al type
+    assert all("label" in c for c in catalog_summary())
+
+
+def test_enum_param_exposes_choices():
+    p = _param("service.restart", "service")
+    assert p["kind"] == "enum"
+    assert "capitan-core" in p["choices"] and isinstance(p["choices"], list)
+
+
+def test_int_param_exposes_min_max_default():
+    p = _param("logs.tail", "lines")
+    assert p["kind"] == "int" and p["min"] == 1 and p["max"] == 500 and p["default"] == 100
+
+
+def test_bool_param_kind():
+    assert _param("deploy.run", "restart_wa")["kind"] == "bool"
+
+
+def test_multi_param_kind():
+    p = _param("deploy.release", "services")
+    assert p["kind"] == "multi" and "core" in p["choices"]
+
+
+def test_entity_param_kinds():
+    assert _param("agent.toggle", "agent_id")["kind"] == "agent"
+    assert _param("panel.reboot", "node_id")["kind"] == "node"
+    assert _param("voice.reenroll", "user_id")["kind"] == "user"
+
+
+def test_param_without_presentation_defaults_to_str():
+    p = _param("deploy.release", "core_ref")
+    assert p["kind"] == "str" and "label" in p
+
+
+def test_presentation_does_not_alter_validation():
+    # el catálogo enriquecido no cambia validate_command: choices presentacionales == enum real
+    assert validate_command("agent.toggle", {"agent_id": "haos", "status": "active"})["status"] == "active"
+    with pytest.raises(CommandError):
+        validate_command("logs.tail", {"service": "capitan-core", "lines": 999})

--- a/cloud/tests/test_dashboard_api.py
+++ b/cloud/tests/test_dashboard_api.py
@@ -1,0 +1,71 @@
+"""Tests de los endpoints del dashboard nuevos en FASE 37.6: /api/alerts y /api/logs.
+
+Mismo enfoque que test_metrics_api: TestClient + override de auth + mock de la capa Firestore.
+"""
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from app import firestore_db as fdb
+from app import main, rbac
+from app.auth import Principal, require_dashboard_user
+
+client = TestClient(main.app)
+
+
+def _principal(role: str) -> Principal:
+    return Principal(email=f"{role}@x.z", role=role, caps=rbac.caps_for(role))
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    main.app.dependency_overrides.clear()
+
+
+# ── /api/alerts (gated por access) ─────────────────────────────────────────────
+
+def test_alerts_from_snapshot(monkeypatch):
+    monkeypatch.setattr(fdb, "get_state", lambda: {"alerts": ["doc vence", "lluvia"]})
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("adolescente")
+    r = client.get("/api/alerts")
+    assert r.status_code == 200 and r.json()["alerts"] == ["doc vence", "lluvia"]
+
+
+def test_alerts_empty_when_no_state(monkeypatch):
+    monkeypatch.setattr(fdb, "get_state", lambda: None)
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("familiar")
+    r = client.get("/api/alerts")
+    assert r.status_code == 200 and r.json()["alerts"] == []
+
+
+# ── /api/logs (gated por emit) ─────────────────────────────────────────────────
+
+def test_logs_returns_latest_log_command(monkeypatch):
+    cmds = [
+        {"type": "service.restart", "status": "done"},
+        {"type": "logs.tail", "status": "done", "result": {"ok": True, "output": "linea1\nlinea2"}},
+        {"type": "logs.tail", "status": "done", "result": {"ok": True, "output": "vieja"}},
+    ]
+    monkeypatch.setattr(fdb, "recent_commands", lambda limit=50: cmds)
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("admin")
+    r = client.get("/api/logs")
+    assert r.status_code == 200
+    assert r.json()["log"]["result"]["output"] == "linea1\nlinea2"  # el primero (más reciente)
+
+
+def test_logs_none_when_no_log_commands(monkeypatch):
+    monkeypatch.setattr(fdb, "recent_commands", lambda limit=50: [{"type": "deploy.run"}])
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("admin")
+    r = client.get("/api/logs")
+    assert r.status_code == 200 and r.json()["log"] is None
+
+
+def test_logs_requires_emit(monkeypatch):
+    monkeypatch.setattr(fdb, "recent_commands", lambda limit=50: [])
+    main.app.dependency_overrides[require_dashboard_user] = lambda: _principal("familiar")  # sin emit
+    r = client.get("/api/logs")
+    assert r.status_code == 403

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (4/13 — hecho 37.1-37.4; pendientes 37.5-37.12).
+Estado:   EN CURSO (5/13 — hecho 37.1-37.4, 37.6; pendientes 37.5, 37.7-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3524,7 +3524,7 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
             celular. Premisa transversal de la fase, no una sección aparte.
 
 #### Etapa C - Backend cloud
-- [ ] 37.6  Endpoints `/api/alerts` y `/api/logs` (poll del resultado de `logs.tail`); ampliar
+- [x] 37.6  Endpoints `/api/alerts` y `/api/logs` (poll del resultado de `logs.tail`); ampliar
             `/api/me`/`/api/state` con las caps nuevas y `/api/catalog` con la metadata de
             presentación por parámetro (`kind`/`label`/`choices`/`min`/`max`/`default`) sin
             cambiar `validate_command`. RBAC aplicado por endpoint.


### PR DESCRIPTION
Etapa C (backend cloud), base para la UI de comandos 37.5.

- **Catálogo enriquecido** (`commands.py`): cada comando con `label` legible y cada parámetro con `kind` de widget (enum/multi/bool/int/str/node/user/agent) + `choices`/`min`/`max`/`default`. **No toca `validate_command`** — es sólo presentación.
- **`/api/alerts`** — alertas del snapshot (gated `access`).
- **`/api/logs`** — último resultado de `logs.tail`/`logs.satellite` ya ejecutado por el bridge (gated `emit`).
- `/api/me` y `/api/state` ya exponen las caps nuevas (`view_pii`) vía el RBAC de 37.2.

Tests de presentación del catálogo y de ambos endpoints (41 passed en los archivos tocados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)