### PR TITLE
fase 36.10 — dashboards de continuidad + bump core

### DIFF
--- a/backoffice/templates/metrics.html
+++ b/backoffice/templates/metrics.html
@@ -25,6 +25,7 @@
 <div class="flex gap-2 mb-5 border-b border-gray-800">
   <button data-tab="voz" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-emerald-500 text-white">🎙️ Voz</button>
   <button data-tab="llm" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-400 hover:text-white">🤖 LLM / Agentes</button>
+  <button data-tab="continuidad" class="tab-btn px-4 py-2 text-sm font-medium border-b-2 border-transparent text-gray-400 hover:text-white">⤴️ Continuidad</button>
 </div>
 
 <!-- ── Sección VOZ ──────────────────────────────────────────────────────────── -->
@@ -107,6 +108,15 @@
   </div>
 </section>
 
+<section data-panel="continuidad" class="hidden">
+  <div id="cont-cards" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6"></div>
+
+  <div class="bg-gray-900 border border-gray-800 rounded-xl p-4">
+    <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Conversaciones, requests y turnos/conv promedio</div>
+    <canvas id="cont-chart" height="90"></canvas>
+  </div>
+</section>
+
 <script>
 const $ = (id) => document.getElementById(id);
 const fmtNum = (v) => v == null ? "—" : (typeof v === "number" ? v.toLocaleString("es") : v);
@@ -161,6 +171,7 @@ const vozChart = mkChart("voz-chart", "bar");
 const wwChart = mkChart("ww-chart", "line");
 const confChart = mkChart("conf-chart", "line");
 const llmChart = mkChart("llm-chart", "line");
+const contChart = mkChart("cont-chart", "line");
 
 function applySeries(chart, payload, colorOffset) {
   chart.data.labels = (payload.labels || []).map(fmtLabel);
@@ -264,10 +275,28 @@ function bucketFor() {
   return 86400;                      // 1 d
 }
 
+async function loadContinuidad() {
+  const [sum, series] = await Promise.all([
+    getJSON("/api/metrics/continuity/summary?" + qs()),
+    getJSON("/api/metrics/continuity/series?" + qs({bucket: bucketFor()})),
+  ]);
+  $("cont-cards").innerHTML =
+    card("Conversaciones", fmtNum(sum.conversations)) +
+    card("Turnos/conv prom", sum.avg_turns_per_conv == null ? "—" : sum.avg_turns_per_conv.toFixed(2)) +
+    card("Multi-turno", fmtPct(sum.multi_turn_pct), fmtNum(sum.multi_turn_conversations) + " convs") +
+    card("Repreguntas sost.", fmtPct(sum.sustained_pct), fmtNum(sum.sustained_conversations) + " convs") +
+    card("Replies a proact.", fmtNum(sum.proactive_replies), "rate " + fmtPct(sum.proactive_reply_rate)) +
+    card("Requests pendientes", fmtNum(sum.pending_requests));
+  applySeries(contChart, series, 1);
+}
+
 let activeTab = "voz";
 async function reload() {
-  try { activeTab === "voz" ? await loadVoz() : await loadLLM(); }
-  catch (e) { console.error(e); }
+  try {
+    if (activeTab === "voz") await loadVoz();
+    else if (activeTab === "llm") await loadLLM();
+    else await loadContinuidad();
+  } catch (e) { console.error(e); }
 }
 
 // Tabs

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -132,6 +132,8 @@ class MetricsSnapshot(BaseModel):
     llm_by_model: list[dict[str, Any]] = Field(default_factory=list)
     llm_by_agent: list[dict[str, Any]] = Field(default_factory=list)
     llm_series: dict[str, Any] = Field(default_factory=dict)
+    continuity_summary: dict[str, Any] = Field(default_factory=dict)  # FASE 36.10
+    continuity_series: dict[str, Any] = Field(default_factory=dict)   # FASE 36.10
 
 
 class CommandRequest(BaseModel):

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -82,6 +82,9 @@
               <table id="m-models"><thead><tr><th>modelo</th><th>llamadas</th><th>lat ms</th><th>tokens</th></tr></thead><tbody></tbody></table>
               <table id="m-agents"><thead><tr><th>agente</th><th>steps</th><th>aciertos</th><th>lat ms</th></tr></thead><tbody></tbody></table>
             </div>
+            <h3>Continuidad</h3>
+            <div id="m-cont-summary" class="grid"></div>
+            <canvas id="m-cont-chart" height="80"></canvas>
           </div>
         </div>
       </section>
@@ -590,7 +593,7 @@ async function refresh() {
 }
 
 // ── Métricas (FASE 35.6) ──────────────────────────────────────────────────────
-let mVoiceChart = null, mLlmChart = null, mConfChart = null, mWwChart = null;
+let mVoiceChart = null, mLlmChart = null, mConfChart = null, mWwChart = null, mContChart = null;
 const mLabel = (ts) => new Date(ts * 1000).toLocaleString("es", {day:"2-digit",month:"2-digit",hour:"2-digit",minute:"2-digit"});
 
 function mkMetricChart(canvasId, type) {
@@ -668,6 +671,19 @@ async function loadMetrics() {
     const thr = (vs.speaker_threshold != null) ? vs.speaker_threshold : null;
     $("m-conf-thr").textContent = thr != null ? `· threshold ${thr}` : "";
   }
+
+  // Continuidad conversacional (FASE 36.10): turnos/conv, % multi-turno, repreguntas
+  // sostenidas y replies a proactivos.
+  const cont = metrics.continuity_summary || {};
+  $("m-cont-summary").innerHTML =
+    `<div><b>${mFmt(cont.conversations)}</b> convs</div>` +
+    `<div><b>${cont.avg_turns_per_conv ?? "—"}</b> turnos/conv</div>` +
+    `<div><b>${mPct(cont.multi_turn_pct)}</b> multi-turno</div>` +
+    `<div><b>${mPct(cont.sustained_pct)}</b> repreguntas sost.</div>` +
+    `<div title="pendientes ${mFmt(cont.pending_requests)} · tasa ${mPct(cont.proactive_reply_rate)}">` +
+    `<b>${mFmt(cont.proactive_replies)}</b> replies a proact.</div>`;
+  if (!mContChart) mContChart = mkMetricChart("m-cont-chart", "line");
+  setSeries(mContChart, metrics.continuity_series || {}, ["#a78bfa", "#60a5fa", "#34d399"]);
 
   // Tablas de detalle (sólo presentes para roles con view_full)
   const models = metrics.llm_by_model || [], agents = metrics.llm_by_agent || [];

--- a/cloud/bridge/metrics_snapshot.py
+++ b/cloud/bridge/metrics_snapshot.py
@@ -48,4 +48,6 @@ def build_metrics_snapshot(hours: int = WINDOW_HOURS) -> dict:
         "llm_by_model":  (_get(f"{base}/llm/by-model?{q}") or {}).get("models", []),
         "llm_by_agent":  (_get(f"{base}/llm/by-agent?{q}") or {}).get("agents", []),
         "llm_series":    _get(f"{base}/llm/series?{qs}") or {},
+        "continuity_summary": _get(f"{base}/continuity/summary?{q}") or {},   # FASE 36.10
+        "continuity_series":  _get(f"{base}/continuity/series?{qs}") or {},    # FASE 36.10
     }

--- a/cloud/bridge/test_bridge.py
+++ b/cloud/bridge/test_bridge.py
@@ -149,6 +149,18 @@ def test_metrics_snapshot_unwraps_list_envelopes():
     assert snap["voice_series"]["labels"] == [1, 2]
 
 
+def test_metrics_snapshot_emits_continuity():  # FASE 36.10
+    def fake_get(url, **k):
+        if "continuity/summary" in url: return {"conversations": 4, "avg_turns_per_conv": 1.5,
+                                                "multi_turn_pct": 0.5, "proactive_replies": 1}
+        if "continuity/series" in url:  return {"labels": [1], "series": []}
+        return None
+    with patch.object(metrics_snapshot, "_get", fake_get):
+        snap = metrics_snapshot.build_metrics_snapshot()
+    assert snap["continuity_summary"]["conversations"] == 4
+    assert snap["continuity_series"]["labels"] == [1]
+
+
 # ── deploy.run / deploy.release invocan el motor único (FASE 34) ───────────────
 
 def test_deploy_run_invokes_engine(monkeypatch):

--- a/cloud/tests/test_metrics_contract.py
+++ b/cloud/tests/test_metrics_contract.py
@@ -28,6 +28,20 @@ def test_metrics_snapshot_carries_voice_conf_series():
     assert snap.voice_conf_series["series"][0]["name"] == "known_conf"
 
 
+def test_metrics_snapshot_carries_continuity():  # FASE 36.10
+    snap = MetricsSnapshot(ts="2026-06-24T00:00:00Z",
+        continuity_summary={"conversations": 3, "avg_turns_per_conv": 2.0,
+                            "multi_turn_pct": 0.66, "proactive_replies": 2},
+        continuity_series={"labels": [1, 2], "series": [{"name": "avg_turns", "data": [2.0, 1.5]}]})
+    assert snap.continuity_summary["conversations"] == 3
+    assert snap.continuity_series["series"][0]["name"] == "avg_turns"
+
+
+def test_minimal_snapshot_continuity_defaults_empty():  # FASE 36.10
+    d = MetricsSnapshot(ts="2026-06-24T00:00:00Z").model_dump()
+    assert d["continuity_summary"] == {} and d["continuity_series"] == {}
+
+
 def test_ts_required():
     with pytest.raises(Exception):
         MetricsSnapshot()

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3358,9 +3358,9 @@ Objetivo: Una capa de conversación como COLUMNA VERTEBRAL de la continuidad, ch
           contexto y rutee al agente dueño; (c) identificar al usuario una vez por sesión
           (no por conversación); (d) dar a cada agente un contexto consistente (user_context
           por-agente + historial reciente). Reemplaza y expande el épico 18.16 (#532).
-Estado:   EN CURSO (8/11 — Etapa A completa: 36.1, 36.2, 36.3; Etapa B: 36.4, 36.5 listas,
+Estado:   EN CURSO (9/11 — Etapa A completa: 36.1, 36.2, 36.3; Etapa B: 36.4, 36.5 listas,
           falta 36.6 deploy+e2e contra NSPanel físico; Etapa C completa: 36.7, 36.8;
-          Etapa D completa: 36.9).
+          Etapa D completa: 36.9; Etapa E: 36.10 lista, falta 36.11 docs+e2e).
 Deps:     conversations.py (FASE 9/22), intent_state + proactivo (FASE 22/27), 19.4 (ruteo WA
           por intent_id — base del frente proactivo), FASE 16 (audio_server/satellite), FASE 35
           (métricas, para 36.10).
@@ -3433,8 +3433,13 @@ Modelo conceptual (decisiones de diseño):
             PR core #242. Tests (test_greeting.py + test_recursive_hotpath.py).
 
 #### Etapa E - Observabilidad y documentación
-- [ ] 36.10 Métricas de continuidad (turnos por conversación, % de exchanges multi-turno,
+- [x] 36.10 Métricas de continuidad (turnos por conversación, % de exchanges multi-turno,
             repreguntas sostenidas, replies a proactivos) integradas a los dashboards de FASE 35.
+            core: `metrics_store.continuity_aggregates/series` (desde request_metrics por conv_id)
+            + `intent_state.proactive_reply_stats` + endpoints `/metrics/continuity/{summary,series}`
+            (PR core #243). dashboards: tab "Continuidad" en el backoffice local (`metrics.html`) y
+            sección en el cloud (`dashboard.html`), alimentada por el push del bridge
+            (`metrics_snapshot` + `MetricsSnapshot`). Tests core + cloud (contract + bridge).
 - [ ] 36.11 Tests e2e cross-canal (voz y WA) del ciclo completo + docs: sección "continuidad
             conversacional" en `masterplan/arquitectura_funcional.md` y `README`.
 


### PR DESCRIPTION
## FASE 36.10 (umbrella) — Dashboards de continuidad

Bump del submodule `core` a la 36.10 (endpoints `/metrics/continuity/{summary,series}`, PR core #243) + integración en ambos dashboards de FASE 35:

- **Backoffice local** (`backoffice/templates/metrics.html`): nueva pestaña **Continuidad** con cards (conversaciones, turnos/conv, % multi-turno, % repreguntas sostenidas, replies a proactivos + pendientes) y serie temporal. El proxy `/api/metrics/{path}` ya forwardea genéricamente.
- **Cloud** (`cloud/app/templates/dashboard.html`): sección **Continuidad** en métricas, alimentada por el push egress-only del bridge.
- **Bridge** (`cloud/bridge/metrics_snapshot.py`): agrega `continuity_summary`/`continuity_series` al snapshot.
- **Modelo cloud** (`cloud/app/models.py`): campos `continuity_summary`/`continuity_series` en `MetricsSnapshot` (aditivos, `schema_version` sin cambios; `filter_metrics` los deja pasar a todos los roles por ser agregados).

## Tests
- `cloud/tests/test_metrics_contract.py`: el snapshot transporta continuidad / defaults vacíos.
- `cloud/bridge/test_bridge.py`: el snapshot emite los campos de continuidad.
- Suites: bridge 35, cloud contract+api 15, core 885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)