### PR TITLE
fix: FASE 38 — UX del form de config (no pisar form abierto + hints claros)

### DIFF
--- a/backoffice/templates/panels.html
+++ b/backoffice/templates/panels.html
@@ -74,15 +74,18 @@
           <form hx-post="/panels/{{ p.name }}/config" hx-target="#cfg-st-{{ p.name }}"
                 hx-swap="innerHTML" class="flex flex-wrap items-end gap-4">
             <input type="hidden" name="node_id" value="{{ p.node_id }}">
+            {% set dash_title = (dashboards | selectattr('url', 'equalto', dev.default_dashboard) | map(attribute='title') | first) if dev.default_dashboard else None %}
             <div>
-              <label class="block text-xs text-gray-500 mb-1">Apagar pantalla tras (seg, 0 = nunca)</label>
+              <label class="block text-xs text-gray-500 mb-1">Apagar pantalla tras (seg, 0 = nunca)
+                {% if dev and dev.screen_timeout_secs is not none %}<span class="text-gray-600">· en el dispositivo: {{ 'nunca' if dev.screen_timeout_secs == 0 else dev.screen_timeout_secs ~ 's' }}</span>{% endif %}</label>
               <input name="screen_timeout_secs" type="number" min="0" step="5"
                      value="{{ cur_to if cur_to is not none else '' }}"
                      placeholder="120"
                      class="w-32 px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
             </div>
             <div>
-              <label class="block text-xs text-gray-500 mb-1">Dashboard por defecto</label>
+              <label class="block text-xs text-gray-500 mb-1">Dashboard por defecto
+                {% if dev %}<span class="text-gray-600">· en el dispositivo: {{ dash_title or (dev.default_dashboard if dev.default_dashboard else 'sin fijar desde el sistema') }}</span>{% endif %}</label>
               <select name="default_dashboard"
                       class="px-3 py-1.5 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200">
                 <option value="">— sin cambiar / login default —</option>
@@ -96,7 +99,6 @@
               Guardar config
             </button>
             <span id="cfg-st-{{ p.name }}" class="text-xs"></span>
-            {% if dev %}<span class="text-xs text-gray-500">· en el dispositivo: {{ dev.screen_timeout_secs if dev.screen_timeout_secs is not none else '?' }}s</span>{% endif %}
           </form>
         </td>
       </tr>

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -425,6 +425,9 @@ function renderWakeword(ww) {
 }
 
 function renderPanels(state) {
+  // No re-renderizar mientras un form de config está abierto: el refresh periódico colapsaría
+  // el form y perdería lo que el usuario está tipeando (FASE 38). Se re-renderiza al cerrarlo.
+  if (document.querySelector("#panels .panel-cfg:not(.hidden)")) return;
   const nodes = (state.wakeword || {}).nodes || [];
   // versión/al-día por panel desde la matriz de targets (kind satellite)
   const tgt = {};
@@ -445,15 +448,21 @@ function renderPanels(state) {
         + ` <span id="pan-${id}" class="muted"></span></span>` : "";
     // FASE 38: form de config contextual (apagado de pantalla + dashboard por defecto), oculto.
     const curTo = cfg.screen_timeout_secs != null ? cfg.screen_timeout_secs : "";
+    // Hints del estado REAL del dispositivo (lo que reporta el satélite).
+    const toHint = dev.screen_timeout_secs != null
+      ? ` <span class="muted">· en el dispositivo: ${dev.screen_timeout_secs === 0 ? "nunca" : dev.screen_timeout_secs + "s"}</span>` : "";
+    const dashTitle = (((LAST_STATE || {}).dashboards || []).find(d => d.url === dev.default_dashboard) || {}).title;
+    const dashHint = dev.default_dashboard
+      ? ` <span class="muted">· en el dispositivo: ${esc(dashTitle || dev.default_dashboard)}</span>`
+      : ` <span class="muted">· sin dashboard fijado desde el sistema</span>`;
     const cfgForm = CAPS.emit
       ? `<div id="cfg-${id}" class="panel-cfg hidden">`
-        + `<div class="field"><label>Apagar pantalla tras (seg, 0 = nunca)</label>`
+        + `<div class="field"><label>Apagar pantalla tras (seg, 0 = nunca)${toHint}</label>`
         + `<input id="cfgto-${id}" type="number" min="0" step="5" value="${curTo}" placeholder="120"></div>`
-        + `<div class="field"><label>Dashboard por defecto</label>`
+        + `<div class="field"><label>Dashboard por defecto${dashHint}</label>`
         + `<select id="cfgdash-${id}">${dashboardOptions(cfg.default_dashboard || "")}</select></div>`
         + `<div><button class="mini" onclick="savePanelCfg('${id}')">guardar config</button> `
         + `<span id="pancfg-${id}" class="muted"></span>`
-        + (dev.screen_timeout_secs != null ? ` <span class="muted">· en el dispositivo: ${dev.screen_timeout_secs}s</span>` : "")
         + `</div></div>` : "";
     return `<div class="tile"><b>${dot(n.online)} ${id}</b>`
       + `<span>${esc(n.ip || "sin ip")}${rms}</span>`


### PR DESCRIPTION
- El refresh de 10s del SPA colapsaba/limpiaba el form de config mientras se editaba (causa de 'vuelve a default'). Ahora no re-renderiza si hay un form abierto.
- Hints del estado real del dispositivo: timeout 0='nunca', dashboard muestra título o 'sin fijar desde el sistema'. El input/select prellenan con ese valor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)