### PR TITLE
chore: fase 45.1 — wake word despierta la pantalla del nodo

### DIFF
--- a/masterplan/arquitectura_funcional.md
+++ b/masterplan/arquitectura_funcional.md
@@ -95,6 +95,16 @@ El form se **prellena con la config REAL del dispositivo** (38.7): el satélite 
 `device_config` y viaja en el snapshot. Ambos backoffices prefieren ese valor (estado real) sobre
 la config guardada en core, así el admin ve lo que efectivamente corre en el panel.
 
+**Despertar la pantalla con la wake word (FASE 45):** complemento del apagado por timeout de la
+FASE 38 — el NSPanel está siempre enchufado y la pantalla se apaga por DPMS, así que al detectar la
+wake word el satélite la despierta para que el overlay del VU-meter sea visible y el panel no parezca
+muerto. Justo tras confirmar la wake word (debounce) y antes de parar el stream, `_wakeup_screen_now`
+consulta el estado real del display (`dumpsys power` → línea `Display Power: state=ON|OFF`) y sólo si
+está apagado manda `su input keyevent KEYCODE_WAKEUP` (activación pura, no el toggle de
+KEYCODE_POWER). Gateado por `WAKEWORD_WAKEUP_SCREEN` (default `true`, emitido en `satellite.env` por
+`nspanel.sh`), toggleable en caliente vía la clave de config remota `wakeup_screen`. Best-effort: si
+`su` falla, no tumba la interacción.
+
 **Ambientes (16.7):** la fuente de verdad de los ambientes son las **áreas de Home Assistant**
 (`ha_client.get_areas()` vía `/api/template`, porque el area registry no está en la REST API de
 estados). El core las expone en `GET /areas` y `GET /rooms` (áreas + augmentación local del

--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -4100,3 +4100,27 @@ Deps:     FASE 41 (runtime recursivo — RecursiveAgent, continuación), FASE 36
             desde el último `retrain_event` persistido (`metrics_store.retrain_history`); el
             `_train_result` in-memory (train en curso/recién hecho) tiene precedencia. Tests
             (rehidrata tras restart, precedencia in-memory, idle si no hay historial). (core)
+
+---
+
+### FASE 45 - Prender la pantalla del nodo al detectar la wake word
+
+```
+Objetivo: Cuando el NSPanel está enchufado y la pantalla se apaga por timeout (FASE 38), detectar
+          la wake word debe despertar la pantalla además de iniciar la conversación, para que el
+          usuario tenga feedback visual (overlay del VU-meter) y vea el dashboard al hablarle al
+          nodo. Hoy `satellite.py` detecta la wake word y arranca la grabación, pero si la pantalla
+          está apagada por DPMS el overlay no se ve y el panel parece muerto.
+Estado:   COMPLETA (1/1).
+Deps:     FASE 16 (satellite.py — loop wake word, `_run_su` root), FASE 38 (screen timeout por panel:
+          `_apply_screen_timeout` ya gestiona el apagado vía `settings put`).
+```
+
+- [x] 45.1  Despertar la pantalla en la detección: en `satellite.py`, justo tras confirmar la wake
+            word (debounce `consecutive >= WAKEWORD_FRAMES_REQ`) y antes de parar el stream, si la
+            pantalla está apagada despertarla con `_run_su("input keyevent KEYCODE_WAKEUP")`. Helper
+            `_is_screen_off()` (parsea `dumpsys power | grep 'Display Power:'` → `state=OFF`) para no
+            mandar el keyevent en vano cuando ya está prendida. Gateado por flag
+            `WAKEWORD_WAKEUP_SCREEN` (default `true`) leído de `satellite.env`; `nspanel.sh` lo emite
+            al generar la config y `_apply_remote_config` lo acepta como key configurable. Tests del
+            parser de `_is_screen_off` (mock de subprocess: ON/OFF/salida vacía). (ear)

--- a/masterplan/issues.yaml
+++ b/masterplan/issues.yaml
@@ -637,6 +637,9 @@
 "44.4":  744
 "44.5":  746
 
+# ── FASE 45 (prender pantalla del nodo al detectar wake word) ────────────────
+"45.1":  749
+
 # ── Anexos (iteraciones futuras) ──────────────────────────────────────────────
 "A.1":   118
 "A.2":   121

--- a/scripts/nspanel.sh
+++ b/scripts/nspanel.sh
@@ -165,6 +165,7 @@ MELSPEC_MODEL=/data/data/com.termux/files/home/wakeword/melspectrogram.onnx
 EMBEDDING_MODEL=/data/data/com.termux/files/home/wakeword/embedding_model.onnx
 WAKEWORD_THRESH=0.8
 WAKEWORD_FRAMES_REQ=2
+WAKEWORD_WAKEUP_SCREEN=true
 COMMAND_SECS=5
 SAMPLE_RATE=16000
 EOF


### PR DESCRIPTION
Cierra la FASE 45 (#749). Bump del submodule `ear` (PR ear #70) + plan/docs.

Al detectar la wake word, si la pantalla del NSPanel está apagada por timeout (FASE 38) se despierta con `su input keyevent KEYCODE_WAKEUP` para que el overlay del VU-meter sea visible.

- `ear` → `_is_screen_off` (dumpsys power) + `_wakeup_screen_now` gateado por `WAKEWORD_WAKEUP_SCREEN`, toggleable vía config remota `wakeup_screen`.
- `nspanel.sh` emite `WAKEWORD_WAKEUP_SCREEN=true` en `satellite.env`.
- `estado.md`: FASE 45 COMPLETA (1/1). `arquitectura_funcional.md`: nueva subsección.

🤖 Generated with [Claude Code](https://claude.com/claude-code)