### PR TITLE
fix: deploy.cloud pinea el umbrella a origin/main antes de buildear

### DIFF
--- a/cloud/bridge/deploy_engine.py
+++ b/cloud/bridge/deploy_engine.py
@@ -492,22 +492,40 @@ TARGETS: list[Target] = [
 ]
 
 
-def run_cloud_release(targets: list[str], emit: Optional[LogEmit] = None) -> ReleaseResult:
+def run_cloud_release(targets: list[str], emit: Optional[LogEmit] = None,
+                      repo_refs: Optional[dict[str, Optional[str]]] = None) -> ReleaseResult:
     """Despliega targets de Cloud Run (cloud-bo, …) por-target con health-gate y rollback a la
     revisión previa si falla. Atomicidad por-target (D7). Reusa ReleaseResult (campo `services`)."""
     result = ReleaseResult(ok=True)
     state = load_state()
+    repo_refs = repo_refs or {}
 
     def _emit(line: str) -> None:
         result.log.append(line)
         if emit:
             emit(line)
 
+    # PIN del repo fuente (umbrella) a origin/main ANTES de buildear. Sin esto, `gcloud run deploy
+    # --source` buildeaba el checkout SIN actualizar → redeployaba el HEAD viejo y la versión nunca
+    # avanzaba (a diferencia de run_release, que pinea cada repo). Una vez por repo fuente.
+    pinned: dict[str, bool] = {}
+    for name in targets:
+        t = CLOUDRUN_TARGETS.get(name)
+        if t and t.source_repo in REPOS and t.source_repo not in pinned:
+            r = t.source_repo
+            _emit(f"--- pin {r}: → {repo_refs.get(r) or 'origin/main'}")
+            pinned[r] = REPOS[r].pin(repo_refs.get(r), _emit)
+
     for name in targets:
         if name not in CLOUDRUN_TARGETS:
             raise ValueError(f"target cloudrun desconocido: {name!r} (conocidos: {sorted(CLOUDRUN_TARGETS)})")
         t = CLOUDRUN_TARGETS[name]
-        # sha del repo fuente (umbrella) en el checkout que se buildea → versión que correrá el target.
+        if t.source_repo in REPOS and not pinned.get(t.source_repo, True):
+            result.ok = False
+            result.services[name] = {"ok": False, "error": f"pin de {t.source_repo} falló"}
+            _emit(f"  ✗ pin de {t.source_repo} falló — no se despliega {name}")
+            continue
+        # sha del repo fuente (umbrella) en el checkout YA pineado → versión que correrá el target.
         src_sha = REPOS[t.source_repo].head(_emit) if t.source_repo in REPOS else None
         prev = t.active_revision(_emit)
         _emit(f"=== deploy cloudrun {name} ({t.service}) — revisión previa {prev or '?'} ===")

--- a/cloud/bridge/test_deploy_engine.py
+++ b/cloud/bridge/test_deploy_engine.py
@@ -333,6 +333,29 @@ def test_cloud_release_health_fail_rollback(state_tmp, monkeypatch):
     assert de.load_state().get("cloud", {}).get("cloud-bo", {}).get("ok") is False
 
 
+def test_cloud_release_pins_source_before_build(state_tmp, monkeypatch):
+    # Regresión: cloud-bo buildeaba el checkout SIN pinear → redeployaba el HEAD viejo y la
+    # versión nunca avanzaba. Ahora el repo fuente se fetchea+pinea a origin/main ANTES del build.
+    fake = _FakeGcloud(revision="capitan-cloud-00010")
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    de.run_cloud_release(["cloud-bo"])
+    assert fake.did("fetch", "origin")
+    assert fake.did("checkout", "origin/main")
+    idx_pin = next(i for i, c in enumerate(fake.calls) if "checkout" in " ".join(c))
+    idx_deploy = next(i for i, c in enumerate(fake.calls) if "deploy" in c and "--source" in " ".join(c))
+    assert idx_pin < idx_deploy   # el pin ocurre antes del build
+
+
+def test_cloud_release_pin_fail_skips_deploy(state_tmp, monkeypatch):
+    fake = _FakeGcloud(fail=("fetch",))   # el fetch del pin falla
+    monkeypatch.setattr(de, "_run", fake)
+    monkeypatch.setattr(de, "_http_ok", lambda *a, **k: True)
+    res = de.run_cloud_release(["cloud-bo"])
+    assert res.ok is False
+    assert not fake.did("run", "deploy", "--source")   # no buildeó con el repo sin actualizar
+
+
 def test_cloud_release_unknown_target(state_tmp):
     import pytest
     with pytest.raises(ValueError):


### PR DESCRIPTION
**Bug:** tocar "Actualizar" en la fila de cloud-bo corría `deploy.cloud` y reportaba `🟢 done`, pero la versión no avanzaba ("todo sigue igual"). El log mostraba el build desde `5c49a34` (HEAD viejo del checkout del Brain).

**Causa:** `run_cloud_release` leía `REPOS["umbrella"].head()` y `gcloud run deploy --source <umbrella>/cloud` buildeaba el checkout **sin actualizarlo**. A diferencia de `run_release` (core/services), que pinea cada repo a `origin/main` con `Repo.pin` (fetch + checkout), el path cloudrun no pineaba nada → redeployaba el mismo commit viejo y la versión registrada nunca cambiaba.

**Fix:** `run_cloud_release` pinea el repo fuente (umbrella) a `origin/main` (o al ref pedido) **antes** del build; si el pin falla, no despliega ese target. Mismo mecanismo que `run_release`.

Tests: pin (fetch+checkout) ocurre antes del `deploy --source`; pin fallido salta el build. Suite cloud: 162 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)