### PR TITLE
docs: registrar FASE 46 — mejora continua de modelos de voz

### DIFF
--- a/masterplan/estado.md
+++ b/masterplan/estado.md
@@ -4124,3 +4124,60 @@ Deps:     FASE 16 (satellite.py — loop wake word, `_run_su` root), FASE 38 (sc
             `WAKEWORD_WAKEUP_SCREEN` (default `true`) leído de `satellite.env`; `nspanel.sh` lo emite
             al generar la config y `_apply_remote_config` lo acepta como key configurable. Tests del
             parser de `_is_screen_off` (mock de subprocess: ON/OFF/salida vacía). (ear)
+
+---
+
+### FASE 46 - Mejora continua de los modelos de voz (auto-captura + retrain por umbral)
+
+```
+Objetivo: Cerrar el loop de mejora continua de wake word y voice-id. Hoy los negativos de wake word
+          se capturan solos en runtime, pero los positivos y TODO el reentrenamiento son manuales, y
+          el voice-id no acumula ni recalcula nada. Ante cada match CONFIABLE (wake word y voice-id),
+          acumular el audio como muestra del caso correspondiente; disparar el reentrenamiento del
+          modelo respectivo al superar un umbral de muestras nuevas (con cooldown anti-storm),
+          congruente con la captura de falsos positivos ya existente. Reflejar las métricas de
+          reentrenamiento de AMBOS modelos en los DOS backoffices (local y cloud).
+Estado:   Pendiente (0/7).
+Deps:     FASE 16 (audio_server: voice-id, captura de negativos de wake word, /process-audio),
+          FASE 35 (metrics_store: retrain_events, ww_scores, voice_metrics; dashboards web /metrics),
+          FASE 33 (backoffice cloud + egress POST /ingest/metrics).
+Decisiones:
+  - Trigger de retrain: por UMBRAL de muestras nuevas desde el último train + COOLDOWN (intervalo
+    mínimo). Reactivo al uso real, sin scheduler temporal por ahora.
+  - Anti-poisoning: solo se acumulan matches de ALTA confianza (no apenas sobre el umbral); FIFO/cap
+    por nodo/usuario; el enrolado manual queda como ancla y los WAV crudos se conservan para
+    RECOMPUTAR (no promediar en caliente, que derivaría el centroide).
+  - Negativos de voice-id (cross-user): el encoder (resemblyzer GE2E) está congelado — no se
+    "reentrena" con negativos. En su lugar, los positivos acumulados de CADA usuario son los
+    negativos (impostores) de los demás. Esos pares genuino-vs-impostor calibran el threshold; no
+    se suman al embedding del usuario.
+```
+
+- [ ] 46.1  Auto-captura de positivos de wake word en TP confirmado: en `audio_server` (`/process-audio`),
+            tras un match confiable (known speaker + STT con texto válido), guardar el clip que disparó
+            la wake word como sample positivo del usuario (vía `/users/{uid}/wakeword/samples` →
+            `wakeword_samples`). Flag `CAPTURE_POSITIVES` (default true), simétrico a `CAPTURE_NEGATIVES`;
+            FIFO/cap y metadata de provenance (node_id, ts, score, speaker_conf). Tests. (ear)
+- [ ] 46.2  Retrain automático de wake word por umbral + cooldown: monitor periódico en core que dispara
+            `/wakeword/train` cuando hay ≥N positivos/negativos nuevos desde el último `retrain_event`,
+            respetando un intervalo mínimo (cooldown). Registrar el `trigger` real (`fp_threshold`/`auto`)
+            en `retrain_events` (hoy sólo `manual`). Tests del gate (umbral, cooldown, no re-disparo). (core)
+- [ ] 46.3  Auto-captura de muestras de voz en matches de alta confianza: en `/process-audio`, cuando
+            `speaker != guest` y `speaker_conf` supera un MARGEN sobre `SPEAKER_THRESHOLD`, guardar el WAV
+            crudo en un store por-usuario (`~/.local/share/capitan/voice-history/<uid>/`), con cap FIFO y
+            metadata. NO promediar en caliente. Flag `CAPTURE_VOICEID_POSITIVES`. Tests. (ear)
+- [ ] 46.4  Re-cálculo del embedding por umbral + cooldown: cuando un usuario acumula ≥M muestras nuevas
+            de alta confianza, RECOMPUTAR su embedding desde los WAV crudos (enrolado manual como ancla),
+            no por promedio ciego. Endpoint análogo a `/wakeword/train` (`/users/{uid}/voiceid/retrain`).
+            Registrar el evento de retrain. Tests (recompute determinista, cooldown, ancla preservada). (ear)
+- [ ] 46.5  Negativos cross-user + calibración del threshold de voice-id: usar los positivos acumulados
+            de cada usuario como negativos (impostores) de los demás; con los pares genuino-vs-impostor
+            calcular scores y calibrar el threshold (global y/o por-usuario) en el punto de operación
+            (EER o FAR objetivo) en vez del 0.75 fijo. Persistir el/los threshold(s) calibrado(s) y
+            exponerlos. (Base para un futuro clasificador usuario-vs-resto.) Tests de la calibración. (ear + core)
+- [ ] 46.6  Unificar `retrain_events` para ambos modelos: columna `model` (`wakeword`|`voiceid`) +
+            poblar `val_accuracy`/`fp_rate` (hoy NULL). Migración idempotente del schema, `record_retrain_event`
+            y los endpoints de consulta por modelo (`/metrics/.../retrains`). Tests. (core)
+- [ ] 46.7  Métricas de retrain de ambos modelos en los DOS backoffices: extender `/metrics` (backoffice
+            local) y el dashboard cloud (vía egress `POST /ingest/metrics`) con la tabla/serie de retrains
+            de wake word y voice-id (trigger, muestras nuevas, resultado, val_accuracy/fp_rate). Tests. (core + backoffice + cloud)

--- a/masterplan/issues.yaml
+++ b/masterplan/issues.yaml
@@ -640,6 +640,15 @@
 # ── FASE 45 (prender pantalla del nodo al detectar wake word) ────────────────
 "45.1":  749
 
+# ── FASE 46 (mejora continua de modelos de voz: auto-captura + retrain) ───────
+"46.1":  751
+"46.2":  752
+"46.3":  753
+"46.4":  754
+"46.5":  755
+"46.6":  756
+"46.7":  757
+
 # ── Anexos (iteraciones futuras) ──────────────────────────────────────────────
 "A.1":   118
 "A.2":   121


### PR DESCRIPTION
Registra la FASE 46 en el plan: auto-captura de audio en cada match confiable (wake word y voice-id) + retrain automático por umbral de muestras nuevas con cooldown, congruente con la captura de FP ya existente, y métricas de retrain de ambos modelos en los dos backoffices.

Tareas 46.1–46.7 → issues #751-757 (umbrella). Decisiones clave:
- Trigger: umbral de muestras + cooldown (sin scheduler temporal).
- Anti-poisoning: solo matches de alta confianza, recompute desde WAV crudos (no average ciego), enrolado manual como ancla.
- Negativos de voice-id **cross-user**: los positivos de cada usuario son los impostores de los demás → calibran el threshold (el encoder está congelado, no se reentrena).

Lint OK, sync dry-run confirma #751-757 abiertos y mapeados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)