### PR TITLE
docs: fase 43.7 — orquestador como agente de primera clase (FASE 43 COMPLETA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ iGPU** (Radeon 780M / ROCm): a qwen3 8b+4b pair exceeds the ~8 GB GTT ceiling an
 qwen2.5 7b+3b pair loads but the leaf's tool-constrained generation aborts intermittently — so the
 tree runs single-model. A dedicated GPU would unlock the tier and cut latency.
 
+**Orchestrator as a first-class agent (Phase 43).** The root agent is no longer a hardcoded runtime
+construct: it lives in the catalog (`agent_registry.get_catalog()` = domain `get_registry()` + a
+synthetic `orchestrator` entry of `kind="orchestrator"` — not delegable, not proactive, not
+disableable) and its config (LLM `model`, `system_prompt`, and guards `max_iters`/`max_depth`/
+`llm_budget`/`routing_hint_enabled`) lives in `agent_config`, hot-editable like any agent.
+`build_root_agent` reads it; the per-agent model now wins over the global `AGENT_LEAF_MODEL` env
+(generalizing Phase 42's env-only tier). It's editable from both backoffices: the local one shows it
+in `/agents` with an edit form; the cloud one with the typed `agent.config` command (model picker fed
+by `GET /models` via the snapshot).
+
 ---
 
 ## Observability (Phase 35)

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -61,6 +61,15 @@ la pantalla con `screen_off_timeout` y abre el dashboard con `am start -d`. Egre
 inbound; el panel hace el PULL. El snapshot lleva la config vigente de cada panel (no PII) para
 prellenar el form.
 
+**Configurar el orquestador / agentes (FASE 43).** La sección Agentes incluye, por agente (rol
+`emit`), un botón "configurar" que abre el form tipado en el comando `agent.config`: modelo LLM
+(selector poblado desde `snapshot.models`, kind de presentación `model`), `system_prompt` y guards
+(`max_iters`/`max_depth`/`llm_budget`/`routing_hint_enabled`). El bridge lo ejecuta como
+`PATCH /agents/{id}/config` en core (allow-list al `config_schema`). El **orquestador** (agente raíz)
+aparece con badge 🎼 — configurable pero sin activar/desactivar (no es delegable ni proactivo ni
+desactivable); su `kind` y su config efectiva viajan en el snapshot (sin secretos) para prellenar el
+form.
+
 ## Deploy de servicios (FASE 34)
 
 El dashboard incluye una **matriz de targets**: una fila por componente que corre (core,

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -273,6 +273,36 @@ calls: raíz→haos→tool→consolidación). Es el costo aceptado de que el pla
 Observabilidad en FASE 41.9: llamadas LLM y tool_calls por request, profundidad del árbol, y uso de
 las tools de housekeeping (la métrica `bypass_rate` de 40.6 tiende a 0 y se deprecó).
 
+#### Orquestador como agente de primera clase (FASE 43)
+
+Cerrando el refactor recursivo, el **orquestador (agente raíz) deja de ser un constructo runtime
+hardcodeado** y pasa a ser un agente más, configurable y presente en el catálogo:
+
+- **En el catálogo.** `agent_registry.get_catalog()` = `get_registry()` (sólo agentes de dominio
+  delegables, intacto — lo consumen el scheduler proactivo, las agent cards y el clasificador) **+**
+  una entry sintética del orquestador (`ORCHESTRATOR_ID = "orchestrator"`, `kind="orchestrator"`).
+  El orquestador es **kind especial**: no delegable (excluido de los `sub_agents` y de los enums de
+  `call_agent` de todo nodo — no rompe la recursión), no proactivo, y no desactivable (status fijo
+  `active`).
+- **Config en `agent_config`** (SQLite, editable en caliente como cualquier agente), con su
+  `config_schema`: `model` (backend LLM), `system_prompt` (override del `_ROOT_SYSTEM`), `max_iters`,
+  `max_depth`, `llm_budget`, `routing_hint_enabled`. `build_root_agent` lee la config efectiva
+  (`agent_registry.orchestrator_config()`); el RunContext del server toma `max_depth`/`llm_budget` de
+  ahí; el hint del clasificador (42.3) se gatea con `routing_hint_enabled`. Defaults derivados del
+  runtime/env (`AGENT_MODEL`, `AGENT_MAX_ITERS`, …).
+- **Modelo POR-AGENTE** (generaliza y subsume el tier env-only de 42.2). Cada `RecursiveAgent` toma su
+  `model` de su config efectiva; el resolver del server (`_resolve_agent_model`) ya no pisa
+  `child.model` con la env global: prioriza override explícito en `agent_config` > `AGENT_LEAF_MODEL`
+  (tier global) > el modelo del propio agente. `AGENT_LEAF_MODEL` queda como default global (su uso
+  efectivo sigue gateado por el hardware — la iGPU 780M no sostiene dos modelos concurrentes).
+- **API y backoffices.** Core: `GET /agents` (y `/agents-meta`) lo incluyen vía `get_catalog`;
+  `PATCH /agents/orchestrator/config` y `/metadata` lo editan (config con allow-list al schema);
+  `/status` y `/proactive` lo rechazan (400); `GET /models` lista los modelos de Ollama. El
+  **backoffice local** lo muestra en `/agents` con badge 🎼 y form de edición (modelo/prompt/guards,
+  `routing_hint_enabled` como checkbox). El **backoffice cloud** lo opera egress-only con el comando
+  tipado `agent.config` (widget `model` poblado por `snapshot.models`); el orquestador y su config
+  viajan en el snapshot (sin secretos).
+
 #### Persistencia de datos (SQLite — FASE 32)
 
 Toda la data del sistema vive en **`~/.local/share/capitan/capitan.db`** (SQLite) vía

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3939,7 +3939,7 @@ Objetivo: Cerrar el refactor del runtime recursivo (FASE 41/42) formalizando al 
           POR-AGENTE (subsume el tier env-only de 42.2); (d) lo expone y edita desde AMBOS
           backoffices (form local + comando tipado cloud egress-only). Mantiene su naturaleza
           especial sin romper la recursión.
-Estado:   EN CURSO (6/7 — Etapas A-D completas (core + UI local + UI cloud); falta sólo docs (43.7)).
+Estado:   COMPLETA (7/7).
 Deps:     FASE 41 (runtime recursivo — RecursiveAgent, build_root_agent, resolver),
           FASE 42 (AGENT_LEAF_MODEL — se subsume en config por-agente),
           FASE 14 (agent_config + edición de agentes desde backoffice — patrón a reusar),
@@ -4008,6 +4008,6 @@ Decisiones tomadas:
             (`test_commands`, `test_bridge`: validación, executor, snapshot valida el contrato).
 
 #### Etapa E - documentación
-- [ ] 43.7  Docs: `arquitectura_funcional.md` (orquestador como agente configurable + modelo
-            por-agente que subsume el tier de 42.2), READMEs (core, cloud, raíz); lint de estado +
-            sync de issues.
+- [x] 43.7  Docs: `arquitectura_funcional.md` (nueva sección "Orquestador como agente de primera
+            clase" + modelo por-agente que subsume el tier de 42.2), READMEs (core: endpoints +
+            `/models`; raíz: párrafo FASE 43; cloud: comando `agent.config`); lint de estado + sync.


### PR DESCRIPTION
FASE 43.7 (#723) — documentación + cierre de FASE 43.

- `masterplan/arquitectura_funcional.md`: nueva sección **"Orquestador como agente de primera clase"** (catálogo vía `get_catalog`, config en `agent_config`, modelo por-agente que subsume el tier de 42.2, API + ambos backoffices).
- README raíz: párrafo de FASE 43 en la sección del runtime recursivo.
- `cloud/README.md`: comando `agent.config` + badge del orquestador.
- Bump submodule `core` (core/README: endpoints del orquestador + `/models`, PR core #239).
- `estado.md`: 43.7 `[x]`, **FASE 43 COMPLETA (7/7)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)