### PR TITLE
FASE 40.4 — decisión agnóstica (core pointer + estado)

### DIFF
--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -192,6 +192,16 @@ fija el id de la conversación canónica de WhatsApp y la marca a la espera del 
 lo sellan al `conversation_id` del turno (`apply_agent_updates`). La pregunta "¿esto es la respuesta
 o un comando nuevo dentro de la MISMA conversación?" queda para la Etapa C (40.4).
 
+**Etapa C — decisión agnóstica respuesta-vs-comando (40.4, resuelto).** Erradica la última
+precedencia dura pre-LLM. Dentro de una conversación que espera un reply: (a) un sí/no **pelado**
+(`conversations.is_bare_yes_no`) se captura por **fast-path** sin llamar al planner —un sí/no suelto
+nunca es un comando, y se evalúa **antes** del ack porque "sí"/"ok"/"dale" son a la vez ack y
+respuesta; (b) cualquier otro enunciado lo decide el **planner**: se le pasa la pregunta pendiente
+como contexto (`coordinator.coordinate(pending_question=...)`) y devuelve `{"reply_to_pending": true}`
+si es la respuesta, o un plan normal si es un comando nuevo (el `fast_classifier` se saltea cuando
+hay pregunta pendiente). En WhatsApp, `wa_inbound` sólo captura el quoted-reply **dirigido**
+(intent_id explícito); sin intent_id la decisión la toma `process()` por el mismo camino agnóstico.
+
 #### Persistencia de datos (SQLite — FASE 32)
 
 Toda la data del sistema vive en **`~/.local/share/capitan/capitan.db`** (SQLite) vía

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3735,7 +3735,7 @@ Objetivo: Garantizar que la elección de agente sea SIEMPRE producto de la plane
           observado: un `request` intent pendiente (típicamente un proactivo de finanzas, creado
           SIN `conversation_id`) captura cualquier enunciado siguiente como su respuesta y
           devuelve "Entendido, el plan 'X' queda sin cambios" ante, p.ej., una consulta de clima.
-Estado:   EN CURSO (3/6 — Etapas A y B completas).
+Estado:   EN CURSO (4/6 — Etapas A, B y C completas; quedan 40.5 y 40.6).
 Deps:     FASE 9  (coordinador LLM — el corazón agnóstico a preservar),
           FASE 22 (intents tipados + captura 22.5 — el path a corregir),
           FASE 36 (ContinuationState — el mecanismo CORRECTO de espera de respuesta),
@@ -3781,7 +3781,7 @@ Hallazgos de la auditoría inicial (ya realizada — base de esta fase):
             explícita. Tests.
 
 #### Etapa C - Decisión agnóstica respuesta-vs-comando
-- [ ] 40.4  Hacer agnóstica la decisión "¿respuesta a lo pendiente o comando nuevo?": pasar la
+- [x] 40.4  Hacer agnóstica la decisión "¿respuesta a lo pendiente o comando nuevo?": pasar la
             pregunta pendiente como CONTEXTO al coordinador y dejar que el plan resuelva el destino
             (incluida la opción "es la respuesta al intent X" como un resultado más del planner),
             en vez de precedencia dura pre-LLM. Conservar a lo sumo un fast-path barato para


### PR DESCRIPTION
## Etapa C — FASE 40 (umbrella)

Bump del pointer de `core` a la decisión agnóstica respuesta-vs-comando ([core#218](https://github.com/mblasi/home-agents-core/pull/218)), marca de `estado.md` (40.4 `[x]`, FASE 40 → EN CURSO 4/6) y doc de Etapa C en `arquitectura_funcional.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)