### PR TITLE
feat: fase 46.7 — métricas de retrain de ambos modelos en los dos backoffices

### DIFF
--- a/backoffice/templates/metrics.html
+++ b/backoffice/templates/metrics.html
@@ -61,7 +61,8 @@
     <div class="text-xs text-gray-400 uppercase tracking-wider mb-3">Reentrenamientos</div>
     <table class="w-full text-sm">
       <thead class="text-gray-500 text-xs uppercase">
-        <tr><th class="text-left py-1">Fecha</th><th class="text-right">Pos</th><th class="text-right">Neg</th>
+        <tr><th class="text-left py-1">Fecha</th><th class="text-left">Modelo</th><th class="text-left">Trigger</th>
+            <th class="text-right">Pos</th><th class="text-right">Neg</th>
             <th class="text-right">Val acc</th><th class="text-right">FP rate</th><th class="text-right">Dur</th><th class="text-right">Estado</th></tr>
       </thead>
       <tbody id="voz-retrains" class="font-mono text-gray-300"></tbody>
@@ -193,7 +194,7 @@ async function loadVoz() {
     getJSON("/api/metrics/voice/series?" + qs({...extra, bucket: bucketFor()})),
     getJSON("/api/metrics/voice/conf-series?" + qs({...extra, bucket: bucketFor()})),
     getJSON("/api/metrics/wakeword/series?" + qs({...extra, bucket: bucketFor()})),
-    getJSON("/api/metrics/voice/retrains?limit=10"),
+    getJSON("/api/metrics/voice/retrains?limit=20"),
   ]);
   $("voz-cards").innerHTML =
     card("Eventos", fmtNum(sum.total)) +
@@ -218,12 +219,13 @@ async function loadVoz() {
   $("conf-thr").textContent = sum.speaker_threshold != null ? "· threshold " + sum.speaker_threshold : "";
   $("voz-retrains").innerHTML = (retr.retrains || []).map(r => `<tr class="border-t border-gray-800">
     <td class="py-1">${r.ts ? new Date(r.ts*1000).toLocaleString("es") : "—"}</td>
+    <td class="text-left">${r.model || "wakeword"}</td><td class="text-left">${r.trigger || "—"}</td>
     <td class="text-right">${fmtNum(r.n_positive)}</td><td class="text-right">${fmtNum(r.n_negative)}</td>
     <td class="text-right">${r.val_accuracy != null ? r.val_accuracy : "—"}</td>
     <td class="text-right">${r.fp_rate != null ? r.fp_rate : "—"}</td>
     <td class="text-right">${r.duration_s != null ? r.duration_s + "s" : "—"}</td>
     <td class="text-right">${r.status || "—"}</td></tr>`).join("") ||
-    `<tr><td colspan="7" class="py-2 text-gray-600">sin reentrenamientos</td></tr>`;
+    `<tr><td colspan="9" class="py-2 text-gray-600">sin reentrenamientos</td></tr>`;
 }
 
 // ── LLM ─────────────────────────────────────────────────────────────────────

--- a/cloud/app/templates/dashboard.html
+++ b/cloud/app/templates/dashboard.html
@@ -82,6 +82,10 @@
               <table id="m-models"><thead><tr><th>modelo</th><th>llamadas</th><th>lat ms</th><th>tokens</th></tr></thead><tbody></tbody></table>
               <table id="m-agents"><thead><tr><th>agente</th><th>steps</th><th>aciertos</th><th>lat ms</th></tr></thead><tbody></tbody></table>
             </div>
+            <h3>Reentrenamientos</h3>
+            <div id="m-retrains-wrap">
+              <table id="m-retrains"><thead><tr><th>modelo</th><th>trigger</th><th>muestras</th><th>val acc</th><th>FP rate</th><th>dur</th><th>estado</th><th>fecha</th></tr></thead><tbody></tbody></table>
+            </div>
             <h3>Continuidad</h3>
             <div id="m-cont-summary" class="grid"></div>
             <canvas id="m-cont-chart" height="80"></canvas>
@@ -694,6 +698,16 @@ async function loadMetrics() {
   $("m-agents").querySelector("tbody").innerHTML = agents.map(a =>
     `<tr><td>${esc(a.agent_id) || "—"}</td><td>${mFmt(a.steps)}</td><td>${mPct(a.success_rate)}</td>` +
     `<td>${mFmt(a.avg_latency_ms)}</td></tr>`).join("");
+
+  // Reentrenamientos: wake word + voice-id (FASE 46.7). Sólo presente para roles con view_full.
+  const retrains = metrics.retrains || [];
+  $("m-retrains-wrap").style.display = retrains.length ? "" : "none";
+  $("m-retrains").querySelector("tbody").innerHTML = retrains.map(r =>
+    `<tr><td>${esc(r.model) || "wakeword"}</td><td>${esc(r.trigger) || "—"}</td>` +
+    `<td>${mFmt(r.n_positive)}</td><td>${r.val_accuracy != null ? r.val_accuracy : "—"}</td>` +
+    `<td>${r.fp_rate != null ? r.fp_rate : "—"}</td><td>${r.duration_s != null ? r.duration_s + "s" : "—"}</td>` +
+    `<td>${esc(r.status) || "—"}</td>` +
+    `<td class="muted">${r.ts ? new Date(r.ts*1000).toLocaleString("es") : "—"}</td></tr>`).join("");
 }
 
 // ── Formulario tipado de comandos (37.5) ──────────────────────────────────────

--- a/cloud/bridge/metrics_snapshot.py
+++ b/cloud/bridge/metrics_snapshot.py
@@ -43,7 +43,8 @@ def build_metrics_snapshot(hours: int = WINDOW_HOURS) -> dict:
         "voice_series":  _get(f"{base}/voice/series?{qs}") or {},
         "voice_conf_series": _get(f"{base}/voice/conf-series?{qs}") or {},   # FASE 37.12
         "ww_score_series":   _get(f"{base}/wakeword/series?{qs}") or {},      # FASE 37.11
-        "retrains":      (_get(f"{base}/voice/retrains?limit=10") or {}).get("retrains", []),
+        # Sin filtro de modelo → trae wake word + voice-id mezclados (más reciente primero, FASE 46.7)
+        "retrains":      (_get(f"{base}/voice/retrains?limit=20") or {}).get("retrains", []),
         "llm_summary":   _get(f"{base}/llm/summary?{q}") or {},
         "llm_by_model":  (_get(f"{base}/llm/by-model?{q}") or {}).get("models", []),
         "llm_by_agent":  (_get(f"{base}/llm/by-agent?{q}") or {}).get("agents", []),


### PR DESCRIPTION
FASE 46.7. Refleja los reentrenamientos de wake word y voice-id en los dos backoffices:
- **Local** (`metrics.html`): columnas Modelo + Trigger en la tabla de Reentrenamientos, limit 20.
- **Cloud** (`dashboard.html`): nueva tabla de Reentrenamientos (el campo `retrains` ya estaba en snapshot/modelo/RBAC, faltaba el render; gateado por `view_full`).
- **Bridge**: snapshot de retrains a limit 20 (mezcla ambos modelos).

Cloud metrics tests 59 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)