### PR TITLE
fase 36.11 — FASE 36 COMPLETA + docs continuidad + bump core

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ by `GET /models` via the snapshot).
 
 ---
 
+## Conversation continuity (Phase 36)
+
+Continuity is unified across channels rather than patched per channel. A `Conversation`
+(`core/conversations.py`) is channel-aware: the inactivity TTL is per channel (voice ~120s,
+WhatsApp 6h), and `ContinuationState` models "awaiting the user's reply" (`clarification` /
+`field` / `reply`) as one persisted state exposed on every response.
+
+- **WhatsApp resumes by recency** — a new inbound message reopens the sender's latest vigent
+  conversation instead of starting a fresh one on a time gap.
+- **Proactive notifications are turns** — delivering an advise/goal/request seeds an `assistant`
+  turn tied to its `intent_id`; the user's reply (quoted or by recency) lands in that conversation
+  and routes to the owner agent.
+- **The greeting is per session** — the recognition greeting (`greeting.py`) is prepended once
+  per user/channel session (`greeted_at` + cooldown), not on every conversation.
+- **Multi-turn history reaches the LLM** — the recursive hot-path records each turn so
+  `conv.context()` carries the prior turns to the model on the next request.
+- **Continuity metrics** (turns/conv, multi-turn %, sustained follow-ups, proactive replies) are
+  exposed at `GET /metrics/continuity/*` and charted in both backoffices.
+
+The full cross-channel cycle is covered e2e in `core/tests/test_continuity_e2e.py`; only the
+on-device voice verification with the physical NSPanel remains (36.6).
+
+---
+
 ## Observability (Phase 35)
 
 Voice and LLM metrics are centralized in SQLite by `core/metrics_store.py`, separate from

--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -605,10 +605,40 @@ usuario/asistente al LLM.
   (anti-alucinación) pero el voice-id reconoce al hablante, el server NO calla: sintetiza
   "no te entendí, repetí" con `needs_reply` (reabre el mic). Voz guest con STT dudoso →
   204 mudo + hard negative (probable TV). `_transcribe` devuelve `(texto, motivo)`.
+- **Reanudación asíncrona en WhatsApp (36.7):** un mensaje entrante sin `conversation_id`
+  explícito (no es un quoted-reply) reanuda la última conversación vigente del remitente vía
+  `resume_latest(source)` —revive incluso conversaciones marcadas `expired` mientras sigan
+  dentro del TTL del canal (6h)—, en vez de abrir una nueva por gap temporal. Conversaciones
+  cerradas o fuera de TTL arrancan frescas; el `conversation_id` explícito tiene precedencia.
+- **Proactivos como turnos (36.8):** al entregar una notificación proactiva (request/advise/
+  goal) por WhatsApp se siembra un turno `assistant` en la conversación canónica del usuario,
+  con meta `{intent_id, agent_id, proactive}` (`_register_proactive_turn`). Para un `request`
+  además se sella el `conversation_id` del intent y se deja la conversación esperando el reply
+  (`kind="reply"`). Así un reply —quoted (19.4) o por recencia (36.7)— cae en ese hilo, con la
+  pregunta como contexto, y el orquestador lo captura y rutea al **agente dueño** del intent.
+  El `advise` siembra el turno y sella el `conversation_id` pero no fuerza `kind="reply"` (no
+  debe secuestrar el próximo comando); el `goal` sólo siembra el turno.
+- **Saludo por sesión (36.9):** el saludo señala el **reconocimiento** del usuario, no el
+  inicio de una conversación. `greeting.py` guarda `greeted_at` por canal en
+  `user.preferences` y respeta un cooldown configurable (`GREETING_COOLDOWN_SECS`, default 6h,
+  override por canal). Se antepone 1x por usuario/canal por sesión (`_maybe_prepend_greeting`,
+  aplicado a los tres paths: recursivo, fallback, stream). Los invitados no se saludan.
+- **Historial multi-turno en el hot-path (36.11):** el runtime recursivo LEE `conv.context()`
+  para armar los `messages` del LLM (`agent_runtime._build_messages`); ahora también ESCRIBE
+  el turno (`conv.add("user"/"assistant", ...)`) al cerrar cada request en `_process_recursive`
+  —antes sólo lo hacía el fallback FASE 40—, así el historial llega efectivamente al LLM en el
+  turno siguiente. `ignore` (respuesta vacía) no deja turno; el saludo no se persiste (es
+  presentación). Los proactivos (36.8) ya sembraban su turno aparte.
+- **Observabilidad de continuidad (36.10):** `metrics_store.continuity_aggregates/series`
+  derivan de `request_metrics` agrupando por `conv_id` (turnos/conv, % multi-turno ≥2 requests,
+  % repreguntas sostenidas ≥3) e `intent_state.proactive_reply_stats` cuenta los replies a
+  proactivos vs. pendientes/vencidos. Expuesto en `GET /metrics/continuity/{summary,series}` y
+  reflejado en el tab "Continuidad" de ambos backoffices (local y cloud vía push del bridge).
 
-> Fronteras de continuidad pendientes (FASE 36): deploy + verificación e2e en paneles (36.6),
-> proactivos como turnos + reanudar conversación en WhatsApp (etapa C), saludo por sesión
-> (etapa D). La sección se consolida en 36.11.
+> El ciclo se valida e2e cross-canal en `tests/test_continuity_e2e.py` (voz: saludo por sesión
+> + multi-turno; WhatsApp: cruce proactivo→reply por recencia ruteado al dueño; canales como
+> sesiones independientes). Pendiente sólo la verificación e2e en hardware con el NSPanel físico
+> (36.6 — deploy + repregunta de voz sin re-wake).
 
 ---
 

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -3358,9 +3358,10 @@ Objetivo: Una capa de conversación como COLUMNA VERTEBRAL de la continuidad, ch
           contexto y rutee al agente dueño; (c) identificar al usuario una vez por sesión
           (no por conversación); (d) dar a cada agente un contexto consistente (user_context
           por-agente + historial reciente). Reemplaza y expande el épico 18.16 (#532).
-Estado:   EN CURSO (9/11 — Etapa A completa: 36.1, 36.2, 36.3; Etapa B: 36.4, 36.5 listas,
-          falta 36.6 deploy+e2e contra NSPanel físico; Etapa C completa: 36.7, 36.8;
-          Etapa D completa: 36.9; Etapa E: 36.10 lista, falta 36.11 docs+e2e).
+Estado:   COMPLETA (10/11 — 36.6 postergada: deploy + verificación e2e contra NSPanel físico,
+          es hardware, no código). Etapa A: 36.1-36.3; Etapa B: 36.4, 36.5; Etapa C: 36.7, 36.8;
+          Etapa D: 36.9; Etapa E: 36.10, 36.11. El e2e cross-canal destapó y corrigió que el
+          hot-path recursivo no persistía turnos (el historial multi-turno no llegaba al LLM).
 Deps:     conversations.py (FASE 9/22), intent_state + proactivo (FASE 22/27), 19.4 (ruteo WA
           por intent_id — base del frente proactivo), FASE 16 (audio_server/satellite), FASE 35
           (métricas, para 36.10).
@@ -3440,8 +3441,13 @@ Modelo conceptual (decisiones de diseño):
             (PR core #243). dashboards: tab "Continuidad" en el backoffice local (`metrics.html`) y
             sección en el cloud (`dashboard.html`), alimentada por el push del bridge
             (`metrics_snapshot` + `MetricsSnapshot`). Tests core + cloud (contract + bridge).
-- [ ] 36.11 Tests e2e cross-canal (voz y WA) del ciclo completo + docs: sección "continuidad
+- [x] 36.11 Tests e2e cross-canal (voz y WA) del ciclo completo + docs: sección "continuidad
             conversacional" en `masterplan/arquitectura_funcional.md` y `README`.
+            `tests/test_continuity_e2e.py` (path recursivo: saludo por sesión + multi-turno en voz;
+            canales independientes; cruce proactivo→reply por recencia ruteado al dueño en WA).
+            El e2e destapó que el hot-path recursivo LEÍA pero no ESCRIBÍA turnos → fix en
+            `_process_recursive` (conv.add por request). Docs: sección consolidada en
+            arquitectura_funcional.md + README (raíz + core). PR core #244.
 
 ### FASE 37 - Backoffice cloud completo (paridad de secciones egress-only + sidebar)
 


### PR DESCRIPTION
## FASE 36.11 (umbrella) — cierre de la fase

Bump del submodule `core` a la 36.11 (PR core #244) + documentación consolidada:

- **`masterplan/estado.md`**: 36.11 `[x]`; **FASE 36 → COMPLETA** (10/11; **36.6 postergada** — deploy + verificación e2e contra el NSPanel físico, es hardware, no código).
- **`masterplan/arquitectura_funcional.md`**: sección "Conversaciones y continuidad" consolidada con 36.7 (resume_latest WA), 36.8 (proactivos como turnos), 36.9 (saludo por sesión), 36.10 (métricas) y 36.11 (registro de turnos en el hot-path recursivo).
- **`README.md`** (raíz): nueva sección "Conversation continuity (Phase 36)".

El e2e cross-canal destapó y corrigió que el hot-path recursivo de producción no persistía turnos, así que el historial multi-turno no llegaba al LLM (fix incluido en el PR de core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)