### PR TITLE
fase 37.8 — handlers agent.toggle / panel.reboot / proactive.run

### DIFF
--- a/cloud/bridge/README.md
+++ b/cloud/bridge/README.md
@@ -48,6 +48,13 @@ Comandos de deploy (catálogo tipado, validados en nube y bridge):
 Versionado: tras un deploy sano, tag semver por repo (gate `DEPLOY_TAG_RELEASES`). Estado
 persistido en `~/.local/share/capitan/deploy_state.json` (matriz de versiones + último release).
 
+Comandos de operación (FASE 37.8 — acotados, sólo admin, validados en nube y bridge):
+- `agent.toggle {agent_id, status}` — `PATCH /agents/{id}/status` del core (active/planned/unavailable).
+- `proactive.run {agent_id}` — `POST /proactive/{id}/run` del core (dispara el ciclo proactivo).
+- `panel.reboot {node_id}` — resuelve la IP del nodo en el audio_server (`/nodes`) y reusa
+  `scripts/nspanel.sh reboot` (adb `su -c reboot`, único camino del firmware eWeLink). No
+  reimplementa el reboot.
+
 ## Credencial (33.13)
 
 La SA del bridge (`capitan-bridge@<project>.iam.gserviceaccount.com`) **no tiene

--- a/cloud/bridge/executor.py
+++ b/cloud/bridge/executor.py
@@ -153,6 +153,61 @@ def _voice_reenroll(p: dict) -> ExecResult:
         return ExecResult(False, "", f"endpoint de enroll no disponible: {exc}")
 
 
+def _agent_toggle(p: dict) -> ExecResult:
+    """FASE 37.8: cambia el status de un agente (PATCH /agents/{id}/status del core). El status
+    ya viene validado por el catálogo (active/planned/unavailable)."""
+    try:
+        r = requests.patch(f"{CORE_URL}/agents/{p['agent_id']}/status",
+                            json={"status": p["status"]}, timeout=10)
+        r.raise_for_status()
+        return ExecResult(True, f"{p['agent_id']} → {p['status']}")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", f"no se pudo cambiar el agente: {exc}")
+
+
+def _proactive_run(p: dict) -> ExecResult:
+    """FASE 37.8: dispara el ciclo proactivo de un agente (POST /proactive/{id}/run del core)."""
+    try:
+        r = requests.post(f"{CORE_URL}/proactive/{p['agent_id']}/run", timeout=60)
+        r.raise_for_status()
+        return ExecResult(True, f"proactivo {p['agent_id']}: {str(r.json())[:300]}")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", f"no se pudo correr el agente: {exc}")
+
+
+NSPANEL_SCRIPT = os.environ.get("NSPANEL_SCRIPT", os.path.join(REPO_DIR, "scripts", "nspanel.sh"))
+
+
+def _node_ip(node_id: str) -> str | None:
+    try:
+        nodes = requests.get(f"{AUDIO_URL}/nodes", timeout=8).json()
+        for n in nodes if isinstance(nodes, list) else []:
+            if n.get("node_id") == node_id:
+                return n.get("ip")
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _panel_reboot(p: dict) -> ExecResult:
+    """FASE 37.8: reinicia un NSPanel reusando scripts/nspanel.sh (adb `su -c reboot`, el único
+    camino de reboot del firmware eWeLink). Resuelve la IP del nodo desde el registro del
+    audio_server y se la pasa al script por NSPANEL_IP. No reimplementa el reboot."""
+    node_id = p["node_id"]
+    ip = _node_ip(node_id)
+    if not ip:
+        return ExecResult(False, "", f"no encontré la IP del panel {node_id!r} (¿online?)")
+    env = {**os.environ, "NSPANEL_IP": ip}
+    try:
+        proc = subprocess.run(["bash", NSPANEL_SCRIPT, "reboot"],
+                              capture_output=True, text=True, timeout=30, env=env)
+        out = ((proc.stdout or "") + (proc.stderr or "")).strip()
+        ok = proc.returncode == 0
+        return ExecResult(ok, out, "" if ok else f"reboot falló (exit {proc.returncode})")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", f"no se pudo reiniciar el panel: {exc}")
+
+
 HANDLERS = {
     "service.restart": _service_restart,
     "service.status": _service_status,
@@ -164,6 +219,9 @@ HANDLERS = {
     "config.reload": _config_reload,
     "wakeword.retrain": _wakeword_retrain,
     "voice.reenroll": _voice_reenroll,
+    "agent.toggle": _agent_toggle,
+    "panel.reboot": _panel_reboot,
+    "proactive.run": _proactive_run,
 }
 
 # Comandos largos que emiten progreso EN VIVO (D5): el handler acepta un callback `emit` y va

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -234,6 +234,63 @@ def test_deploy_satellites_todos_por_default(monkeypatch):
     assert captured["url"].endswith("/nodes/*/update")   # sin node_id → todos
 
 
+# ── FASE 37.8: handlers de operación (agent.toggle / panel.reboot / proactive.run) ──
+
+def _resp(payload=None):
+    return type("R", (), {"raise_for_status": lambda self: None,
+                          "json": lambda self: payload or {}})()
+
+
+def test_agent_toggle_patches_core_status(monkeypatch):
+    captured = {}
+
+    def fake_patch(url, json=None, timeout=10):
+        captured.update(url=url, json=json)
+        return _resp()
+
+    monkeypatch.setattr(executor.requests, "patch", fake_patch)
+    r = executor.execute("agent.toggle", {"agent_id": "haos", "status": "planned"})
+    assert r.ok and captured["url"].endswith("/agents/haos/status")
+    assert captured["json"] == {"status": "planned"}
+
+
+def test_proactive_run_posts_core(monkeypatch):
+    captured = {}
+
+    def fake_post(url, timeout=60):
+        captured["url"] = url
+        return _resp({"ran": True})
+
+    monkeypatch.setattr(executor.requests, "post", fake_post)
+    r = executor.execute("proactive.run", {"agent_id": "clima"})
+    assert r.ok and captured["url"].endswith("/proactive/clima/run")
+
+
+def test_panel_reboot_resolves_ip_and_runs_script(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(executor.requests, "get",
+        lambda url, timeout=8: _resp([{"node_id": "comedor", "ip": "192.168.68.113"}]))
+
+    class P:
+        returncode = 0; stdout = "Reiniciando"; stderr = ""
+
+    def fake_run(args, **kw):
+        captured.update(args=args, ip=kw.get("env", {}).get("NSPANEL_IP"))
+        return P()
+
+    monkeypatch.setattr(executor.subprocess, "run", fake_run)
+    r = executor.execute("panel.reboot", {"node_id": "comedor"})
+    assert r.ok
+    assert captured["args"][0] == "bash" and captured["args"][-1] == "reboot"
+    assert captured["ip"] == "192.168.68.113"   # IP resuelta del registro → env del script
+
+
+def test_panel_reboot_unknown_node(monkeypatch):
+    monkeypatch.setattr(executor.requests, "get", lambda url, timeout=8: _resp([]))
+    r = executor.execute("panel.reboot", {"node_id": "fantasma"})
+    assert not r.ok and "IP" in r.error
+
+
 # ── Logs en vivo (D5): emit del executor + batching del bridge ─────────────────
 
 def test_execute_passes_emit_to_deploy(monkeypatch):

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (7/13 — hecho 37.1-37.7; pendientes 37.8-37.12).
+Estado:   EN CURSO (8/13 — hecho 37.1-37.8; pendientes 37.9-37.12).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3533,7 +3533,7 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
 - [x] 37.7  `cloud/bridge/snapshot.py`: emitir los campos nuevos reusando datos que ya computan
             core/backoffice (sin PII en claro; sólo conteos). No reimplementar lógica.
             (Alertas vía `/alerts/recent` no-consumible —core—, no `/alerts` que drena el TTS.)
-- [ ] 37.8  `cloud/bridge/executor.py`: implementar `agent.toggle`, `panel.reboot`,
+- [x] 37.8  `cloud/bridge/executor.py`: implementar `agent.toggle`, `panel.reboot`,
             `proactive.run` (tipo→función concreta, sin eval; auditoría como los existentes),
             invocando las APIs/scripts del Brain ya existentes.
 


### PR DESCRIPTION
Etapa D. Implementa los handlers de operación en el executor (tipo→función, sin eval, auditados):

- `agent.toggle` → PATCH /agents/{id}/status del core
- `proactive.run` → POST /proactive/{id}/run del core
- `panel.reboot` → resuelve la IP del nodo en el audio_server y reusa `scripts/nspanel.sh reboot` (adb su -c reboot)

Tests con requests/subprocess mockeados (23 passed). Docs en bridge/README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)