### PR TITLE
feat: fase 43.5 — UI del orquestador en el backoffice local

### DIFF
--- a/backoffice/server.py
+++ b/backoffice/server.py
@@ -702,9 +702,36 @@ def agent_edit_page(request: Request, agent_id: str, connected: str = "", oauth_
                    all_agents=all_agents)
 
 
+def _parse_config_from_form(form, schema: dict) -> dict:
+    """Construye el dict de config desde el form según el config_schema del agente.
+    Soporta float/int/bool(checkbox)/str. Los bool se setean SIEMPRE (checked→True, ausente→False)."""
+    config: dict = {}
+    for key, meta in schema.items():
+        t = meta.get("type", "str")
+        raw_val = form.get(f"config_{key}")
+        if t == "bool":
+            config[key] = bool(raw_val)  # checkbox: presente=on→True, ausente→False
+            continue
+        if raw_val is None:
+            continue
+        val_str = str(raw_val).strip()
+        try:
+            if t == "float":
+                config[key] = float(val_str)
+            elif t == "int":
+                config[key] = int(val_str)
+            else:
+                config[key] = val_str
+        except (ValueError, TypeError):
+            config[key] = val_str
+    return config
+
+
 @app.post("/agents/{agent_id}/edit")
 async def agent_edit_submit(request: Request, agent_id: str):
     form = await request.form()
+    agent_info = _core(f"/agents/{agent_id}") or {}
+    is_orchestrator = agent_info.get("kind") == "orchestrator"
 
     # Nombre, nombre de fantasía, icono y descripción (agent card)
     name       = str(form.get("name", "")).strip()
@@ -716,6 +743,15 @@ async def agent_edit_submit(request: Request, agent_id: str):
               json={"name": name or None, "fancy_name": fancy_name or None,
                     "icon": icon or None, "desc": desc or None})
 
+    # Config: campos dinámicos según config_schema del agente (model/system_prompt/guards...)
+    config = _parse_config_from_form(form, agent_info.get("config_schema") or {})
+    if config:
+        _core(f"/agents/{agent_id}/config", method="PATCH", json=config)
+
+    # 43.5: el orquestador sólo edita metadata + config (no status/examples/afinidades/RBAC/etc.).
+    if is_orchestrator:
+        return RedirectResponse(f"/agents/{agent_id}/edit?saved=1", status_code=303)
+
     # Status
     status = str(form.get("status", "")).strip()
     if status:
@@ -725,28 +761,6 @@ async def agent_edit_submit(request: Request, agent_id: str):
     ex_raw = str(form.get("examples", ""))
     examples = [e.strip().strip('"\'') for e in ex_raw.splitlines() if e.strip()]
     _core(f"/agents/{agent_id}/examples", method="PATCH", json={"examples": examples})
-
-    # Config: campos dinámicos según config_schema del agente
-    agent_info = _core(f"/agents/{agent_id}") or {}
-    schema = agent_info.get("config_schema") or {}
-    config: dict = {}
-    for key, meta in schema.items():
-        raw_val = form.get(f"config_{key}")
-        if raw_val is None:
-            continue
-        val_str = str(raw_val).strip()
-        t = meta.get("type", "str")
-        try:
-            if t == "float":
-                config[key] = float(val_str)
-            elif t == "int":
-                config[key] = int(val_str)
-            else:
-                config[key] = val_str
-        except (ValueError, TypeError):
-            config[key] = val_str
-    if config:
-        _core(f"/agents/{agent_id}/config", method="PATCH", json=config)
 
     # User context schema (9.21)
     schema_json = str(form.get("user_context_schema_json", "")).strip()

--- a/backoffice/templates/agent_detail.html
+++ b/backoffice/templates/agent_detail.html
@@ -10,9 +10,11 @@
     {% if agent.fancy_name %}<span class="text-indigo-300 text-base font-normal ml-2 italic">{{ agent.fancy_name }}</span>{% endif %}
     <span class="text-gray-500 text-base font-normal ml-1">{{ agent_id }}</span>
     {% if agent.dynamic %}<span class="ml-2 text-xs text-indigo-400 bg-indigo-900/30 border border-indigo-800 px-2 py-0.5 rounded-full">dinámico</span>{% endif %}
+    {% if agent.kind == 'orchestrator' %}<span class="ml-2 text-xs text-indigo-300 bg-indigo-900/30 border border-indigo-700 px-2 py-0.5 rounded-full">🎼 orquestador</span>{% endif %}
     {% if proactive_info %}<span class="ml-2 text-xs text-violet-400 bg-violet-900/20 border border-violet-800 px-2 py-0.5 rounded-full">🔄 proactivo</span>{% endif %}
   </h1>
   <div class="ml-auto flex gap-2 items-center">
+    {% if agent.kind != 'orchestrator' %}
     {% set proactive_on = agent.get('proactive_enabled', true) %}
     <button id="proactive-toggle-{{ agent_id }}"
       hx-post="/agents/{{ agent_id }}/proactive/toggle"
@@ -23,6 +25,7 @@
         {% else %}bg-gray-800 text-gray-500 border-gray-700 hover:bg-gray-700{% endif %}">
       proactivo: {{ 'on' if proactive_on else 'off' }}
     </button>
+    {% endif %}
     <a href="/agents/{{ agent_id }}/edit"
        class="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
       Editar

--- a/backoffice/templates/agent_edit.html
+++ b/backoffice/templates/agent_edit.html
@@ -18,6 +18,17 @@
 {% endif %}
 
 <form method="POST" action="/agents/{{ agent_id }}/edit">
+  {% set is_orch = agent.kind == 'orchestrator' %}
+
+  {% if is_orch %}
+  <div class="bg-indigo-900/20 border border-indigo-800/50 rounded-xl p-4 mb-5">
+    <p class="text-xs text-indigo-300">
+      🎼 <span class="font-semibold">Orquestador</span> — agente raíz del árbol recursivo. Recibe el
+      pedido, planifica y delega en los agentes de dominio. Es configurable (modelo LLM, prompt,
+      guards) pero no se desactiva, no es proactivo y ningún agente delega en él.
+    </p>
+  </div>
+  {% endif %}
 
   <!-- Sección 0: Nombre e icono -->
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
@@ -46,6 +57,7 @@
   </div>
 
   <!-- Sección 1: Status -->
+  {% if not is_orch %}
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
     <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Estado</h2>
     <div class="flex gap-4">
@@ -85,6 +97,7 @@
     </p>
     {% endif %}
   </div>
+  {% endif %}
 
   <!-- Sección 2: Carta del Coordinador -->
   <div id="card" class="bg-gray-900 border border-indigo-900/50 rounded-xl p-5 mb-5">
@@ -107,6 +120,7 @@
     </div>
 
     <!-- Ejemplos -->
+    {% if not is_orch %}
     <div>
       <label class="block text-xs font-medium text-gray-400 mb-1">Ejemplos de activación</label>
       <textarea
@@ -120,6 +134,7 @@
         3-5 ejemplos variados mejoran significativamente la precisión del routing.
       </p>
     </div>
+    {% endif %}
   </div>
 
   <!-- Sección 3: Backends -->
@@ -179,7 +194,10 @@
   {% if agent.config_schema %}
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
     <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-1">Configuración</h2>
-    <p class="text-xs text-gray-600 mb-4">Los cambios de configuración aplican al reiniciar el core.</p>
+    <p class="text-xs text-gray-600 mb-4">
+      {% if is_orch %}Los cambios aplican de inmediato (el orquestador lee su config en cada pedido).
+      {% else %}Los cambios de configuración aplican al reiniciar el core.{% endif %}
+    </p>
     <div class="grid grid-cols-1 gap-4">
       {% for key, meta in agent.config_schema.items() %}
       {% set cur_val = agent.config.get(key, meta.default) %}
@@ -215,6 +233,13 @@
           {% if meta.type == 'float' %}step="any"{% endif %}
           class="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200
                  focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500">
+        {% elif meta.type == 'bool' %}
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="config_{{ key }}" value="1"
+                 {% if cur_val %}checked{% endif %}
+                 class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500">
+          <span class="text-sm text-gray-300">Activado</span>
+        </label>
         {% else %}
         <input
           type="text"
@@ -272,6 +297,7 @@
   {% endif %}
 
   <!-- Sección 7: Afinidades entre agentes -->
+  {% if not is_orch %}
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
     <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-1">Afinidades entre agentes</h2>
     <p class="text-xs text-gray-600 mb-4">
@@ -302,7 +328,7 @@
       {% set current_affinities = agent.get('affinities') or [] %}
       {% if all_agents %}
       <div class="grid grid-cols-2 gap-1.5 max-h-48 overflow-y-auto pr-1">
-        {% for aid, ainfo in all_agents.items() if aid != agent_id %}
+        {% for aid, ainfo in all_agents.items() if aid != agent_id and ainfo.get('kind') != 'orchestrator' %}
         <label class="flex items-center gap-2 px-3 py-2 bg-gray-800/50 rounded-lg cursor-pointer hover:bg-gray-800 transition-colors">
           <input type="checkbox" name="affinity_{{ aid }}" value="1"
                  {% if aid in current_affinities %}checked{% endif %}
@@ -319,8 +345,10 @@
       {% endif %}
     </div>
   </div>
+  {% endif %}
 
   <!-- Sección 8: Acceso por rol -->
+  {% if not is_orch %}
   <div class="bg-gray-900 border border-gray-800 rounded-xl p-5 mb-5">
     <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-1">Acceso por rol</h2>
     <p class="text-xs text-gray-600 mb-3">Qué roles tienen acceso a este agente por defecto.</p>
@@ -339,6 +367,7 @@
       {% endfor %}
     </div>
   </div>
+  {% endif %}
 
   <div class="flex gap-3">
     <button type="submit"

--- a/backoffice/templates/agents.html
+++ b/backoffice/templates/agents.html
@@ -46,6 +46,7 @@
               <div class="text-xs text-gray-500">
                 {{ aid }}
                 {% if info.dynamic %}<span class="ml-1 text-indigo-400 text-xs">dinámico</span>{% endif %}
+                {% if info.kind == 'orchestrator' %}<span class="ml-1 text-indigo-300 text-xs">🎼 orquestador</span>{% endif %}
               </div>
             </div>
           </div>
@@ -53,6 +54,10 @@
         <td class="px-4 py-3 text-gray-300">{{ info.desc }}</td>
         <td class="px-4 py-3 text-center" id="status-cell-{{ aid }}">
           {% set st = info.status %}
+          {% if info.kind == 'orchestrator' %}
+          <span title="El orquestador siempre está activo"
+                class="px-2 py-1 rounded text-xs font-medium bg-emerald-900/50 text-emerald-400">active</span>
+          {% else %}
           <button
             hx-post="/agents/{{ aid }}/toggle"
             hx-target="#status-cell-{{ aid }}"
@@ -62,14 +67,20 @@
               {% if st == 'active' %}bg-emerald-900/50 text-emerald-400 hover:bg-emerald-900{% elif st == 'planned' %}bg-gray-800 text-gray-500 hover:bg-gray-700{% else %}bg-red-900/50 text-red-400 hover:bg-red-900{% endif %}">
             {{ st }}
           </button>
+          {% endif %}
         </td>
         <td class="px-4 py-3 text-center">
-          {% if info.proactive_enabled %}
+          {% if info.kind == 'orchestrator' %}
+            <span class="text-gray-600 text-xs">—</span>
+          {% elif info.proactive_enabled %}
             <span class="px-2 py-0.5 bg-indigo-900/50 text-indigo-400 rounded text-xs">on</span>
           {% else %}
             <span class="px-2 py-0.5 bg-gray-800 text-gray-600 rounded text-xs">off</span>
           {% endif %}
         </td>
+        {% if info.kind == 'orchestrator' %}
+        <td class="px-4 py-3 text-center"><span class="text-gray-600 text-xs">—</span></td>
+        {% else %}
         <td class="px-4 py-3 text-center"
             id="reachable-{{ aid }}"
             hx-get="/api/agents/{{ aid }}/reachable"
@@ -78,6 +89,7 @@
             hx-target="#reachable-{{ aid }}">
           <span class="text-gray-500 text-xs animate-pulse">…</span>
         </td>
+        {% endif %}
         <td class="px-4 py-3 text-center">
           <div class="flex items-center justify-center gap-2">
             <a href="/agents/{{ aid }}/detail"

--- a/backoffice/tests/test_orchestrator_form.py
+++ b/backoffice/tests/test_orchestrator_form.py
@@ -1,0 +1,53 @@
+"""FASE 43.5 — parsing de config del form del backoffice (incl. el orquestador).
+
+El backoffice no tenía suite; este test cubre _parse_config_from_form, en particular el tipo
+`bool` (checkbox) que el orquestador usa para routing_hint_enabled. Correr con:
+    cd backoffice && python -m pytest tests/ -q
+"""
+import sys
+from pathlib import Path
+
+from starlette.datastructures import FormData
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import server
+
+SCHEMA = {
+    "model":                {"type": "select"},
+    "system_prompt":        {"type": "text"},
+    "max_iters":            {"type": "int"},
+    "llm_budget":           {"type": "int"},
+    "routing_hint_enabled": {"type": "bool"},
+}
+
+
+def test_parses_select_int_text():
+    f = FormData([("config_model", "qwen2.5:3b"), ("config_max_iters", "7"),
+                  ("config_system_prompt", "SOS X.")])
+    cfg = server._parse_config_from_form(f, SCHEMA)
+    assert cfg["model"] == "qwen2.5:3b"
+    assert cfg["max_iters"] == 7 and isinstance(cfg["max_iters"], int)
+    assert cfg["system_prompt"] == "SOS X."
+
+
+def test_bool_checked_true():
+    f = FormData([("config_routing_hint_enabled", "1")])
+    assert server._parse_config_from_form(f, SCHEMA)["routing_hint_enabled"] is True
+
+
+def test_bool_unchecked_false():
+    # el checkbox ausente debe quedar False (no omitido) — si no, nunca se podría desactivar
+    f = FormData([("config_model", "x")])
+    cfg = server._parse_config_from_form(f, SCHEMA)
+    assert cfg["routing_hint_enabled"] is False
+
+
+def test_absent_non_bool_keys_skipped():
+    f = FormData([("config_routing_hint_enabled", "1")])
+    cfg = server._parse_config_from_form(f, SCHEMA)
+    assert "model" not in cfg and "max_iters" not in cfg  # no presentes → no se tocan
+
+
+def test_bad_int_falls_back_to_str():
+    f = FormData([("config_max_iters", "abc")])
+    assert server._parse_config_from_form(f, SCHEMA)["max_iters"] == "abc"

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3939,7 +3939,7 @@ Objetivo: Cerrar el refactor del runtime recursivo (FASE 41/42) formalizando al 
           POR-AGENTE (subsume el tier env-only de 42.2); (d) lo expone y edita desde AMBOS
           backoffices (form local + comando tipado cloud egress-only). Mantiene su naturaleza
           especial sin romper la recursión.
-Estado:   EN CURSO (4/7 — Etapa A (43.1-43.3) + Etapa B (43.4 API) completas; falta UI local/cloud + docs).
+Estado:   EN CURSO (5/7 — Etapas A+B+C (UI local) completas; falta UI cloud (43.6) + docs (43.7)).
 Deps:     FASE 41 (runtime recursivo — RecursiveAgent, build_root_agent, resolver),
           FASE 42 (AGENT_LEAF_MODEL — se subsume en config por-agente),
           FASE 14 (agent_config + edición de agentes desde backoffice — patrón a reusar),
@@ -3991,10 +3991,12 @@ Decisiones tomadas:
             Tests TestClient (catálogo, allow-list, rechazos, /models up/down). (PR core #237)
 
 #### Etapa C - backoffice local
-- [ ] 43.5  UI: el `orchestrator` aparece en `/agents` con badge especial; su detail/edit muestra y
-            edita `model` (dropdown desde `/models`), `system_prompt` y los guards
-            (max_iters/max_depth/llm_budget/routing_hint_enabled). Oculta los toggles que no aplican
-            (proactive, delegabilidad, status). Reusa el form de FASE 14.
+- [x] 43.5  UI local: el `orchestrator` aparece en `/agents` con badge 🎼 (status fijo, sin
+            toggle ni eliminar); su detail oculta el toggle proactivo; su edit edita `model`
+            (dropdown desde `/models`), `system_prompt` y los guards (incl. `routing_hint_enabled`
+            como checkbox `bool` nuevo) y oculta status/ejemplos/afinidades/RBAC. El submit sólo
+            manda metadata+config para el orquestador. Core: `/agents-meta` lo incluye + `kind` por
+            entry (PR core #238). Tests del parser de config (backoffice).
 
 #### Etapa D - backoffice cloud
 - [ ] 43.6  Comando tipado `agent.config` (CATALOG/PRESENTATION/validación, admin-only): params


### PR DESCRIPTION
FASE 43.5 (#721) — el orquestador, editable desde el backoffice local.

- **Lista** (`/agents`): badge 🎼, status fijo `active` (sin toggle), sin botón eliminar, reachable/proactive en `—`.
- **Detail**: badge 🎼; oculta el toggle proactivo.
- **Edit**: edita `model` (dropdown desde `/models`), `system_prompt` y guards (`max_iters`/`max_depth`/`llm_budget`/`routing_hint_enabled`); este último como checkbox **bool** (tipo nuevo en el form). Oculta status/ejemplos/afinidades/RBAC. El orquestador queda fuera de las afinidades de otros agentes.
- **Submit**: para el orquestador sólo emite metadata + config; `_parse_config_from_form` extraído con soporte `bool` (checkbox: ausente→False).
- **Core** (bump submodule a 31029ad): `/agents-meta` incluye al orquestador y expone `kind` por entry (PR core #238).

Tests del parser (backoffice/tests, suite nueva). Templates validados con Jinja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)