### PR TITLE
fase 37.7 — snapshot emite alerts/wakeword.status/counts (+ bump core)

### DIFF
--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -90,9 +90,11 @@ def _nodes() -> list[dict]:
 
 def _wakeword(nodes: list[dict]) -> dict:
     fps = [n.get("fp", 0) for n in nodes]
+    status = (_get(f"{CORE_URL}/wakeword/train/status") or {}).get("status", "idle")
     return {
         "last_score": None,  # no expuesto por el audio_server actual
         "false_positives_24h": sum(fps) if fps else None,
+        "status": status,    # estado del último retrain (FASE 37.1/37.7)
         "nodes": [
             {
                 "id": n.get("node_id", n.get("room", "?")),
@@ -246,6 +248,27 @@ def _versions(nodes: list[dict]) -> dict:
     return out
 
 
+def _alerts() -> list[str]:
+    """Alertas recientes SIN consumir la cola (FASE 37.7): usa /alerts/recent (peek), no
+    /alerts (drain) — drenar le robaría alertas al satélite que las lee por TTS."""
+    data = _get(f"{CORE_URL}/alerts/recent")
+    return [str(a) for a in data][:RECENT_LIMIT] if isinstance(data, list) else []
+
+
+def _counts() -> dict:
+    """Conteos agregados (sin contenido PII en claro, FASE 37.1): sólo el largo de cada lista
+    admin que el core ya expone. Nunca sale texto de intents/goals/rutinas/conversaciones."""
+    def _len(path: str) -> int:
+        d = _get(f"{CORE_URL}{path}")
+        return len(d) if isinstance(d, list) else 0
+    return {
+        "intents":       _len("/intents"),
+        "goals":         _len("/goals"),
+        "routines":      _len("/routines"),
+        "conversations": _len("/conversations"),
+    }
+
+
 def build_snapshot() -> dict:
     """Arma el snapshot completo. Nunca lanza: campos faltantes quedan vacíos."""
     nodes = _nodes()
@@ -260,4 +283,6 @@ def build_snapshot() -> dict:
         "wakeword": _wakeword(nodes),
         "users_summary": _users(),
         "versions": _versions(nodes),
+        "alerts": _alerts(),
+        "counts": _counts(),
     }

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -84,6 +84,39 @@ def test_snapshot_maps_agents_and_nodes():
     assert snap["users_summary"][0]["intents_pending"] == 1
 
 
+# ── FASE 37.7: campos nuevos del snapshot (alerts, counts, wakeword.status) ──────
+
+def test_snapshot_emits_new_fields_and_validates():
+    from app.models import StateSnapshot
+
+    def fake_get(url, timeout=4):
+        if url.endswith("/alerts/recent"):       return ["doc vence", "lluvia fuerte"]
+        if url.endswith("/wakeword/train/status"): return {"status": "running"}
+        if url.endswith("/intents"):              return [{"user_id": "m"}, {"user_id": "j"}]
+        if url.endswith("/goals"):                return [{"id": "g1"}]
+        if url.endswith("/routines"):             return [{"id": "r1"}, {"id": "r2"}, {"id": "r3"}]
+        if url.endswith("/conversations"):        return [{"id": "c1"}]
+        return None
+
+    with patch.object(snapshot, "_get", fake_get), \
+         patch.object(snapshot, "_systemctl_active", lambda u: False):
+        snap = snapshot.build_snapshot()
+    assert snap["alerts"] == ["doc vence", "lluvia fuerte"]
+    assert snap["wakeword"]["status"] == "running"
+    assert snap["counts"] == {"intents": 2, "goals": 1, "routines": 3, "conversations": 1}
+    # No usa el endpoint destructivo /alerts (drain): sólo /alerts/recent (peek).
+    StateSnapshot(**snap)   # el shape del bridge valida contra el contrato de la nube
+
+
+def test_snapshot_new_fields_default_when_down():
+    with patch.object(snapshot, "_get", lambda *a, **k: None), \
+         patch.object(snapshot, "_systemctl_active", lambda u: False):
+        snap = snapshot.build_snapshot()
+    assert snap["alerts"] == []
+    assert snap["counts"] == {"intents": 0, "goals": 0, "routines": 0, "conversations": 0}
+    assert snap["wakeword"]["status"] == "idle"
+
+
 # ── metrics_snapshot (FASE 35.5) ────────────────────────────────────────────────
 
 import metrics_snapshot  # noqa: E402

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (6/13 — hecho 37.1-37.6; pendientes 37.7-37.12).
+Estado:   EN CURSO (7/13 — hecho 37.1-37.7; pendientes 37.8-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3530,8 +3530,9 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
             cambiar `validate_command`. RBAC aplicado por endpoint.
 
 #### Etapa D - Bridge / executor (Brain)
-- [ ] 37.7  `cloud/bridge/snapshot.py`: emitir los campos nuevos reusando datos que ya computan
+- [x] 37.7  `cloud/bridge/snapshot.py`: emitir los campos nuevos reusando datos que ya computan
             core/backoffice (sin PII en claro; sólo conteos). No reimplementar lógica.
+            (Alertas vía `/alerts/recent` no-consumible —core—, no `/alerts` que drena el TTS.)
 - [ ] 37.8  `cloud/bridge/executor.py`: implementar `agent.toggle`, `panel.reboot`,
             `proactive.run` (tipo→función concreta, sin eval; auditoría como los existentes),
             invocando las APIs/scripts del Brain ya existentes.


### PR DESCRIPTION
Etapa D. El bridge emite los campos contratados en 37.1.

- `alerts` — vía **`/alerts/recent`** (peek no-consumible añadido en core #213), **no** `/alerts` que drena la cola del TTS del satélite.
- `wakeword.status` — de `/wakeword/train/status`.
- `counts` — `len` de `/intents`,`/goals`,`/routines`,`/conversations`: **sólo enteros**, sin contenido PII.

Best-effort: con las fuentes caídas, defaults vacíos. Valida contra `StateSnapshot`. Incluye bump del submodule core al merge de #213.

Tests: emisión de los campos nuevos + defaults con fuentes caídas (19 passed en bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)