### PR TITLE
feat: fase 43.6 — configurar el orquestador desde el backoffice cloud

### DIFF
--- a/cloud/app/commands.py
+++ b/cloud/app/commands.py
@@ -110,6 +110,16 @@ CATALOG: dict[str, dict[str, tuple[Callable[[Any], Any], bool]]] = {
                         "status": (_enum("status", AGENT_STATUSES), True)},
     "panel.reboot":    {"node_id": (_str("node_id"), True)},
     "proactive.run":   {"agent_id": (_str("agent_id"), True)},
+    # FASE 43.6: configurar un agente (en particular el ORQUESTADOR): modelo LLM + guards +
+    # system_prompt. El core valida con allow-list al config_schema del agente; acá sólo se
+    # tipa. Todos los params de config son opcionales (merge parcial).
+    "agent.config":    {"agent_id": (_str("agent_id"), True),
+                        "model": (_str("model"), False),
+                        "system_prompt": (_str("system_prompt"), False),
+                        "max_iters": (_int_range("max_iters", 1, 20), False),
+                        "max_depth": (_int_range("max_depth", 1, 10), False),
+                        "llm_budget": (_int_range("llm_budget", 1, 100), False),
+                        "routing_hint_enabled": (_bool("routing_hint_enabled"), False)},
     # FASE 38: config por panel (apagado de pantalla por inactividad + dashboard por defecto).
     # El bridge upserta en core y marca el nodo en audio_server; el satélite la reaplica.
     "panel.config":    {"node_id": (_str("node_id"), True),
@@ -155,6 +165,7 @@ def validate_command(cmd_type: str, params: dict[str, Any] | None) -> dict[str, 
 #         user   → selector de usuario
 #         agent  → selector de agente
 #         dashboard → selector de dashboard de HA (poblado desde snapshot.dashboards, FASE 38)
+#         model  → selector de modelo LLM (poblado desde snapshot.models, FASE 43)
 # Comandos con entidad-ancla (agent.toggle/panel.reboot/proactive.run/...) se invocan como
 # acciones contextuales en su sección; igual se exponen aquí para completitud.
 CMD_LABELS: dict[str, str] = {
@@ -173,6 +184,7 @@ CMD_LABELS: dict[str, str] = {
     "panel.reboot": "Reiniciar panel",
     "proactive.run": "Correr agente proactivo",
     "panel.config": "Configurar panel",
+    "agent.config": "Configurar agente / orquestador",
 }
 
 PRESENTATION: dict[str, dict[str, dict[str, Any]]] = {
@@ -197,6 +209,13 @@ PRESENTATION: dict[str, dict[str, dict[str, Any]]] = {
                         "status": {"kind": "enum", "label": "Estado", "choices": AGENT_STATUSES}},
     "panel.reboot":    {"node_id": {"kind": "node", "label": "Panel"}},
     "proactive.run":   {"agent_id": {"kind": "agent", "label": "Agente"}},
+    "agent.config":    {"agent_id": {"kind": "agent", "label": "Agente"},
+                        "model": {"kind": "model", "label": "Modelo LLM"},
+                        "system_prompt": {"kind": "str", "label": "System prompt"},
+                        "max_iters": {"kind": "int", "label": "Máx. iteraciones por nodo", "min": 1, "max": 20},
+                        "max_depth": {"kind": "int", "label": "Máx. profundidad de delegación", "min": 1, "max": 10},
+                        "llm_budget": {"kind": "int", "label": "Presupuesto LLM (árbol)", "min": 1, "max": 100},
+                        "routing_hint_enabled": {"kind": "bool", "label": "Usar hint de routing"}},
     "panel.config":    {"node_id": {"kind": "node", "label": "Panel"},
                         "screen_timeout_secs": {"kind": "int", "label": "Apagar pantalla tras (seg, 0 = nunca)",
                                                 "min": 0, "max": 86400, "default": 120},

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -32,6 +32,8 @@ class AgentState(BaseModel):
     id: str
     active: bool
     proactive: bool = False
+    kind: str = "domain"            # FASE 43: "orchestrator" para el agente raíz
+    config: dict = Field(default_factory=dict)  # config efectiva (model/system_prompt/guards)
 
 
 class RecentCommand(BaseModel):
@@ -106,6 +108,8 @@ class StateSnapshot(BaseModel):
     counts: Counts = Field(default_factory=Counts)
     # FASE 38: dashboards de HA para poblar el selector del comando panel.config (no PII).
     dashboards: list[Dashboard] = Field(default_factory=list)
+    # FASE 43: modelos LLM disponibles en Ollama, para poblar el selector del comando agent.config.
+    models: list[str] = Field(default_factory=list)
     # Matriz unificada de targets (34.15): {targets: [{id,label,where,kind,version,url,latest,
     # latest_url,behind,command,params,advanced}], satellite_expected}. Opcional (retrocompat).
     versions: dict[str, Any] = Field(default_factory=dict)

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -387,6 +387,21 @@ const actToggle = (id, status) =>
     { label: `Poner ${id} en ${status}`, status: $("act-" + id) });
 const actProactive = (id) =>
   runCommand("proactive.run", { agent_id: id }, { label: `Correr ${id}`, status: $("act-" + id) });
+// 43.6: abre el form tipado en agent.config, prellenado con el agente y su config actual.
+function actConfig(id) {
+  location.hash = "acciones";
+  setTimeout(() => {
+    const sel = $("cmd-type"); if (!sel) return;
+    sel.value = "agent.config"; renderFields();
+    const set = (n, v) => { const e = $("f-" + n); if (e == null || v == null) return;
+      if (e.type === "checkbox") e.checked = !!v; else e.value = v; };
+    set("agent_id", id);
+    const a = ((LAST_STATE || {}).agents || []).find(x => x.id === id) || {};
+    const c = a.config || {};
+    ["model", "system_prompt", "max_iters", "max_depth", "llm_budget"].forEach(k => set(k, c[k]));
+    if ("routing_hint_enabled" in c) set("routing_hint_enabled", c.routing_hint_enabled);
+  }, 0);
+}
 const actReboot = (id) =>
   runCommand("panel.reboot", { node_id: id }, { label: `Reiniciar panel ${id}`, status: $("pan-" + id) });
 const actRetrain = () =>
@@ -531,15 +546,22 @@ async function refresh() {
     $("agents").innerHTML = (state.agents || [])
       .map(a => {
         const id = esc(a.id);
+        const isOrch = a.kind === "orchestrator";
         let act = "";
         if (CAPS.emit) {
-          const toggle = a.active
-            ? `<button class="mini" onclick="actToggle('${id}','planned')">desactivar</button>`
-            : `<button class="mini" onclick="actToggle('${id}','active')">activar</button>`;
-          const proa = a.proactive ? ` <button class="mini" onclick="actProactive('${id}')">correr</button>` : "";
-          act = ` ${toggle}${proa} <span id="act-${id}" class="muted"></span>`;
+          const cfg = `<button class="mini" onclick="actConfig('${id}')">configurar</button>`;
+          if (isOrch) {
+            // 43.6: el orquestador no se activa/desactiva ni corre proactivo — sólo se configura.
+            act = ` ${cfg} <span id="act-${id}" class="muted"></span>`;
+          } else {
+            const toggle = a.active
+              ? `<button class="mini" onclick="actToggle('${id}','planned')">desactivar</button>`
+              : `<button class="mini" onclick="actToggle('${id}','active')">activar</button>`;
+            const proa = a.proactive ? ` <button class="mini" onclick="actProactive('${id}')">correr</button>` : "";
+            act = ` ${toggle}${proa} ${cfg} <span id="act-${id}" class="muted"></span>`;
+          }
         }
-        return `<div>${dot(a.active)} <b>${id}</b>${a.proactive ? " ⚡" : ""}${act}</div>`;
+        return `<div>${isOrch ? "🎼" : dot(a.active)} <b>${id}</b>${isOrch ? " <span class=\"muted\">(orquestador)</span>" : ""}${a.proactive ? " ⚡" : ""}${act}</div>`;
       }).join("");
     renderWakeword(state.wakeword || {});
     renderPanels(state);
@@ -679,6 +701,11 @@ function dashboardOptions(selectedUrl) {
     + dl.map(d => `<option value="${esc(d.url)}"${d.url === selectedUrl ? " selected" : ""}>${esc(d.title)}</option>`).join("");
 }
 
+// Modelos LLM disponibles (FASE 43), desde el snapshot. Para el selector del comando agent.config.
+function modelOptions() {
+  return ((LAST_STATE || {}).models || []).map(m => m);
+}
+
 function fieldWidget(p) {
   const id = "f-" + p.name;
   const opt = (vals, withEmpty) =>
@@ -692,6 +719,8 @@ function fieldWidget(p) {
       w = `<select id="${id}">${opt(entityChoices(p.kind), true)}</select>`; break;
     case "dashboard":   // FASE 38: selector de dashboard de HA (value=url, label=título)
       w = `<select id="${id}">${dashboardOptions("")}</select>`; break;
+    case "model":       // FASE 43: selector de modelo LLM (poblado del snapshot)
+      w = `<select id="${id}">${opt(modelOptions(), true)}</select>`; break;
     case "multi":
       w = `<div id="${id}" class="checks">` + (p.choices || []).map(v =>
         `<label class="chk"><input type="checkbox" value="${esc(v)}"> ${esc(v)}</label>`).join("") + `</div>`; break;

--- a/cloud/bridge/executor.py
+++ b/cloud/bridge/executor.py
@@ -180,6 +180,21 @@ def _agent_toggle(p: dict) -> ExecResult:
         return ExecResult(False, "", f"no se pudo cambiar el agente: {exc}")
 
 
+def _agent_config(p: dict) -> ExecResult:
+    """FASE 43.6: configura un agente (en particular el ORQUESTADOR) — PATCH /agents/{id}/config
+    del core. Los params (menos agent_id) son el merge parcial de config; el core aplica su
+    allow-list al config_schema del agente."""
+    body = {k: v for k, v in p.items() if k != "agent_id"}
+    if not body:
+        return ExecResult(False, "", "no se especificó ningún campo de configuración")
+    try:
+        r = requests.patch(f"{CORE_URL}/agents/{p['agent_id']}/config", json=body, timeout=10)
+        r.raise_for_status()
+        return ExecResult(True, f"{p['agent_id']}: {', '.join(sorted(body))} actualizado")
+    except Exception as exc:  # noqa: BLE001
+        return ExecResult(False, "", f"no se pudo configurar el agente: {exc}")
+
+
 def _proactive_run(p: dict) -> ExecResult:
     """FASE 37.8: dispara el ciclo proactivo de un agente (POST /proactive/{id}/run del core)."""
     try:
@@ -265,6 +280,7 @@ HANDLERS = {
     "wakeword.retrain": _wakeword_retrain,
     "voice.reenroll": _voice_reenroll,
     "agent.toggle": _agent_toggle,
+    "agent.config": _agent_config,
     "panel.reboot": _panel_reboot,
     "proactive.run": _proactive_run,
     "panel.config": _panel_config,

--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -75,12 +75,26 @@ def _agents() -> list[dict]:
     for aid, meta in data.items():
         if not isinstance(meta, dict):
             continue
-        out.append({
+        kind = meta.get("kind", "domain")
+        entry = {
             "id": aid,
             "active": meta.get("status") == "active",
             "proactive": bool(meta.get("proactive") or meta.get("proactive_enabled")),
-        })
+            "kind": kind,
+        }
+        # FASE 43: la config efectiva del orquestador viaja para prellenar el form de agent.config.
+        # Sin secretos (model/system_prompt/guards). Sólo el orquestador la necesita en la UI.
+        if kind == "orchestrator":
+            entry["config"] = meta.get("config") or {}
+        out.append(entry)
     return out
+
+
+def _models() -> list[str]:
+    """Modelos LLM disponibles en Ollama (FASE 43), para el selector del comando agent.config."""
+    data = _get(f"{CORE_URL}/models")
+    models = data.get("models") if isinstance(data, dict) else None
+    return models if isinstance(models, list) else []
 
 
 def _nodes() -> list[dict]:
@@ -307,4 +321,5 @@ def build_snapshot() -> dict:
         "alerts": _alerts(),
         "counts": _counts(),
         "dashboards": _dashboards(),   # FASE 38: selector de dashboard del comando panel.config
+        "models": _models(),           # FASE 43: selector de modelo del comando agent.config
     }

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -502,3 +502,49 @@ def test_snapshot_nodes_carry_device_config():
     node = snap["wakeword"]["nodes"][0]
     assert node["device_config"] == {"screen_timeout_secs": 120}
     StateSnapshot(**snap)
+
+
+def test_agent_config_patches_core_config(monkeypatch):
+    captured = {}
+
+    def fake_patch(url, json=None, timeout=10):
+        captured.update(url=url, json=json)
+        return _resp()
+
+    monkeypatch.setattr(executor.requests, "patch", fake_patch)
+    r = executor.execute("agent.config", {"agent_id": "orchestrator",
+                                          "model": "qwen2.5:3b", "max_iters": 6})
+    assert r.ok and captured["url"].endswith("/agents/orchestrator/config")
+    assert captured["json"] == {"model": "qwen2.5:3b", "max_iters": 6}  # sin agent_id
+
+
+def test_agent_config_no_fields_fails():
+    r = executor.execute("agent.config", {"agent_id": "orchestrator"})
+    assert not r.ok and "configuraci" in r.error.lower()
+
+
+def test_snapshot_includes_models_and_orchestrator():
+    from app.models import StateSnapshot
+
+    def fake_get(url, timeout=4):
+        if url.endswith("/agents"):
+            return {
+                "haos": {"status": "active", "proactive_enabled": True, "kind": "domain"},
+                "orchestrator": {"status": "active", "kind": "orchestrator",
+                                 "config": {"model": "qwen2.5:7b", "max_iters": 5,
+                                            "routing_hint_enabled": True}},
+            }
+        if url.endswith("/models"):
+            return {"models": ["qwen2.5:3b", "qwen2.5:7b"]}
+        return None
+
+    with patch.object(snapshot, "_get", fake_get), \
+         patch.object(snapshot, "_systemctl_active", lambda u: False):
+        snap = snapshot.build_snapshot()
+
+    assert snap["models"] == ["qwen2.5:3b", "qwen2.5:7b"]
+    orch = next(a for a in snap["agents"] if a["id"] == "orchestrator")
+    assert orch["kind"] == "orchestrator" and orch["config"]["model"] == "qwen2.5:7b"
+    haos = next(a for a in snap["agents"] if a["id"] == "haos")
+    assert haos["kind"] == "domain" and "config" not in haos  # config sólo para el orquestador
+    StateSnapshot(**snap)   # valida contra el contrato de la nube

--- a/cloud/tests/test_commands.py
+++ b/cloud/tests/test_commands.py
@@ -254,3 +254,40 @@ def test_panel_config_presentation_kinds():
     assert _param("panel.config", "node_id")["kind"] == "node"
     assert _param("panel.config", "screen_timeout_secs")["kind"] == "int"
     assert _param("panel.config", "default_dashboard")["kind"] == "dashboard"
+
+
+# ── FASE 43.6: agent.config (orquestador configurable) ────────────────────────
+
+def test_agent_config_ok():
+    out = validate_command("agent.config", {
+        "agent_id": "orchestrator", "model": "qwen2.5:3b", "system_prompt": "SOS X.",
+        "max_iters": 6, "max_depth": 3, "llm_budget": 12, "routing_hint_enabled": False})
+    assert out["agent_id"] == "orchestrator" and out["model"] == "qwen2.5:3b"
+    assert out["routing_hint_enabled"] is False and out["max_iters"] == 6
+
+
+def test_agent_config_requires_agent_id():
+    with pytest.raises(CommandError):
+        validate_command("agent.config", {"model": "qwen2.5:7b"})
+
+
+def test_agent_config_partial_is_ok():
+    # config parcial: sólo el modelo (merge en el core)
+    assert validate_command("agent.config", {"agent_id": "orchestrator", "model": "qwen2.5:7b"}) == {
+        "agent_id": "orchestrator", "model": "qwen2.5:7b"}
+
+
+def test_agent_config_int_out_of_range():
+    with pytest.raises(CommandError):
+        validate_command("agent.config", {"agent_id": "orchestrator", "max_iters": 999})
+
+
+def test_agent_config_unknown_param_rejected():
+    with pytest.raises(CommandError):
+        validate_command("agent.config", {"agent_id": "orchestrator", "status": "unavailable"})
+
+
+def test_agent_config_param_kinds():
+    assert _param("agent.config", "agent_id")["kind"] == "agent"
+    assert _param("agent.config", "model")["kind"] == "model"
+    assert _param("agent.config", "routing_hint_enabled")["kind"] == "bool"

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3939,7 +3939,7 @@ Objetivo: Cerrar el refactor del runtime recursivo (FASE 41/42) formalizando al 
           POR-AGENTE (subsume el tier env-only de 42.2); (d) lo expone y edita desde AMBOS
           backoffices (form local + comando tipado cloud egress-only). Mantiene su naturaleza
           especial sin romper la recursión.
-Estado:   EN CURSO (5/7 — Etapas A+B+C (UI local) completas; falta UI cloud (43.6) + docs (43.7)).
+Estado:   EN CURSO (6/7 — Etapas A-D completas (core + UI local + UI cloud); falta sólo docs (43.7)).
 Deps:     FASE 41 (runtime recursivo — RecursiveAgent, build_root_agent, resolver),
           FASE 42 (AGENT_LEAF_MODEL — se subsume en config por-agente),
           FASE 14 (agent_config + edición de agentes desde backoffice — patrón a reusar),
@@ -3999,12 +3999,13 @@ Decisiones tomadas:
             entry (PR core #238). Tests del parser de config (backoffice).
 
 #### Etapa D - backoffice cloud
-- [ ] 43.6  Comando tipado `agent.config` (CATALOG/PRESENTATION/validación, admin-only): params
-            agent_id + claves de config (`model` kind enum poblado por el snapshot de modelos
-            disponibles, `system_prompt` text, guards numéricos, `routing_hint_enabled` bool) +
-            executor que llama el PATCH del core. Snapshot: incluir al `orchestrator` con su config
-            (egress-safe) + lista de modelos disponibles. UI contextual "configurar" del orquestador
-            en `dashboard.html`. Tests (`test_commands`, `test_bridge`).
+- [x] 43.6  Comando tipado `agent.config` (CATALOG/PRESENTATION/validación, admin-only via `emit`):
+            agent_id + config (kind `model` NUEVO poblado por el snapshot, system_prompt, guards int,
+            routing_hint_enabled bool); executor `_agent_config` → PATCH /config del core. Snapshot:
+            `models` (de `GET /models`) + el orquestador con `kind` y su `config` (egress-safe).
+            `AgentState`/`StateSnapshot` extendidos. UI: botón "configurar" por agente + `actConfig`
+            que prellena el form tipado; el orquestador con badge 🎼 sin toggle. Tests
+            (`test_commands`, `test_bridge`: validación, executor, snapshot valida el contrato).
 
 #### Etapa E - documentación
 - [ ] 43.7  Docs: `arquitectura_funcional.md` (orquestador como agente configurable + modelo


### PR DESCRIPTION
FASE 43.6 (#722) — el orquestador, configurable desde el cloud (egress-only).

- **Comando** `agent.config` (admin-only via `emit`): agent_id + model/system_prompt/guards/routing_hint_enabled. Validado en `commands.py` (allow-list cerrada); el core reaplica su propia allow-list al config_schema.
- **Widget nuevo** `model` (kind de presentación) poblado desde `snapshot.models`.
- **Executor** `_agent_config` → `PATCH /agents/{id}/config` (manda sólo los campos provistos).
- **Snapshot**: top-level `models` (de `GET /models`) + el orquestador con `kind` y su `config` efectiva (egress-safe, sin secretos). `AgentState.kind/config` + `StateSnapshot.models`.
- **UI**: botón "configurar" por agente + `actConfig()` que abre el form tipado prellenado (agente + config actual del orquestador); el orquestador se renderiza con badge 🎼 sin toggle activar/desactivar.

Tests: validación (`test_commands`), executor + snapshot valida el contrato `StateSnapshot` (`test_bridge`). Suite cloud: 160 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)