### PR TITLE
fix: cache-bust style.css (v38→v39) para que aplique .panels-grid

### DIFF
--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Capitán · backoffice en la nube</title>
-  <link rel="stylesheet" href="/static/style.css?v=38">
+  <link rel="stylesheet" href="/static/style.css?v=39">
 </head>
 <body>
 


### PR DESCRIPTION
El cambio de `.panels-grid` en style.css no se veía porque el navegador cacheaba `style.css?v=38`. Bump a v39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)