### PR TITLE
fix: config de paneles en cloud-bo — UI alineada + labels claros + fix atenuado

### DIFF
--- a/cloud/app/static/style.css
+++ b/cloud/app/static/style.css
@@ -63,9 +63,13 @@ main { max-width: 1000px; width: 100%; margin: 0 auto; padding: 20px; }
 .tile span { font-size: 12px; color: var(--muted); }
 .tile.ok b { color: #2ea043; }
 .tile.warn b { color: #f0a020; }
+/* FASE 38: paneles en una sola columna (una row full-width por panel) — evita el desalineado
+   de tiles de altura dispar al abrir el form de config. */
+.panels-grid { grid-template-columns: 1fr; }
 /* FASE 38: form de config contextual por panel */
 .panel-cfg { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--line);
   display: flex; flex-direction: column; gap: 8px; }
+.panel-cfg-title { font-weight: 600; font-size: 13px; }
 .panel-cfg .field { max-width: 100%; }
 .panel-cfg input, .panel-cfg select { font-size: 13px; }
 

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -433,7 +433,7 @@ function renderPanels(state) {
   const tgt = {};
   ((state.versions || {}).targets || []).filter(t => t.kind === "satellite")
     .forEach(t => { tgt[t.label] = t; });
-  $("panels").innerHTML = nodes.length ? `<div class="grid">` + nodes.map(n => {
+  $("panels").innerHTML = nodes.length ? `<div class="grid panels-grid">` + nodes.map(n => {
     const t = tgt[n.id] || {};
     const ver = t.version ? `<span class="muted">${esc(t.version)}</span>` : "";
     const upd = t.behind ? ` <span class="warn">⬆ desactualizado</span>` : "";
@@ -444,7 +444,7 @@ function renderPanels(state) {
     const dev = n.device_config || {};
     const act = CAPS.emit
       ? `<span><button class="mini" onclick="actReboot('${id}')">reiniciar</button>`
-        + ` <button class="mini" onclick="togglePanelCfg('${id}')">configurar</button>`
+        + ` <button id="cfgbtn-${id}" class="mini" onclick="togglePanelCfg('${id}')">configurar</button>`
         + ` <span id="pan-${id}" class="muted"></span></span>` : "";
     // FASE 38: form de config contextual (apagado de pantalla + dashboard por defecto), oculto.
     const curTo = cfg.screen_timeout_secs != null ? cfg.screen_timeout_secs : "";
@@ -457,11 +457,12 @@ function renderPanels(state) {
       : ` <span class="muted">· sin dashboard fijado desde el sistema</span>`;
     const cfgForm = CAPS.emit
       ? `<div id="cfg-${id}" class="panel-cfg hidden">`
+        + `<div class="panel-cfg-title">Ajustes de ${id}</div>`
         + `<div class="field"><label>Apagar pantalla tras (seg, 0 = nunca)${toHint}</label>`
         + `<input id="cfgto-${id}" type="number" min="0" step="5" value="${curTo}" placeholder="120"></div>`
         + `<div class="field"><label>Dashboard por defecto${dashHint}</label>`
         + `<select id="cfgdash-${id}">${dashboardOptions(cfg.default_dashboard || "")}</select></div>`
-        + `<div><button class="mini" onclick="savePanelCfg('${id}')">guardar config</button> `
+        + `<div><button class="mini" onclick="savePanelCfg('${id}')">guardar</button> `
         + `<span id="pancfg-${id}" class="muted"></span>`
         + `</div></div>` : "";
     return `<div class="tile"><b>${dot(n.online)} ${id}</b>`
@@ -470,10 +471,13 @@ function renderPanels(state) {
   }).join("") + `</div>` : `<span class="muted">sin paneles registrados</span>`;
 }
 
-// FASE 38: muestra/oculta el form de config de un panel.
+// FASE 38: muestra/oculta el form de config de un panel y refleja el estado en el botón.
 function togglePanelCfg(id) {
   const el = $("cfg-" + id);
-  if (el) el.classList.toggle("hidden");
+  if (!el) return;
+  el.classList.toggle("hidden");
+  const btn = $("cfgbtn-" + id);
+  if (btn) btn.textContent = el.classList.contains("hidden") ? "configurar" : "cancelar";
 }
 
 // FASE 38: emite panel.config con lo cargado en el form contextual del panel.

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -67,8 +67,12 @@ fuente de verdad en core) administrable desde **ambos backoffices**. Claves inic
 extensible): `screen_timeout_secs` (segundos de inactividad para apagar la pantalla; `0` = nunca) y
 `default_dashboard` (deeplink de HA Companion que abre el panel). El **satélite hace PULL** de su
 config —mismo patrón que el auto-update de código/modelo— y la aplica en el dispositivo: el apagado
-de pantalla con el ajuste nativo de Android (`settings put system screen_off_timeout`, vía `su`) y
-el dashboard con `am start -d <url>`. Flujo: el backoffice (local) o el comando `panel.config` (cloud,
+de pantalla con DOS ajustes nativos de Android vía `su` — `screen_off_timeout` (ms) y, crítico,
+`stay_on_while_plugged_in` (bitmask AC|USB|WIRELESS): un timeout finito pone `stay_on=0` para que la
+pantalla efectivamente se apague (con `stay_on!=0`, default del firmware eWeLink en algunos paneles,
+Android no duerme la pantalla enchufada y el timeout sólo la ATENÚA, nunca off), y `0`=nunca usa
+`stay_on=7` + 24h de respaldo. El wake-word sigue activo con la pantalla apagada por el
+PARTIAL_WAKE_LOCK de Termux. El dashboard se aplica con `am start -d <url>`. Flujo: el backoffice (local) o el comando `panel.config` (cloud,
 egress-only) upsertan la config en core y marcan el nodo en `audio_server` (`POST /nodes/{id}/config-changed`);
 el próximo heartbeat (~30s) lleva `config_update: true` y el satélite consulta `GET /nodes/{id}/config`
 (proxy de `core /panels/config/{node_id}` + versión md5) y reaplica sólo si cambió. Sin el flag,

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3593,7 +3593,9 @@ Deps:     FASE 16 (paneles + audio_server + heartbeat/auto-update), FASE 33/37 (
           tipados + snapshot egress-only), FASE 32 (tabla panels en SQLite).
 Decisiones tomadas:
           - Pantalla: apagado NATIVO de Android (settings put system screen_off_timeout), no
-            atenuación por brillo. Un solo parámetro en segundos.
+            atenuación por brillo. Un solo parámetro en segundos. NOTA: el satélite también ajusta
+            `stay_on_while_plugged_in` (0 con timeout finito, 7 con 'nunca') — sin esto, en paneles
+            donde el firmware lo deja !=0 la pantalla se ATENÚA enchufada pero nunca se apaga.
           - Dashboard: dropdown poblado desde los dashboards reales de HA (lovelace, vía WebSocket
             lovelace/dashboards/list); se guarda el deeplink completo que abre la Companion.
           - Persistencia: columna `config` JSON en la tabla panels (no columnas tipadas) → se


### PR DESCRIPTION
Aborda los tres issues reportados en la sección de configuración de paneles del backoffice cloud.

## 1. UI desalineada
Los paneles se renderizaban con `grid auto-fill minmax(180px,1fr)` → tiles lado a lado de altura dispar (peor al abrir el form de config) → desalineado. Ahora `.panels-grid` fuerza una sola columna: una row full-width por panel.

## 2. "configurar" vs "guardar config" confuso
- `configurar` (abre el editor inline) ahora alterna a `cancelar` cuando está abierto.
- El form lleva título "Ajustes de \<panel\>".
- El botón de submit pasa de `guardar config` a `guardar`.

## 3. La pieza se atenúa pero no se apaga
Fix en el satélite (submodule ear, PR #68, ya mergeado): el satélite ahora gestiona `stay_on_while_plugged_in` además de `screen_off_timeout`. Causa: la pieza tenía `stay_on_while_plugged_in=7`, con lo que Android no duerme la pantalla enchufada y el timeout sólo la atenúa. Este PR bumpea el pointer de ear.

## Docs
`arquitectura_funcional.md` y `estado.md` actualizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)