### PR TITLE
fase 37.9 — docs + cierre de FASE 37

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,14 @@ The core exposes a read-only metrics API (`GET /metrics/{voice,llm}/*`: summarie
 series as `{labels, series}`, by-model, by-agent, retrains) with range/model/agent/node
 filters. The **local backoffice** renders it at `/metrics` (Chart.js, filters, auto-refresh);
 the **cloud backoffice** shows an equivalent view, fed by the egress-only bridge that pushes
-aggregates to `POST /ingest/metrics` and gated by the FASE 33 RBAC.
+aggregates to `POST /ingest/metrics` and gated by the FASE 33 RBAC. Both also chart **wake-word
+score** and **voice-id confidence** against their thresholds over time (FASE 37).
+
+The cloud backoffice (FASE 37) is a **mobile-first SPA** with a sidebar (Monitoreo / Sistema /
+Administración), hash router and per-capability gating, with full parity with the local
+backoffice for everything that's safe to expose egress-only. Its command UI is end-user grade:
+contextual actions per entity and typed forms rendered from `/api/catalog` (no raw JSON). A new
+admin-only `view_pii` capability gates content (command text); the snapshot only carries counts.
 
 ---
 

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -40,9 +40,16 @@ Bridge (Brain → nube, auth OIDC de la SA del bridge):
 - `POST /commands/{id}/result` — resultado de ejecución.
 
 Dashboard (navegador → nube, auth Firebase + allow-list email):
-- `GET  /api/state` · `GET /api/commands` · `GET /api/catalog`
+- `GET  /api/state` · `GET /api/commands` · `GET /api/catalog` · `GET /api/me`
+- `GET  /api/alerts` (access) · `GET /api/logs` (emit, poll del último logs.tail/satellite)
 - `POST /api/commands` — emite un comando validado contra el catálogo.
-- `GET  /` — dashboard.
+- `GET  /` — dashboard SPA (sidebar + secciones, mobile-first; FASE 37).
+
+El frontend es un **SPA con sidebar** (Monitoreo / Sistema / Administración), router por hash y
+secciones gated por capacidad (`access`/`view_full`/`view_pii`/`emit`). La UI de comandos es
+final-user: acciones contextuales por entidad + formularios tipados desde `/api/catalog` (sin JSON
+crudo). `/api/catalog` enriquece cada parámetro con metadata de presentación
+(`kind`/`label`/`choices`/`min`/`max`/`default`) sin tocar `validate_command`.
 
 ## Deploy de servicios (FASE 34)
 

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -152,7 +152,35 @@ inversión de control.
   RBAC (admin escribe; familiar/adolescente read-only). `BACKOFFICE_TOKEN` queda como
   bootstrap de emergencia offline. Identidad de login = `User.email` (o `gcal_email`).
 
-Contrato y modelo de amenazas: `masterplan/fase33_cloud_backoffice.md`.
+**SPA con sidebar + secciones (FASE 37).** El dashboard cloud pasó de una página única con
+tarjetas apiladas a un **SPA con sidebar** (taxonomía del backoffice local: Monitoreo / Sistema
+/ Administración), router client-side por hash y cada link/vista gated por capacidad. Secciones:
+Resumen, Servicios, Métricas, Alertas, Logs, Actividad, Agentes, Wake word, Paneles, Deploy,
+Usuarios, Acciones, Auditoría. **Mobile-first**: la sidebar colapsa a drawer en viewport chico,
+las tablas anchas scrollean dentro de su card (el acceso remoto es típicamente desde el celular).
+
+- **RBAC ampliado**: nueva capacidad `view_pii` (admin-only, distinta de `view_full`). Sin ella,
+  `filter_state` redacta el **contenido** (texto de comandos en `recent_commands`) dejando la
+  metadata y los conteos. El snapshot sólo lleva conteos de intents/goals/rutinas/conversaciones
+  (nunca el contenido), más `alerts` (texto, vía `/alerts/recent` no-consumible del core) y
+  `wakeword.status`.
+- **UI de comandos final-user (37.5/37.6)**: se eliminó el `<select>` + JSON crudo. Acciones
+  contextuales junto a la entidad (reiniciar servicio, activar/desactivar y correr agente,
+  reiniciar panel, reentrenar wake word) con confirmación en destructivos y feedback inline del
+  estado; y un formulario tipado para comandos sin entidad-ancla, con widgets renderizados desde
+  la metadata de presentación de `/api/catalog` (enum→dropdown, int→número, bool→toggle,
+  node/user/agent→selector). Comandos de operación nuevos en el catálogo: `agent.toggle`,
+  `panel.reboot`, `proactive.run`, `logs.satellite`.
+- **Logs del satélite (37.10)**: `audio_server` es la fuente única del fetch del log del panel
+  (`GET /nodes/{id}/satellite-log`, ssh a Termux); el backoffice local lo llama directo (LAN) y el
+  cloud vía el comando `logs.satellite` → bridge. Sin duplicar la lógica.
+- **Observabilidad de detección (37.11/37.12)**: serie temporal del **score de wake word** vs
+  threshold (el satélite reporta los frames `>= SCORE_LOG_MIN` → `audio_server` → core
+  `ww_scores`) y del **voice-id** (`speaker_conf` known/guest vs `SPEAKER_THRESHOLD`), con charts
+  en Métricas de ambos backoffices (view_full). Viajan por el push de métricas egress-only.
+
+Contrato y modelo de amenazas: `masterplan/fase33_cloud_backoffice.md`. Paridad de secciones y
+detalle de FASE 37: `masterplan/estado.md`.
 
 ---
 

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3437,7 +3437,7 @@ Objetivo: Llevar el backoffice cloud (FASE 33) de una única página SPA con tar
           el backoffice cloud debe ser mobile-friendly (responsive, mobile-first), ya que
           el acceso remoto egress-only es típicamente desde el celular — toda sección,
           sidebar y formulario de comandos debe funcionar y ser usable en pantalla chica.
-Estado:   EN CURSO (12/13 — hecho 37.1-37.8, 37.10, 37.11, 37.12-mobile, 37.12-voiceid; queda 37.9).
+Estado:   COMPLETA (13/13). Pendiente sólo el deploy/verificación e2e en hardware (satélite/ssh).
 Deps:     FASE 33 (backoffice cloud + bridge egress-only + RBAC — COMPLETA, base a extender),
           FASE 35 (dashboards de métricas — COMPLETA, ya viven en el cloud),
           FASE 34 (deploy remoto — la sección Deploy del sidebar consume su versión reportada).
@@ -3550,9 +3550,9 @@ PREMISA TRANSVERSAL DE UX (comandos): TODO lo relativo a comandos invocables —
             local y bridge. Tests con ssh mockeado.
 
 #### Etapa E - Tests y documentación
-- [ ] 37.9  Tests cloud (`cloud/tests`) + bridge (`cloud/bridge/test_bridge.py`) de todo lo
+- [x] 37.9  Tests cloud (`cloud/tests`) + bridge (`cloud/bridge/test_bridge.py`) de todo lo
             nuevo; docs en `masterplan/arquitectura_funcional.md`, `cloud/README.md` y `README`;
-            lint de estado + sync de issues.
+            lint de estado + sync de issues. (Suites: cloud 143, core 734, ear 106.)
 
 #### Etapa G - Observabilidad de detección: score WW + voice-id en el tiempo (ambos backoffices)
 - [x] 37.11 Visualizar el comportamiento del SCORE de wake word vs el threshold a lo largo del


### PR DESCRIPTION
Etapa E. Cierra FASE 37 (13/13).

Tests de todo lo nuevo ya entraron por tarea; suites verdes en conjunto: **cloud 143, core 734, ear 106**.

Docs: `arquitectura_funcional.md` (SPA sidebar, view_pii, UI de comandos, logs satélite, observabilidad score WW + voice-id), `cloud/README.md` (endpoints + SPA), `README` raíz. `estado.md` FASE 37 → COMPLETA.

Pendiente sólo el deploy + verificación e2e en hardware (satélite reportando, ssh Brain→panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)