### PR TITLE
fix: cloud-bo CSS cache + charts infinitos

### DIFF
--- a/cloud/app/static/style.css
+++ b/cloud/app/static/style.css
@@ -103,7 +103,7 @@ table { width: 100%; border-collapse: collapse; font-size: 13px; }
 th { text-align: left; padding: 6px 8px; color: var(--muted); font-weight: 500; border-bottom: 1px solid var(--line); }
 td { padding: 6px 8px; border-bottom: 1px solid var(--line); }
 code { background: var(--bg); padding: 2px 6px; border-radius: 4px; }
-canvas { max-width: 100%; }
+canvas { max-width: 100%; max-height: 320px; }
 
 /* ── Mobile: sidebar → drawer ──────────────────────────────────────────────── */
 .only-mobile { display: none; }

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Capitán · backoffice en la nube</title>
-  <link rel="stylesheet" href="/static/style.css">
+  <link rel="stylesheet" href="/static/style.css?v=37">
 </head>
 <body>
 
@@ -516,7 +516,9 @@ const mLabel = (ts) => new Date(ts * 1000).toLocaleString("es", {day:"2-digit",m
 function mkMetricChart(canvasId, type) {
   return new Chart($(canvasId), {
     type, data: {labels: [], datasets: []},
-    options: {responsive: true, maintainAspectRatio: false,
+    // maintainAspectRatio:true evita que el canvas crezca sin tope dentro de una card de altura
+    // no acotada (el bug del "recuadro blanco infinito"). El height del <canvas> fija el ratio.
+    options: {responsive: true, maintainAspectRatio: true,
       plugins: {legend: {labels: {boxWidth: 12}}}, scales: {y: {beginAtZero: true}}},
   });
 }


### PR DESCRIPTION
Fixes reportados en el cloud-bo desplegado:
1. **Layout roto** = navegador con la `style.css` vieja cacheada (sin `.view`/`.sidebar`/`.only-mobile`). Cache-bust `?v=37` en el `<link>`.
2. **Recuadro blanco infinito** en métricas = `maintainAspectRatio:false` sin contenedor de altura fija. Pasa a `true` + `max-height:320px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)