### PR TITLE
FASE 38.7 — prefill del form con la config real del dispositivo

### DIFF
--- a/backoffice/templates/panels.html
+++ b/backoffice/templates/panels.html
@@ -62,8 +62,13 @@
                   class="text-xs text-red-400 hover:text-red-300">quitar</button>
         </td>
       </tr>
-      {# FASE 38: configuración del panel (apagado de pantalla + dashboard por defecto) #}
+      {# FASE 38: configuración del panel (apagado de pantalla + dashboard por defecto).
+         Prefill con la config REAL del dispositivo (device_config del heartbeat) si el panel
+         está online; si no, con la config guardada en core. #}
+      {% set dev = (node.device_config if node else {}) or {} %}
       {% set cfg = p.config or {} %}
+      {% set cur_to = dev.screen_timeout_secs if dev.screen_timeout_secs is not none else cfg.screen_timeout_secs %}
+      {% set cur_dash = dev.default_dashboard or cfg.default_dashboard %}
       <tr class="border-t border-gray-800/50 bg-gray-900/40">
         <td colspan="6" class="px-4 py-3">
           <form hx-post="/panels/{{ p.name }}/config" hx-target="#cfg-st-{{ p.name }}"
@@ -72,7 +77,7 @@
             <div>
               <label class="block text-xs text-gray-500 mb-1">Apagar pantalla tras (seg, 0 = nunca)</label>
               <input name="screen_timeout_secs" type="number" min="0" step="5"
-                     value="{{ cfg.screen_timeout_secs if cfg.screen_timeout_secs is not none else '' }}"
+                     value="{{ cur_to if cur_to is not none else '' }}"
                      placeholder="120"
                      class="w-32 px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
             </div>
@@ -82,7 +87,7 @@
                       class="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
                 <option value="">— sin cambiar / login default —</option>
                 {% for d in dashboards %}
-                <option value="{{ d.url }}" {% if d.url == cfg.default_dashboard %}selected{% endif %}>{{ d.title }}</option>
+                <option value="{{ d.url }}" {% if d.url == cur_dash %}selected{% endif %}>{{ d.title }}</option>
                 {% endfor %}
               </select>
             </div>
@@ -91,6 +96,7 @@
               Guardar config
             </button>
             <span id="cfg-st-{{ p.name }}" class="text-xs"></span>
+            {% if dev %}<span class="text-xs text-gray-500">· en el dispositivo: {{ dev.screen_timeout_secs if dev.screen_timeout_secs is not none else '?' }}s</span>{% endif %}
           </form>
         </td>
       </tr>

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -50,6 +50,8 @@ class WakewordNode(BaseModel):
     # FASE 38: config vigente del panel (no PII): {screen_timeout_secs, default_dashboard}.
     # Prefila el form de "Configurar panel" en el dashboard cloud.
     config: dict[str, Any] = Field(default_factory=dict)
+    # FASE 38: config REAL leída del dispositivo (heartbeat del satélite); prevalece para el prefill.
+    device_config: dict[str, Any] = Field(default_factory=dict)
 
 
 class Wakeword(BaseModel):

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -436,7 +436,9 @@ function renderPanels(state) {
     const upd = t.behind ? ` <span class="warn">⬆ desactualizado</span>` : "";
     const rms = n.rms != null ? ` · rms ${n.rms}` : "";
     const id = esc(n.id);
-    const cfg = n.config || {};
+    // FASE 38: prefill con la config REAL del dispositivo (device_config) si está; si no, la guardada.
+    const cfg = Object.assign({}, n.config || {}, n.device_config || {});
+    const dev = n.device_config || {};
     const act = CAPS.emit
       ? `<span><button class="mini" onclick="actReboot('${id}')">reiniciar</button>`
         + ` <button class="mini" onclick="togglePanelCfg('${id}')">configurar</button>`
@@ -450,7 +452,9 @@ function renderPanels(state) {
         + `<div class="field"><label>Dashboard por defecto</label>`
         + `<select id="cfgdash-${id}">${dashboardOptions(cfg.default_dashboard || "")}</select></div>`
         + `<div><button class="mini" onclick="savePanelCfg('${id}')">guardar config</button> `
-        + `<span id="pancfg-${id}" class="muted"></span></div></div>` : "";
+        + `<span id="pancfg-${id}" class="muted"></span>`
+        + (dev.screen_timeout_secs != null ? ` <span class="muted">· en el dispositivo: ${dev.screen_timeout_secs}s</span>` : "")
+        + `</div></div>` : "";
     return `<div class="tile"><b>${dot(n.online)} ${id}</b>`
       + `<span>${esc(n.ip || "sin ip")}${rms}</span>`
       + `<span>${ver}${upd}</span>${act}${cfgForm}</div>`;

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -120,7 +120,8 @@ def _wakeword(nodes: list[dict]) -> dict:
                 "ip": n.get("ip") or None,
                 "online": n.get("state") == "active",
                 "rms": None,
-                "config": configs.get(n.get("node_id"), {}),   # FASE 38
+                "config": configs.get(n.get("node_id"), {}),   # FASE 38: config guardada (core)
+                "device_config": n.get("device_config") or {}, # FASE 38: config REAL del dispositivo
             }
             for n in nodes
         ],

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -481,3 +481,24 @@ def test_snapshot_nodes_carry_config_and_dashboards():
     assert node["config"] == {"screen_timeout_secs": 120}
     assert snap["dashboards"] == dashboards
     StateSnapshot(**snap)   # valida contra el contrato de la nube
+
+
+def test_snapshot_nodes_carry_device_config():
+    from app.models import StateSnapshot
+
+    def fake_get(url, timeout=4):
+        if url.endswith("/nodes"):
+            return [{"node_id": "nspanel-comedor", "state": "active",
+                     "device_config": {"screen_timeout_secs": 120}}]
+        if url.endswith("/panels"):
+            return [{"name": "comedor", "node_id": "nspanel-comedor", "config": {}}]
+        if url.endswith("/dashboards"):
+            return []
+        return None
+
+    with patch.object(snapshot, "_get", fake_get), \
+         patch.object(snapshot, "_systemctl_active", lambda u: False):
+        snap = snapshot.build_snapshot()
+    node = snap["wakeword"]["nodes"][0]
+    assert node["device_config"] == {"screen_timeout_secs": 120}
+    StateSnapshot(**snap)

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -76,6 +76,11 @@ converge igual en el ciclo de sync (`MODEL_SYNC_SECS`) y al arrancar. El selecto
 puebla desde `GET /dashboards` (core consulta los dashboards de lovelace por WebSocket
 `lovelace/dashboards/list`, no expuesto en la REST API; cacheado). El satélite es el **único
 aplicador** del dashboard (no se toca `start-ha.sh`, que reescribe `nspanel.sh converge`).
+El form se **prellena con la config REAL del dispositivo** (38.7): el satélite lee su
+`screen_off_timeout` vigente (`settings get`) y reporta su config aplicada en el heartbeat
+(`dev_screen_timeout_secs`/`dev_dashboard`); `audio_server` la expone en `/nodes` como
+`device_config` y viaja en el snapshot. Ambos backoffices prefieren ese valor (estado real) sobre
+la config guardada en core, así el admin ve lo que efectivamente corre en el panel.
 
 **Ambientes (16.7):** la fuente de verdad de los ambientes son las **áreas de Home Assistant**
 (`ha_client.get_areas()` vía `/api/template`, porque el area registry no está en la REST API de

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3588,7 +3588,7 @@ Objetivo: Dar a cada panel NSPanel una sección de CONFIGURACIÓN administrable 
           lugar para más:
             1. Tiempo de inactividad para apagar la pantalla (screen_timeout_secs, 0 = nunca).
             2. Dashboard por defecto del panel (default_dashboard, deeplink de HA Companion).
-Estado:   COMPLETA (6/6). Pendiente sólo el deploy + verificación e2e en hardware (satélite/su/am).
+Estado:   COMPLETA (7/7). Pendiente sólo la verificación e2e en hardware (satélite/su/am).
 Deps:     FASE 16 (paneles + audio_server + heartbeat/auto-update), FASE 33/37 (cloud + comandos
           tipados + snapshot egress-only), FASE 32 (tabla panels en SQLite).
 Decisiones tomadas:
@@ -3624,3 +3624,8 @@ Decisiones tomadas:
             (`test_commands`, `test_bridge`).
 - [x] 38.6  Docs: `arquitectura_funcional.md` (config de paneles + flujo pull), READMEs (raíz,
             core, ear, cloud); lint de estado + sync de issues.
+- [x] 38.7  Prefill con la config REAL del dispositivo: el satélite lee el `screen_off_timeout`
+            vigente (`settings get`) y reporta su config aplicada en el heartbeat
+            (`dev_screen_timeout_secs`/`dev_dashboard`); `audio_server` la expone en `/nodes`
+            (`device_config`) y la lleva el snapshot; ambos backoffices prellenan el form con el
+            estado del dispositivo (fallback a la config guardada en core). Tests.


### PR DESCRIPTION
Cierra los dos issues reportados y agrega lo pedido:

1. **Combo de dashboards vacío en el cloud** + **2. config no persistía (volvía a default)**: el bridge estaba corriendo el código viejo (snapshot/executor sin FASE 38) — se reinició (capitan-bridge). El combo se puebla del snapshot y panel.config ya ejecuta.
2. **Prefill con la config actual del panel, leída del dispositivo**: el satélite reporta su screen_off_timeout real + último dashboard aplicado en el heartbeat → audio_server lo expone en /nodes (device_config) → snapshot → ambos backoffices prellenan el form con el estado real (fallback a core), con hint 'en el dispositivo'.

Tests: ear 119 · cloud 151. Incluye pointer de ear (#66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)