### PR TITLE
fix: matriz de deploy — behind compara la versión mostrada, no el sha de main

### DIFF
--- a/cloud/bridge/snapshot.py
+++ b/cloud/bridge/snapshot.py
@@ -252,15 +252,19 @@ def _versions(nodes: list[dict]) -> dict:
             if t.kind == "cloudrun":
                 cs = cloud_state.get(t.id, {})
                 run_ver, run_url = cs.get("tag") or cs.get("version"), cs.get("url")
-                run_sha = cs.get("version")
             else:
-                run_ver, run_url, run_sha = ri.get("tag") or ri.get("sha"), ri.get("url"), ri.get("sha")
+                run_ver, run_url = ri.get("tag") or ri.get("sha"), ri.get("url")
+            latest_ver = ri.get("latest_tag") or ri.get("latest_sha")
             out["targets"].append({
                 "id": t.id, "label": t.label, "where": t.where, "kind": t.kind,
                 "advanced": t.advanced,
                 "version": run_ver, "url": run_url,
-                "latest": ri.get("latest_tag") or ri.get("latest_sha"), "latest_url": ri.get("latest_url"),
-                "behind": bool(run_sha and ri.get("latest_sha") and run_sha != ri["latest_sha"]),
+                "latest": latest_ver, "latest_url": ri.get("latest_url"),
+                # `behind` compara EXACTAMENTE lo que se muestra (tag vs tag, o sha vs sha si no hay
+                # tag) — no el tag visible contra el sha de origin/main. Si no, un target tagueado a
+                # la última release pero con main adelantado sin nuevo tag mostraba "misma versión +
+                # rezagado".
+                "behind": bool(run_ver and latest_ver and run_ver != latest_ver),
                 "command": t.command, "params": t.params,
             })
     except Exception:

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -404,6 +404,40 @@ def test_snapshot_versions_panels_y_ser9():
     assert any(t["id"] == "core" and t["kind"] == "service" for t in v["targets"])
 
 
+def test_snapshot_versions_service_behind_compares_displayed_version():
+    """Un service tagueado a la última release NO está rezagado aunque origin/main haya avanzado
+    sin nuevo tag: `behind` compara lo que se muestra (tag vs tag), no el tag contra el sha de
+    origin/main. Repro del bug 'misma versión + ⬆ rezagado'."""
+    def fake_get(url, timeout=4):
+        if url.endswith("/satellite/version"):
+            return {"version": "abc123def456"}
+        if url.endswith("/nodes"):
+            return []
+        if url.endswith("/health"):
+            return {"status": "ok", "nodes": 0}
+        return None
+
+    # tag corriendo == último tag, pero el sha de origin/main difiere (main avanzó sin release)
+    at_latest = {"sha": "aaaaaa", "tag": "v0.1.7", "url": "u",
+                 "latest_sha": "bbbbbb", "latest_tag": "v0.1.7", "latest_url": "lu"}
+    behind = {"sha": "aaaaaa", "tag": "v0.1.7", "url": "u",
+              "latest_sha": "bbbbbb", "latest_tag": "v0.1.8", "latest_url": "lu"}
+
+    def run(repo_info):
+        with patch.object(snapshot, "_get", fake_get), \
+             patch.object(snapshot, "_systemctl_active", lambda u: True), \
+             patch.object(snapshot, "_maybe_fetch", lambda *a, **k: None), \
+             patch.object(snapshot, "_repo_git_info", lambda de, repo: repo_info):
+            snap = snapshot.build_snapshot()
+        return {t["id"]: t for t in snap["versions"]["targets"]}
+
+    core = run(at_latest)["core"]
+    assert core["version"] == core["latest"] == "v0.1.7"
+    assert core["behind"] is False                       # mismo tag → al día
+
+    assert run(behind)["core"]["behind"] is True          # tag distinto → rezagado
+
+
 # ── FASE 38: panel.config (executor + snapshot) ───────────────────────────────
 
 def test_executor_panel_config_upserts_core_and_flags_audio():


### PR DESCRIPTION
## Problema

El panel de deploy (cloud-bo y backoffice local) mostraba filas incoherentes: misma versión en *Corre* y *Disponible* pero estado `⬆ rezagado`/`⬆ actualizar`.

```
core    Brain  v0.1.7   v0.1.7   ⬆ rezagado   ← incoherente
audio_server  Brain  v0.1.7  v0.1.7  🟢 al día  ← correcto
backoffice    Brain  v0.1.11  v0.1.11  ⬆ rezagado  ← incoherente
```

## Causa

`cloud/bridge/snapshot.py:_versions()` mostraba el **tag** (`latest_tag`) en *Disponible* pero calculaba `behind` comparando **shas**: `run_sha` (HEAD local) vs `latest_sha` (origin/main). Cuando main avanzaba con commits sin un nuevo tag de release, el tag mostrado coincidía pero los shas diferían → 'misma versión + rezagado'. audio_server (repo ear) tenía origin/main en el commit tagueado, por eso coincidía; los satélites ya comparaban md5 de forma consistente.

## Fix

`behind` compara exactamente lo que se muestra (tag vs tag, o sha vs sha como fallback), coherente con el modelo de releases tagueadas. Test de regresión en `test_bridge.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)