### PR TITLE
chore: fase 36.9 — submodule pointer + estado

### DIFF
--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3358,8 +3358,9 @@ Objetivo: Una capa de conversación como COLUMNA VERTEBRAL de la continuidad, ch
           contexto y rutee al agente dueño; (c) identificar al usuario una vez por sesión
           (no por conversación); (d) dar a cada agente un contexto consistente (user_context
           por-agente + historial reciente). Reemplaza y expande el épico 18.16 (#532).
-Estado:   EN CURSO (7/11 — Etapa A completa: 36.1, 36.2, 36.3; Etapa B: 36.4, 36.5 listas,
-          falta 36.6 deploy+e2e contra NSPanel físico; Etapa C completa: 36.7, 36.8).
+Estado:   EN CURSO (8/11 — Etapa A completa: 36.1, 36.2, 36.3; Etapa B: 36.4, 36.5 listas,
+          falta 36.6 deploy+e2e contra NSPanel físico; Etapa C completa: 36.7, 36.8;
+          Etapa D completa: 36.9).
 Deps:     conversations.py (FASE 9/22), intent_state + proactivo (FASE 22/27), 19.4 (ruteo WA
           por intent_id — base del frente proactivo), FASE 16 (audio_server/satellite), FASE 35
           (métricas, para 36.10).
@@ -3422,9 +3423,14 @@ Modelo conceptual (decisiones de diseño):
             Tests (test_proactive_turns.py, incl. cruce e2e wa_inbound→process→owner).
 
 #### Etapa D - Identidad y saludo (core)
-- [ ] 36.9  Saludo por sesión: `greeted_at` por usuario/canal; saludar 1x por sesión
+- [x] 36.9  Saludo por sesión: `greeted_at` por usuario/canal; saludar 1x por sesión
             señalando reconocimiento del usuario (no en cada conversación nueva). Cooldown
-            configurable. Reemplaza el saludo por-conversación actual. Tests.
+            configurable. Reemplaza el saludo por-conversación actual. `greeting.py`
+            (should_greet/mark_greeted/maybe_prepend); `greeted_at` por canal en
+            `user.preferences`; cooldown `GREETING_COOLDOWN_SECS` (default 6h) + override por
+            canal. Centralizado en `_maybe_prepend_greeting`, aplicado a los tres paths
+            (recursivo —antes NO saludaba—, fallback FASE 40, stream). Invitados no se saludan.
+            PR core #242. Tests (test_greeting.py + test_recursive_hotpath.py).
 
 #### Etapa E - Observabilidad y documentación
 - [ ] 36.10 Métricas de continuidad (turnos por conversación, % de exchanges multi-turno,


### PR DESCRIPTION
Actualiza el pointer de `core` a la 36.9 (PR core #242) y marca la tarea completa en `masterplan/estado.md` (FASE 36 → 8/11, Etapa D completa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)