### PR TITLE
FASE 40.6 — observabilidad de bypass (dashboards + core pointer) · FASE 40 COMPLETA

### DIFF
--- a/backoffice/templates/metrics.html
+++ b/backoffice/templates/metrics.html
@@ -225,11 +225,16 @@ async function loadLLM() {
     getJSON("/api/metrics/llm/by-agent?" + qs(extra)),
   ]);
   const rq = sum.requests || {}, lc = sum.llm_calls || {};
+  const bp = sum.bypass || {}, bt = bp.by_type || {};
+  const rate = t => fmtPct((bt[t] || {}).rate);
   $("llm-cards").innerHTML =
     card("Requests", fmtNum(rq.requests)) +
     card("Lat. total", rq.avg_total_latency_ms != null ? rq.avg_total_latency_ms + " ms" : "—") +
     card("Lat. coord", rq.avg_coordinator_ms != null ? rq.avg_coordinator_ms + " ms" : "—") +
     card("Fast-path", fmtPct(rq.fast_classifier_rate), "unknown " + fmtPct(rq.unknown_rate)) +
+    card("Bypass del planner", fmtPct(bp.bypass_rate),
+         "cap " + rate("capture") + " · fc " + rate("fast_classifier") +
+         " · close " + rate("close") + " · ack " + rate("ack")) +
     card("LLM calls", fmtNum(lc.calls), "lat " + fmtNum(lc.avg_latency_ms) + " ms") +
     card("Tokens", fmtNum((lc.prompt_tokens||0)+(lc.completion_tokens||0)),
          "p " + fmtNum(lc.prompt_tokens) + " / c " + fmtNum(lc.completion_tokens));

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -599,10 +599,14 @@ async function loadMetrics() {
     ["#34d399", "#f87171"]);
 
   const ls = metrics.llm_summary || {}, rq = ls.requests || {}, lc = ls.llm_calls || {};
+  const bp = ls.bypass || {}, bt = bp.by_type || {};
+  const bRate = t => mPct((bt[t] || {}).rate);
   $("m-llm-summary").innerHTML =
     `<div><b>${mFmt(rq.requests)}</b> requests</div><div><b>${rq.avg_total_latency_ms ?? "—"}</b> ms lat</div>` +
     `<div><b>${mPct(rq.fast_classifier_rate)}</b> fast-path</div>` +
-    `<div><b>${mFmt((lc.prompt_tokens||0)+(lc.completion_tokens||0))}</b> tokens</div>`;
+    `<div><b>${mFmt((lc.prompt_tokens||0)+(lc.completion_tokens||0))}</b> tokens</div>` +
+    `<div title="cap ${bRate("capture")} · fc ${bRate("fast_classifier")} · close ${bRate("close")} · ack ${bRate("ack")}">` +
+    `<b>${mPct(bp.bypass_rate)}</b> bypass planner</div>`;
   if (!mLlmChart) mLlmChart = mkMetricChart("m-llm-chart", "line");
   setSeries(mLlmChart, metrics.llm_series || {}, ["#60a5fa", "#fbbf24"]);
 

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -211,6 +211,17 @@ de margen** top1-top2 (`CLASSIFIER_MARGIN`): si dos agentes empatan, la elecció
 difiere al planner LLM en vez de que el clasificador decida con poca evidencia (margen en
 `CoordinatorTrace.fast_margin`). Ninguno de los tres decide agente de forma sesgada.
 
+**Etapa E — observabilidad de bypass (40.6, resuelto).** Cada cortocircuito que evita el planner
+queda instrumentado para detectar regresiones de bias: `RequestTrace.bypass` + columna
+`request_metrics.bypass`. `server._record_bypass` marca close/ack/capture (que ocurren antes de
+`new_trace`) y el fast_classifier se deriva del coordinador. `metrics_store.bypass_rates()` expone
+total, requests que pasaron por el planner y conteo+tasa por tipo, vía `GET /metrics/llm/bypass` y
+dentro de `/metrics/llm/summary`. Ambos backoffices web (`/metrics` local y dashboard cloud)
+muestran la **tasa de bypass del planner** con desglose por tipo; un salto en `capture`/
+`fast_classifier` señala que el routing dejó de ser orgánico. Con esto **FASE 40 queda COMPLETA**:
+la elección de agente es siempre producto de la planeación del LLM sobre (prompt + AgentCards), sin
+cortocircuitos deterministas que secuestren el routing.
+
 #### Persistencia de datos (SQLite — FASE 32)
 
 Toda la data del sistema vive en **`~/.local/share/capitan/capitan.db`** (SQLite) vía

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3735,7 +3735,7 @@ Objetivo: Garantizar que la elección de agente sea SIEMPRE producto de la plane
           observado: un `request` intent pendiente (típicamente un proactivo de finanzas, creado
           SIN `conversation_id`) captura cualquier enunciado siguiente como su respuesta y
           devuelve "Entendido, el plan 'X' queda sin cambios" ante, p.ej., una consulta de clima.
-Estado:   EN CURSO (5/6 — Etapas A-D completas; queda 40.6 observabilidad).
+Estado:   COMPLETA (panel zellij de 40.6 N/A — los paneles ear ya no existen, FASE 21).
 Deps:     FASE 9  (coordinador LLM — el corazón agnóstico a preservar),
           FASE 22 (intents tipados + captura 22.5 — el path a corregir),
           FASE 36 (ContinuationState — el mecanismo CORRECTO de espera de respuesta),
@@ -3796,7 +3796,9 @@ Hallazgos de la auditoría inicial (ya realizada — base de esta fase):
             por ausencia de contexto) y agregar guard de umbral/ambigüedad. Tests de falsos positivos.
 
 #### Etapa E - Observabilidad de bypass
-- [ ] 40.6  Instrumentar cada bypass: registrar en el trace (FASE 24) cuándo una request NO pasó
+- [x] 40.6  Instrumentar cada bypass: registrar en el trace (FASE 24) cuándo una request NO pasó
             por el planner y por qué cortocircuito (close/ack/capture/fast_classifier). Métrica de
             tasa de bypass por tipo en `/metrics` (ambos backoffices) + panel zellij, para detectar
             regresiones de bias. Tests de ingesta.
+            (panel zellij N/A: `ear/dashboard.kdl` y `panel_*.py` ya no existen — pipeline laptop
+            reemplazado en FASE 21; la observabilidad persistida vive en los `/metrics` web.)


### PR DESCRIPTION
## Etapa E — FASE 40 (umbrella) · cierra FASE 40

Bump del pointer de `core` a la observabilidad de bypass ([core#220](https://github.com/mblasi/home-agents-core/pull/220)) + dashboards web y cierre de la fase.

- **Backoffice local** (`metrics.html`) y **cloud** (`dashboard.html`): card "Bypass del planner" con tasa global y desglose por tipo (capture/fast_classifier/close/ack). El cloud se alimenta del push egress-only (`llm_summary` ya incluye `bypass`).
- `estado.md`: 40.6 `[x]`, **FASE 40 → COMPLETA**. Panel zellij N/A (`ear/dashboard.kdl`/`panel_*.py` ya no existen — pipeline laptop reemplazado en FASE 21).
- Doc de Etapa E en `arquitectura_funcional.md`.

FASE 40 completa: la elección de agente es siempre producto de la planeación del LLM sobre (prompt + AgentCards), sin cortocircuitos deterministas que secuestren el routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)